### PR TITLE
Quaternion patch 1

### DIFF
--- a/src/Math/Core/Quaternion.cs
+++ b/src/Math/Core/Quaternion.cs
@@ -475,7 +475,10 @@ namespace Fusee.Math.Core
         /// <returns>A normalized quaternion rotation.</returns>
         public static Quaternion FromAxisAngle(float3 axis, float angle)
         {
-            if (axis.LengthSquared > M.EpsilonFloat)
+            if (axis.LengthSquared < M.EpsilonFloat)
+                return Identity;
+                
+            if (axis.LengthSquared > 1f)
                 return Identity;
 
             var result = Identity;
@@ -545,7 +548,7 @@ namespace Fusee.Math.Core
             // The following requires halfAngle to be at least 0.5 degrees.
             if (cosHalfAngle < 0.99995f)
             {
-                // Console.WriteLine("Proper Slerp for big angle: " + MathHelper.RadiansToDegrees((float)System.Math.Acos(cosHalfAngle))+ "°");
+                // Console.WriteLine("Proper Slerp for big angle: " + MathHelper.RadiansToDegrees((float)System.Math.Acos(cosHalfAngle))+ "Â°");
                 // do proper slerp for big angles
                 var halfAngle = (float) System.Math.Acos(cosHalfAngle);
                 var sinHalfAngle = (float) System.Math.Sin(halfAngle);
@@ -556,7 +559,7 @@ namespace Fusee.Math.Core
             }
             else
             {
-                // Console.WriteLine("Simple lerp for small angle: " + MathHelper.RadiansToDegrees((float)System.Math.Acos(cosHalfAngle)) + "°");
+                // Console.WriteLine("Simple lerp for small angle: " + MathHelper.RadiansToDegrees((float)System.Math.Acos(cosHalfAngle)) + "Â°");
                 // do lerp if angle is really small.
                 blendA = 1.0f - blend;
                 blendB = blend;

--- a/src/Math/Core/QuaternionD.cs
+++ b/src/Math/Core/QuaternionD.cs
@@ -456,7 +456,10 @@ namespace Fusee.Math.Core
         /// <returns>A QuaternionD that represents the orientation.</returns>
         public static QuaternionD FromAxisAngle(double3 axis, double angle)
         {
-            if (axis.LengthSquared > M.EpsilonDouble)
+            if (axis.LengthSquared < M.EpsilonFloat)
+                return Identity;
+                
+            if (axis.LengthSquared > 1.0)
                 return Identity;
 
             var result = Identity;


### PR DESCRIPTION
Fixed Quaternion FromAngle Axis,
`if (axis.LengthSquared > M.EpsilonFloat)`
is always true, hence this method returned the identity.