### PR TITLE
Feature/performance optimization

### DIFF
--- a/src/Engine/Core/ConvertSceneGraph.cs
+++ b/src/Engine/Core/ConvertSceneGraph.cs
@@ -23,18 +23,6 @@ namespace Fusee.Engine.Core
         private Dictionary<MaterialPBRComponent, ShaderEffect> _pbrComponent;
         private Stack<SceneNodeContainer> _boneContainers;
 
-        private List<Tuple<SceneNodeContainer, LightResult>> _lightViseratorResults;
-
-        //private IEnumerable<System.Type> _codeComponentSubClasses;
-
-        //public ConvertSceneGraph()
-        //{
-        //  _codeComponentSubClasses = 
-        //    Assembly.GetExecutingAssembly()
-        //    .GetTypes()
-        //    .Where(t => t.IsSubclassOf(typeof(CodeComponent)));
-        //}
-
         /// <summary>
         /// Method is called when going up one hierarchy level while traversing. Override this method to perform pop on any self-defined state.
         /// </summary>
@@ -63,6 +51,7 @@ namespace Fusee.Engine.Core
         }
 
         #region Visitors
+
         /// <summary>
         /// Converts the scene node container.
         /// </summary>
@@ -90,17 +79,6 @@ namespace Fusee.Engine.Core
                 else
                     _convertedScene.Children = new List<SceneNodeContainer> { _currentNode };
             }
-
-            ////WIP!
-            ////If the SceneNodeContainers' name contains the name of some CodeComponent subclass,
-            ////create CodeComponent of this type and add it to the currentNode
-            //foreach (var type in _codeComponentSubClasses)
-            //{
-            //    if (!snc.Name.Contains(type.ToString())) continue;
-
-            //    var codeComp = Activator.CreateInstance(type);
-            //    //_currentNode.AddComponent(codeComp);
-            //}
         }
 
         ///<summary>

--- a/src/Engine/Core/ConvertSceneGraph.cs
+++ b/src/Engine/Core/ConvertSceneGraph.cs
@@ -15,7 +15,7 @@ namespace Fusee.Engine.Core
     /// </summary>
     public class ConvertSceneGraph : SceneVisitor
     {
-        private SceneContainer _convertedScene;        
+        private SceneContainer _convertedScene;
         private Stack<SceneNodeContainer> _predecessors;
         private SceneNodeContainer _currentNode;
 
@@ -49,19 +49,19 @@ namespace Fusee.Engine.Core
         /// <param name="sc">The SceneContainer to convert.</param>
         /// <returns></returns>
         public SceneContainer Convert(SceneContainer sc)
-        { 
+        {
             _predecessors = new Stack<SceneNodeContainer>();
             _convertedScene = new SceneContainer();
-                        
-            _matMap = new Dictionary<MaterialComponent, ShaderEffect>();            
+
+            _matMap = new Dictionary<MaterialComponent, ShaderEffect>();
             _pbrComponent = new Dictionary<MaterialPBRComponent, ShaderEffect>();
             _boneContainers = new Stack<SceneNodeContainer>();
 
-            Traverse(sc.Children);            
-            
+            Traverse(sc.Children);
+
             return _convertedScene;
-        } 
-        
+        }
+
         #region Visitors
         /// <summary>
         /// Converts the scene node container.
@@ -85,7 +85,7 @@ namespace Fusee.Engine.Core
             {
                 _predecessors.Push(new SceneNodeContainer { Name = CurrentNode.Name });
                 _currentNode = _predecessors.Peek();
-                if(_convertedScene.Children != null)
+                if (_convertedScene.Children != null)
                     _convertedScene.Children.Add(_currentNode);
                 else
                     _convertedScene.Children = new List<SceneNodeContainer> { _currentNode };
@@ -97,7 +97,7 @@ namespace Fusee.Engine.Core
             //foreach (var type in _codeComponentSubClasses)
             //{
             //    if (!snc.Name.Contains(type.ToString())) continue;
-                
+
             //    var codeComp = Activator.CreateInstance(type);
             //    //_currentNode.AddComponent(codeComp);
             //}
@@ -106,7 +106,7 @@ namespace Fusee.Engine.Core
         ///<summary>
         ///Converts the transform component.
         ///</summary>
-        [VisitMethod]        
+        [VisitMethod]
         public void ConvTransform(TransformComponent transform)
         {
             if (_currentNode.Components == null)
@@ -123,7 +123,7 @@ namespace Fusee.Engine.Core
         public void ConvMaterial(MaterialComponent matComp)
         {
             var effect = LookupMaterial(matComp);
-            _currentNode.Components.Add(new ShaderEffectComponent{Effect = effect});
+            _currentNode.Components.Add(new ShaderEffectComponent { Effect = effect });
         }
 
         /// <summary>
@@ -135,7 +135,7 @@ namespace Fusee.Engine.Core
         {
             var effect = LookupMaterial(matComp);
             _currentNode.Components.Add(new ShaderEffectComponent { Effect = effect });
-        }        
+        }
 
         /// <summary>
         /// Converts the shader.
@@ -202,15 +202,15 @@ namespace Fusee.Engine.Core
         {
             // check if we have bones
             if (_boneContainers.Count >= 1)
-            {                
-                if(weight.Joints == null) // initialize joint container
+            {
+                if (weight.Joints == null) // initialize joint container
                     weight.Joints = new List<SceneNodeContainer>();
 
                 // set all bones found until this WeightComponent
                 while (_boneContainers.Count != 0)
                     weight.Joints.Add(_boneContainers.Pop());
             }
-           
+
             _currentNode.Components.Add(weight);
         }
         #endregion

--- a/src/Engine/Core/FontMap.cs
+++ b/src/Engine/Core/FontMap.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Runtime.Serialization;
 using System.Text;
 using Fusee.Base.Common;
 using Fusee.Base.Core;
@@ -95,7 +94,7 @@ namespace Fusee.Engine.Core
         /// Gets the image containing all characters specified in the <see cref="Alphabet"/>. Use this image
         /// as a texture used by individual rectangles each displaying a single character. Use the information
         /// retrieved from <see cref="GetGlyphOnMap"/> to position the character rectangles and to align 
-        /// their texure coordinates.
+        /// their texture coordinates.
         /// </summary>
         /// <value>
         /// The font image.
@@ -113,12 +112,12 @@ namespace Fusee.Engine.Core
 
                 var averageAdvance = 0f;
                 var charCount = 0f;
-                
+
                 //Calculate averageAdvance in Font? Ratio FontSize/ averageAdvance does not change with fontSize
                 foreach (char c in _alphabet)
                 {
                     GlyphInfo gi = _font.GetGlyphInfo(c);
-                    averageAdvance += gi.AdvanceX+1;
+                    averageAdvance += gi.AdvanceX + 1;
                     charCount++;
                 }
 
@@ -141,10 +140,10 @@ namespace Fusee.Engine.Core
                     var mult = width / widthOld;
                     _font.PixelHeight = (uint)(_pixelHeight * (mult));
                 }
-                
+
                 // Create the font atlas (the texture containing ALL glyphs)
                 _image = new Texture(new byte[width * width], width, width, new ImagePixelFormat(ColorFormat.Intensity), false);
-               
+
                 var offX = 0;
                 var offY = 0;
                 var rowH = 0;
@@ -153,7 +152,7 @@ namespace Fusee.Engine.Core
                 foreach (char c in _alphabet)
                 {
                     int bitmapLeft, bitmapTop;
-                    IImageData glyphImg = _font.RenderGlyph((uint) c, out bitmapLeft, out bitmapTop);
+                    IImageData glyphImg = _font.RenderGlyph((uint)c, out bitmapLeft, out bitmapTop);
                     if (offX + glyphImg.Width + 1 >= width)
                     {
                         offY += rowH;
@@ -173,8 +172,8 @@ namespace Fusee.Engine.Core
                         BitmapH = glyphImg.Height,
                         BitmapL = bitmapLeft,
                         BitmapT = bitmapTop,
-                        TexOffX = offX/(float) width,
-                        TexOffY = offY/(float) width,
+                        TexOffX = offX / (float)width,
+                        TexOffY = offY / (float)width,
                     };
 
                     _glyphOnMapCache[c] = glyphOnMap;
@@ -270,17 +269,17 @@ namespace Fusee.Engine.Core
                         sb.Append((char)i);
                     _alphabet = sb.ToString();
                 }
-                else 
+                else
                     _alphabet = value;
                 Invalidate();
             }
         }
 
         /// <summary>
-        /// Gets a value indicating whether this <see cref="FontMap"/> is uptodate.
+        /// Gets a value indicating whether this <see cref="FontMap"/> is up-to-date.
         /// </summary>
         /// <value>
-        ///   <c>true</c> if uptodate; otherwise, <c>false</c>.
+        ///   <c>true</c> if up-to-date; otherwise, <c>false</c>.
         /// </value>
         public bool Uptodate => _uptodate;
 
@@ -289,7 +288,7 @@ namespace Fusee.Engine.Core
         /// character from the font <see cref="Image"/>.
         /// </summary>
         /// <param name="c">The character to obtain information for.</param>
-        /// <returns>The <see cref="GlyphOnMap"/> record for the given character containting information where on the texture the glyph resides.</returns>
+        /// <returns>The <see cref="GlyphOnMap"/> record for the given character containing information where on the texture the glyph resides.</returns>
         public GlyphOnMap GetGlyphOnMap(uint c)
         {
             return _glyphOnMapCache[c];

--- a/src/Engine/Core/RenderCanvas.cs
+++ b/src/Engine/Core/RenderCanvas.cs
@@ -160,6 +160,7 @@ namespace Fusee.Engine.Core
 
             RC = new RenderContext(ContextImplementor);
             RC.Viewport(0, 0, Width, Height);
+            RC.SetRenderStateSet(RenderStateSet.Default);
 
             Audio.Instance.AudioImp = AudioImplementor;
             Network.Instance.NetworkImp = NetworkImplementor;
@@ -182,19 +183,18 @@ namespace Fusee.Engine.Core
 
                 //Resets the RenderStateSet and Viewport, View and Projection Matrix to their default state.
                 RC.ResetToDefaultState();
-                RC.SetRenderState(RenderStateSet.Default);
 
                 // post-rendering
                 Input.Instance.PostRender();
             };
 
-            CanvasImplementor.Resize += delegate 
-            {                
+            CanvasImplementor.Resize += delegate
+            {
                 RC.DefaultState.CanvasWidth = Width;
                 RC.DefaultState.CanvasHeight = Height;
-                Resize(new ResizeEventArgs(Width, Height)); 
+                Resize(new ResizeEventArgs(Width, Height));
             };
-        }        
+        }
 
         /// <summary>
         ///     Callback method to invoke user code for rendering a frame.

--- a/src/Engine/Core/RenderContext.cs
+++ b/src/Engine/Core/RenderContext.cs
@@ -871,9 +871,7 @@ namespace Fusee.Engine.Core
 
             // Bones
             _currentShaderParams.FUSEE_BONES = CurrentShaderProgram.GetShaderParam("FUSEE_BONES[0]");
-
-            //
-
+          
             _updatedShaderParams = true;
             UpdateCurrentShader();
         }
@@ -1035,18 +1033,16 @@ namespace Fusee.Engine.Core
         // ReSharper disable once InconsistentNaming
         public void SetFXParam(string name, object value)
         {
-            object tmpFXParam;
-
-            if (AllFXParams.TryGetValue(name, out tmpFXParam)) // already in cache?
+            if (AllFXParams.ContainsKey(name))
             {
-                if (tmpFXParam.Equals(value)) return; // no new value
+                if (AllFXParams[name].Equals(value)) return; // no new value
 
                 AllFXParams[name] = value;
 
                 // Update ShaderEffect
                 _currentShaderEffect.SetEffectParam(name, value);
                 return;
-            }
+            }           
 
             // cache miss
             AllFXParams.Add(name, value);

--- a/src/Engine/Core/RenderContext.cs
+++ b/src/Engine/Core/RenderContext.cs
@@ -8,7 +8,7 @@ using Fusee.Math.Core;
 using Fusee.Serialization;
 
 namespace Fusee.Engine.Core
-{   
+{
 
     /// <summary>
     /// The render context contains all functions necessary to manipulate the underlying rendering hardware. Use this class' elements
@@ -18,6 +18,20 @@ namespace Fusee.Engine.Core
     public class RenderContext
     {
         #region Fields
+
+        #region RenderState management
+
+        /// <summary>
+        /// Saves the current RenderState.
+        /// </summary>
+        public RenderStateSet CurrentRenderState { get; private set; } = new RenderStateSet();
+
+        /// <summary>
+        /// If a state is forced it will remain the value currently set in <see cref="CurrentRenderState"/>.
+        /// </summary>
+        public Dictionary<RenderState, KeyValuePair<bool, uint>> LockedStates { get; private set; } = new Dictionary<RenderState, KeyValuePair<bool, uint>>();
+
+        #endregion
 
         /// <summary>
         /// Gets and sets the viewport width.
@@ -58,7 +72,7 @@ namespace Fusee.Engine.Core
         /// <value>
         ///   <c>true</c> if [debug lines enabled]; otherwise, <c>false</c>.
         /// </value>
-        public bool DebugLinesEnabled { get; set; } = true;       
+        public bool DebugLinesEnabled { get; set; } = true;
 
         /// <summary>
         /// Array of bone matrices.
@@ -80,7 +94,7 @@ namespace Fusee.Engine.Core
 
         #region Private Fields
 
-        private readonly IRenderContextImp _rci;       
+        private readonly IRenderContextImp _rci;
 
         private readonly MatrixParamNames _currentShaderParams;
         private ShaderEffect _currentShaderEffect;
@@ -871,7 +885,7 @@ namespace Fusee.Engine.Core
 
             // Bones
             _currentShaderParams.FUSEE_BONES = CurrentShaderProgram.GetShaderParam("FUSEE_BONES[0]");
-          
+
             _updatedShaderParams = true;
             UpdateCurrentShader();
         }
@@ -1042,7 +1056,7 @@ namespace Fusee.Engine.Core
                 // Update ShaderEffect
                 _currentShaderEffect.SetEffectParam(name, value);
                 return;
-            }           
+            }
 
             // cache miss
             AllFXParams.Add(name, value);
@@ -1498,6 +1512,36 @@ namespace Fusee.Engine.Core
         }
 
         /// <summary>
+        /// Unlocks the given <see cref="RenderState"/>. And sets it to the value it had before it was locked.
+        /// After this call the state can be set to a new value again.
+        /// </summary>
+        /// <param name="state">The state to unlock.</param>
+        /// <param name="resetValue">True by default. Defines if the state gets reset to its pre-locked value.</param>
+        public void UnlockRenderState(RenderState state, bool resetValue = true)
+        {
+            if (LockedStates.ContainsKey(state))
+            {
+                var resetToVal = LockedStates[state].Value;
+                LockedStates[state] = new KeyValuePair<bool, uint>(false, resetToVal);
+
+                if (resetValue)
+                    SetRenderState(state, resetToVal);
+            }
+        }
+
+        /// <summary>
+        /// Unlocks all previously locked <see cref="RenderState"/>s.
+        /// <param name="resetValue">True by default. Defines if the states get reset to their pre-locked value.</param>
+        /// </summary>
+        public void UnlockAllRenderStates(bool resetValue = true)
+        {
+            if (LockedStates.Count == 0) return;
+
+            for (int i = 0; i < LockedStates.Count; i++)
+                UnlockRenderState(LockedStates.ElementAt(i).Key, resetValue);
+        }
+
+        /// <summary>
         /// Apply a single render state to the render context. All subsequent rendering will be
         /// performed using the currently set state unless it is changed to a different value.
         /// </summary>
@@ -1505,13 +1549,44 @@ namespace Fusee.Engine.Core
         /// <param name="value">An unsigned integer value representing the value the state should be set to.
         ///  Depending on the renderState, this value can be interpreted as an integer value, a float value, a
         /// boolean value, or even a color.  </param>
+        /// <param name="doLockState">Forces this state to have the given value and locks the state. Unlock it by calling <see cref="UnlockRenderState(RenderState, bool)"/></param>
         /// <remarks>This method is close to the underlying implementation layer and might be awkward to use
         /// due to the ambiguity of the value parameter type. If you want type-safe state values and also 
         /// want to set a couple of states at the same time, try the more 
-        /// elaborate <see cref="SetRenderState(RenderStateSet)"/> method.</remarks>
-        public void SetRenderState(RenderState renderState, uint value)
+        /// elaborate <see cref="SetRenderStateSet(RenderStateSet, bool)"/> method.</remarks>
+        public void SetRenderState(RenderState renderState, uint value, bool doLockState = false)
         {
-            _rci.SetRenderState(renderState, value);
+            if (LockedStates.TryGetValue(renderState, out var lockedState))
+            {
+                if (lockedState.Key)
+                {
+                    if (doLockState)
+                    {
+                        CurrentRenderState.SetRenderState(renderState, value);
+                        _rci.SetRenderState(renderState, value);
+                        Diagnostics.Warn("PREVIOUSLY LOCKED STATE WAS OVERWRITTEN: Render state " + renderState + " was locked and will remain its old value.\n Call UnlockRenderState(renderState) to undo it.");
+                    }
+                    else
+                        Diagnostics.Warn("Render state " + renderState + " was locked and will remain its old value.\n Call UndoLockRenderState(renderState) to undo it.");
+
+                    return;
+                }
+            }
+
+            var currentVal = CurrentRenderState.GetRenderState(renderState);
+            if (currentVal != value)
+            {
+                if (doLockState)
+                {
+                    if (currentVal != null)
+                        LockedStates[renderState] = new KeyValuePair<bool, uint>(true, (uint)currentVal);
+                    else
+                        LockedStates[renderState] = new KeyValuePair<bool, uint>(true, (uint)RenderStateSet.Default.GetRenderState(renderState));
+                }
+
+                CurrentRenderState.SetRenderState(renderState, value);
+                _rci.SetRenderState(renderState, value);
+            }
         }
 
         /// <summary>
@@ -1520,40 +1595,13 @@ namespace Fusee.Engine.Core
         /// method to change more than one render state at once. 
         /// </summary>
         /// <param name="renderStateSet">A set of render states with their respective values to be set.</param>
-        public void SetRenderState(RenderStateSet renderStateSet)
+        /// <param name="doLockState">Forces all states that are set in this <see cref="RenderStateSet"/> to have the given value and locks them. Unlock them by calling <see cref="UnlockRenderState(RenderState, bool)"/></param>
+        public void SetRenderStateSet(RenderStateSet renderStateSet, bool doLockState = false)
         {
             foreach (var state in renderStateSet.States)
             {
-                var theKey = state.Key;
-                var theValue = state.Value;
-                _rci.SetRenderState(theKey, theValue);
+                SetRenderState(state.Key, state.Value, doLockState);
             }
-        }
-
-        /// <summary>
-        /// Returns the current render state set.
-        /// </summary>        
-        /// <returns></returns>
-        public RenderStateSet GetRenderStateSet()
-        {
-            return new RenderStateSet()
-            {
-                AlphaBlendEnable = _rci.GetRenderState(RenderState.AlphaBlendEnable) != 0,
-                BlendFactor = (float4)(ColorUint)_rci.GetRenderState(RenderState.BlendFactor),
-                BlendOperation = (BlendOperation)_rci.GetRenderState(RenderState.BlendOperation),
-                BlendOperationAlpha = (BlendOperation)_rci.GetRenderState(RenderState.BlendOperationAlpha),
-                DestinationBlend = (Blend)_rci.GetRenderState(RenderState.DestinationBlend),
-                DestinationBlendAlpha = (Blend)_rci.GetRenderState(RenderState.DestinationBlendAlpha),
-                SourceBlend = (Blend)_rci.GetRenderState(RenderState.SourceBlend),
-                SourceBlendAlpha = (Blend)_rci.GetRenderState(RenderState.SourceBlendAlpha),
-
-                CullMode = (Cull)_rci.GetRenderState(RenderState.CullMode),
-                Clipping = _rci.GetRenderState(RenderState.Clipping) != 0,
-                FillMode = (FillMode)_rci.GetRenderState(RenderState.FillMode),
-                ZEnable = _rci.GetRenderState(RenderState.ZEnable) != 0,
-                ZFunc = (Compare)_rci.GetRenderState(RenderState.ZEnable),
-                ZWriteEnable = _rci.GetRenderState(RenderState.ZWriteEnable) != 0
-            };            
         }
 
         /// <summary>
@@ -1563,7 +1611,12 @@ namespace Fusee.Engine.Core
         /// <returns></returns>
         public uint GetRenderState(RenderState renderState)
         {
-            return _rci.GetRenderState(renderState);
+            var currentState = CurrentRenderState.GetRenderState(renderState);
+
+            if (currentState != null)
+                return (uint)currentState;
+            else
+                return (uint)RenderStateSet.Default.GetRenderState(renderState);
         }
 
         /// <summary>
@@ -1662,7 +1715,7 @@ namespace Fusee.Engine.Core
                         SetShaderParamT(param);
                     }
 
-                    SetRenderState(_currentShaderEffect.States[i]);
+                    SetRenderStateSet(_currentShaderEffect.States[i]);
                     // TODO: split up RenderContext.Render into a preparation and a draw call so that we can prepare a mesh once and draw it for each pass.
                     var meshImp = _meshManager.GetMeshImpFromMesh(m);
                     _rci.Render(meshImp);
@@ -1745,8 +1798,8 @@ namespace Fusee.Engine.Core
                 SetShaderParamWritableTextureArray(param.Info.Handle, (WritableTexture[])param.Value);
             }
             else if (param.Value is IWritableTexture)
-            {                
-                SetShaderParamWritableTexture(param.Info.Handle, ((WritableTexture)param.Value));                
+            {
+                SetShaderParamWritableTexture(param.Info.Handle, ((WritableTexture)param.Value));
             }
             else if (param.Value is ITexture)
             {
@@ -1859,7 +1912,7 @@ namespace Fusee.Engine.Core
         public void Viewport(int x, int y, int width, int height, bool renderToScreen = true)
         {
             _rci.Scissor(x, y, width, height);
-            _rci.Viewport(x, y, width, height);            
+            _rci.Viewport(x, y, width, height);
 
             if (!renderToScreen) return;
 
@@ -1963,7 +2016,7 @@ namespace Fusee.Engine.Core
             {
                 _width = value;
                 _aspect = (float)_width / _height;
-                if(_aspect != 0)
+                if (_aspect != 0)
                     Projection = float4x4.CreatePerspectiveFieldOfView(FovDefault, _aspect, ZNearDefautlt, ZFarDefault);
             }
         }
@@ -1992,7 +2045,7 @@ namespace Fusee.Engine.Core
         /// <summary>
         /// The projection matrix.
         /// </summary>
-        public float4x4 Projection { get; private set; }        
+        public float4x4 Projection { get; private set; }
 
         /// <summary>
         /// The default distance to the near clipping plane.
@@ -2019,7 +2072,7 @@ namespace Fusee.Engine.Core
         public RenderContextDefaultState()
         {
             _aspect = (float)_width / _height;
-            Projection = float4x4.CreatePerspectiveFieldOfView(FovDefault, _aspect, ZNearDefautlt, ZFarDefault);            
+            Projection = float4x4.CreatePerspectiveFieldOfView(FovDefault, _aspect, ZNearDefautlt, ZFarDefault);
         }
     }
 

--- a/src/Engine/Core/RenderStateSet.cs
+++ b/src/Engine/Core/RenderStateSet.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
+using System.Linq;
 using Fusee.Base.Common;
 using Fusee.Engine.Common;
 using Fusee.Math.Core;
@@ -10,7 +11,7 @@ namespace Fusee.Engine.Core
     /// Instances are used in the effects system to set a couple of states before a render pass is performed.
     /// </summary>
     public class RenderStateSet
-    { 
+    {
         /// <summary>
         /// OpenGL defaults for the render states.
         /// </summary>
@@ -18,39 +19,160 @@ namespace Fusee.Engine.Core
         {
             get
             {
-                return new RenderStateSet()
+                if (_default == null)
                 {
-                    AlphaBlendEnable = false,
-                    BlendFactor = float4.Zero,
-                    BlendOperation = BlendOperation.Add,
-                    BlendOperationAlpha = BlendOperation.Add,
-                    DestinationBlend = Blend.Zero,
-                    DestinationBlendAlpha = Blend.Zero,
-                    SourceBlend = Blend.One,
-                    SourceBlendAlpha = Blend.One,
+                    _default = new RenderStateSet()
+                    {
+                        AlphaBlendEnable = false,
+                        BlendFactor = float4.Zero,
+                        BlendOperation = BlendOperation.Add,
+                        BlendOperationAlpha = BlendOperation.Add,
+                        DestinationBlend = Blend.Zero,
+                        DestinationBlendAlpha = Blend.Zero,
+                        SourceBlend = Blend.One,
+                        SourceBlendAlpha = Blend.One,
 
-                    CullMode = Cull.Counterclockwise,
-                    Clipping = true,
-                    FillMode = FillMode.Solid,
-                    ZEnable = true,
-                    ZFunc = Compare.Less,
-                    ZWriteEnable = true
-                };
+                        CullMode = Cull.Counterclockwise,
+                        Clipping = true,
+                        FillMode = FillMode.Solid,
+                        ZEnable = true,
+                        ZFunc = Compare.Less,
+                        ZWriteEnable = true
+                    };
+                }
+                return _default;
             }
         }
+        private static RenderStateSet _default;
 
-        private readonly Dictionary<RenderState, uint> _states = new Dictionary<RenderState, uint>();
+        /// <summary>
+        /// Enumerate this set of render states for its contents
+        /// </summary>
+        /// <value>An enumerator to be used in loops returning a key and its respective value.</value>
+        /// <example>
+        /// Use this enumerator in loops to query a RenderStateSet's contents.
+        /// <code>
+        /// RenderStateSet aRenderStateSet = ...;
+        /// foreach (var state in aRenderStateSet.States)
+        ///     DoSomethingWithState(state.Key, state.Value);
+        /// </code>
+        /// </example>
+        public IEnumerable<KeyValuePair<RenderState, uint>> States
+        {
+            get { return _states; }
+        }
+        private readonly Dictionary<RenderState, uint> _states;
+
+        /// <summary>
+        /// Returns a new instance of type <see cref="RenderStateSet"/>.
+        /// </summary>
+        public RenderStateSet()
+        {
+            _states = new Dictionary<RenderState, uint>();
+        }
+
+        /// <summary>
+        /// Returns a new instance of type <see cref="RenderStateSet"/>.
+        /// </summary>
+        /// <param name="states">The values to fill this state set with.</param>
+        public RenderStateSet(Dictionary<RenderState, uint> states)
+        {
+            _states = states;
+        }
+
+        /// <summary>
+        /// Returns a new RenderStateSet with the same states as this instance.
+        /// </summary>
+        public RenderStateSet Copy()
+        {
+            return new RenderStateSet(new Dictionary<RenderState, uint>(_states));
+        }
+
+        /// <summary>
+        /// Returns a new RenderStateSet which contains the delta of this instance (A) and a given RenderStateSet (B).
+        /// Rules
+        /// 1. A has state and B has state and A == B: no need to add the state.
+        /// 2. A has state and B has state and A != B: set state to value of A.
+        /// 3. A has state and B does not: set state to value of A.
+        /// 4. B has state and A has not: set state to default value.
+        /// </summary>
+        /// <param name="otherSet"></param>
+        /// <returns></returns>
+        internal RenderStateSet Delta(RenderStateSet otherSet)
+        {
+            var resStates = new Dictionary<RenderState, uint>();
+
+            //Rule 1 and 2
+            var intersectKeys = _states.Keys.Intersect(otherSet._states.Keys);
+            foreach (var stateEnum in intersectKeys)
+            {
+                if (_states[stateEnum] != otherSet._states[stateEnum])
+                    resStates.Add(stateEnum, _states[stateEnum]);
+            }
+
+            //Rule 3
+            var aWithoutBKeys = _states.Keys.Except(otherSet._states.Keys);
+            foreach (var stateEnum in aWithoutBKeys)
+                resStates.Add(stateEnum, _states[stateEnum]);
+
+            //Rule 4
+            var bWithoutAKeys = otherSet._states.Keys.Except(_states.Keys);
+            foreach (var stateEnum in bWithoutAKeys)
+                resStates.Add(stateEnum, (uint)Default.GetRenderState(stateEnum));
+
+            return new RenderStateSet(resStates);
+        }
 
         /// <summary>
         /// Sets the RenderStates in the Set.
         /// </summary>
         /// <param name="renderStateContainer"></param>
-        public void SetRenderStates(Dictionary<uint, uint> renderStateContainer)
+        internal void SetRenderStates(Dictionary<uint, uint> renderStateContainer)
         {
             foreach (var renderState in renderStateContainer)
             {
                 _states[(RenderState)renderState.Key] = renderState.Value;
             }
+        }
+
+        /// <summary>
+        /// Sets the given <see cref="RenderState"/> on the internal state collection.
+        /// </summary>
+        /// <param name="state">The state.</param>
+        /// <param name="value">The value.</param>
+        internal void SetRenderState(RenderState state, uint value)
+        {
+            if (_states.ContainsKey(state))
+                _states[state] = value;
+            else
+                _states.Add(state, value);
+        }
+
+        /// <summary>
+        /// Tries to get the value of the given <see cref="RenderState"/> from the internal state collection.
+        /// </summary>
+        /// <param name="state">The render state.</param>
+        /// <returns></returns>
+        internal uint? GetRenderState(RenderState state)
+        {
+            if (_states.ContainsKey(state))
+                return _states[state];
+            else
+                return null;
+        }
+
+        /// <summary>
+        /// Tries to get the value of the given <see cref="RenderState"/> from the internal state collection.
+        /// </summary>
+        /// <param name="state">The render state</param>
+        /// <param name="val">The state as uint.</param>
+        /// <returns></returns>
+        internal void GetRenderState(RenderState state, out uint? val)
+        {
+            if (_states.ContainsKey(state))
+                val = _states[state];
+            else
+                val = null;
         }
 
         #region Butter and bread states
@@ -94,7 +216,7 @@ namespace Fusee.Engine.Core
         /// <remarks>
         /// Blending describes the process how the pixel generated by the pixel shader is written into the render target buffer. Typically
         /// it is just copied at its respective pixel position, but several operations are possible to perform a calculation between the 
-        /// pixel vlaue (rgb and a) already in the buffer and the pixel value (rgb and a) created by the pixel shader. The general blending
+        /// pixel value (rgb and a) already in the buffer and the pixel value (rgb and a) created by the pixel shader. The general blending
         /// assignment is  (always independent for rgb and alpha): 
         /// <code>
         ///      OUTrgb = SRCrgb * SourceBlend       {BlendOperation: [+|-|-inv|min|max]}        DSTrgb * DestinationBlend;
@@ -240,71 +362,6 @@ namespace Fusee.Engine.Core
         }
         #endregion
 
-        /* TODO: Implement texture wrapping rahter as a texture property than a "global" render state. This is most
-         * convenient to implment with OpenGL/TK and easier to mimic in DirectX than the other way round.
-        
-        #region Texture states
-        /////// ==============
-
-        /// <summary>
-        /// Texture-wrapping behavior for multiple sets of texture coordinates.
-        /// Valid values for this render state can be any combination of <see cref="T:Fusee.Engine.TextureWrapping"/>. 
-        /// These cause the system to wrap in the direction of the first, second, third, and fourth dimensions, 
-        /// sometimes referred to as the u/v/w or the s/t/r/q directions for a given texture.
-        /// </summary>
-        public TextureWrapping Wrap0
-        {
-            get { return (TextureWrapping)_states[RenderState.Wrap0]; }
-            set { _states[RenderState.Wrap0] = (uint)value; }
-        }
-            
-        /// <summary>
-        /// See <see cref="Wrap0"/>.
-        /// </summary>
-        public TextureWrapping Wrap1
-        {
-            get { return (TextureWrapping)_states[RenderState.Wrap1]; }
-            set { _states[RenderState.Wrap1] = (uint)value; }
-        }
-
-        /// <summary>
-        /// See <see cref="Wrap0"/>.
-        /// </summary>
-        public TextureWrapping Wrap2
-        {
-            get { return (TextureWrapping)_states[RenderState.Wrap2]; }
-            set { _states[RenderState.Wrap2] = (uint)value; }
-        }
-
-        /// <summary>
-        /// See <see cref="Wrap0"/>.
-        /// </summary>
-        public TextureWrapping Wrap3
-        {
-            get { return (TextureWrapping)_states[RenderState.Wrap3]; }
-            set { _states[RenderState.Wrap3] = (uint)value; }
-        }
-        #endregion
-        */
-
-
-        /// <summary>
-        /// Enumerate this set of render states for its contents
-        /// </summary>
-        /// <value>An enumerator to be used in loops returning a key and its respective value.</value>
-        /// <example>
-        /// Use this enumerator in loops to query a RenderStateSet's contents.
-        /// <code>
-        /// RenderStateSet aRenderStateSet = ...;
-        /// foreach (var state in aRenderStateSet.States)
-        ///     DoSomethingWithState(state.Key, state.Value);
-        /// </code>
-        /// </example>
-        public IEnumerable<KeyValuePair<RenderState, uint>> States
-        {
-            get { return _states; }
-        }
-
         // Currently not supported by FUSEE:
         //==================================
         // StencilEnable;
@@ -365,8 +422,6 @@ namespace Fusee.Engine.Core
         // SrgbWriteEnable;
         // DepthBias;
 
-
-
         // Obsolete with Shaders: 
         //=======================
         // ShadeMode ShadeMode;
@@ -400,7 +455,7 @@ namespace Fusee.Engine.Core
         /// <summary>
         /// Enables or disables the separate for the alpha channel.
         /// When set to false, the render target blending factors and operations applied to alpha are forced to be the same as those defined for color. 
-        /// A number of graphics hardware and implementations do not support handling seprate alpha. In this case, this render state behaves as if set to false.
+        /// A number of graphics hardware and implementations do not support handling separate alpha. In this case, this render state behaves as if set to false.
         /// The type of separate alpha blending is controlled by <see cref="SourceBlendAlpha"/> and <see cref="DestinationBlendAlpha"/>.
         /// </summary>
         public bool SeparateAlphaBlendEnable
@@ -409,8 +464,5 @@ namespace Fusee.Engine.Core
             set { _states[RenderState.SeparateAlphaBlendEnable] = value ? 1U : 0U; }
         }
         */
-
-
-
     }
 }

--- a/src/Engine/Core/RendererState.cs
+++ b/src/Engine/Core/RendererState.cs
@@ -24,6 +24,25 @@ namespace Fusee.Engine.Core
         protected CollapsingStateStack<float4x4> _canvasXForm = new CollapsingStateStack<float4x4>();
 
         /// <summary>
+        /// State of the <see cref="ShaderEffect"/>.
+        /// </summary>
+        protected CollapsingStateStack<ShaderEffect> _effect = new CollapsingStateStack<ShaderEffect>();
+
+        /// <summary>
+        /// State of the <see cref="RenderStateSet"/>.
+        /// </summary>
+        protected CollapsingStateStack<RenderStateSet> _renderStates = new CollapsingStateStack<RenderStateSet>();
+
+        /// <summary>
+        /// Gets and sets the top of stack of the Render states state stack.
+        /// </summary>
+        public RenderStateSet RenderUndoStates
+        {
+            get { return _renderStates.Tos; }
+            set { _renderStates.Tos = value; }
+        }
+
+        /// <summary>
         /// Gets and sets the top of stack of the Model Matrix state stack.
         /// </summary>
         public float4x4 Model
@@ -50,8 +69,6 @@ namespace Fusee.Engine.Core
             set => _canvasXForm.Tos = value;
         }
 
-        private readonly StateStack<ShaderEffect> _effect = new StateStack<ShaderEffect>();
-
         /// <summary>
         /// Gets and sets the shader effect.
         /// </summary>
@@ -70,6 +87,7 @@ namespace Fusee.Engine.Core
             RegisterState(_canvasXForm);
             RegisterState(_effect);
             RegisterState(_uiRect);
+            RegisterState(_renderStates);
         }
     }
 }

--- a/src/Engine/Core/SceneRendererDeferred.cs
+++ b/src/Engine/Core/SceneRendererDeferred.cs
@@ -535,19 +535,19 @@ namespace Fusee.Engine.Core
                 }
 
                 UpdateLightAndShadowParams(lightVisRes, _lightingPassEffect, isCastingShadows);
-                _lightingPassEffect.SetEffectParam("PassNo", lightPassCnt);
+                _lightingPassEffect.SetEffectParam(ShaderShards.UniformNameDeclarations.RenderPassNo, lightPassCnt);
 
                 if (_needToSetSSAOTex)
                 {
-                    _lightingPassEffect.SetEffectParam("SsaoOn", _ssaoOn ? 1 : 0);
+                    _lightingPassEffect.SetEffectParam(ShaderShards.UniformNameDeclarations.SsaoOn, _ssaoOn ? 1 : 0);
                     _needToSetSSAOTex = false;
                 }
 
                 //Set background color only in last light pass to NOT blend the color (additive).
                 if (i == LightViseratorResults.Count - 1)
-                    _lightingPassEffect.SetEffectParam("BackgroundColor", BackgroundColor);
+                    _lightingPassEffect.SetEffectParam(ShaderShards.UniformNameDeclarations.BackgroundColor, BackgroundColor);
                 else
-                    _lightingPassEffect.SetEffectParam("BackgroundColor", _texClearColor);
+                    _lightingPassEffect.SetEffectParam(ShaderShards.UniformNameDeclarations.BackgroundColor, _texClearColor);
 
                 _rc.SetShaderEffect(_lightingPassEffect);
                 _rc.Render(_quad);

--- a/src/Engine/Core/SceneRendererForward.cs
+++ b/src/Engine/Core/SceneRendererForward.cs
@@ -9,6 +9,7 @@ using Fusee.Xene;
 using Fusee.Xirkit;
 using Fusee.Base.Common;
 using Fusee.Engine.Common;
+using Fusee.Engine.Core.ShaderShards.Fragment;
 
 namespace Fusee.Engine.Core
 {
@@ -38,7 +39,7 @@ namespace Fusee.Engine.Core
 
                 if (_numberOfLights != _lightResults.Count)
                 {
-                    _lightPararamStringsAllLights = new Dictionary<int, LightParamStrings>();
+                    LightingShard.LightPararamStringsAllLights = new Dictionary<int, LightParamStrings>();
                     HasNumberOfLightsChanged = true;
                     _numberOfLights = _lightResults.Count;
                 }
@@ -705,15 +706,15 @@ namespace Fusee.Engine.Core
 
         #endregion
 
-        private Dictionary<int, LightParamStrings> _lightPararamStringsAllLights = new Dictionary<int, LightParamStrings>();
+        
 
         private void UpdateShaderParamsForAllLights()
         {
             for (var i = 0; i < _lightResults.Count; i++)
             {
-                if (!_lightPararamStringsAllLights.ContainsKey(i))
+                if (!LightingShard.LightPararamStringsAllLights.ContainsKey(i))
                 {
-                    _lightPararamStringsAllLights.Add(i, new LightParamStrings(i));
+                    LightingShard.LightPararamStringsAllLights.Add(i, new LightParamStrings(i));
                 }
 
                 UpdateShaderParamForLight(i, _lightResults[i].Item2);
@@ -734,7 +735,7 @@ namespace Fusee.Engine.Core
                 Diagnostics.Warn("Strength of the light will be clamped between 0 and 1.");
             }
 
-            var lightParamStrings = _lightPararamStringsAllLights[position];
+            var lightParamStrings = LightingShard.LightPararamStringsAllLights[position];
 
             // Set params in modelview space since the lightning calculation is in modelview space
             _rc.SetFXParam(lightParamStrings.PositionViewSpace, _rc.View * lightRes.WorldSpacePos);
@@ -804,40 +805,5 @@ namespace Fusee.Engine.Core
         }
 
         #endregion
-    }
-
-    internal struct LightParamStrings
-    {
-        public string PositionViewSpace;
-        public string PositionWorldSpace;
-        public string Intensities;
-        public string MaxDistance;
-        public string Strength;
-        public string OuterAngle;
-        public string InnerAngle;
-        public string Direction;
-        public string DirectionWorldSpace;
-        public string LightType;
-        public string IsActive;
-        public string IsCastingShadows;
-        public string Bias;
-
-        public LightParamStrings(int arrayPos)
-        {
-            PositionViewSpace = $"allLights[{arrayPos}].position";
-            PositionWorldSpace = $"allLights[{arrayPos}].positionWorldSpace";
-            Intensities = $"allLights[{arrayPos}].intensities";
-            MaxDistance = $"allLights[{arrayPos}].maxDistance";
-            Strength = $"allLights[{arrayPos}].strength";
-            OuterAngle = $"allLights[{arrayPos}].outerConeAngle";
-            InnerAngle = $"allLights[{arrayPos}].innerConeAngle";
-            Direction = $"allLights[{arrayPos}].direction";
-            DirectionWorldSpace = $"allLights[{arrayPos}].directionWorldSpace";
-            LightType = $"allLights[{arrayPos}].lightType";
-            IsActive = $"allLights[{arrayPos}].isActive";
-            IsCastingShadows = $"allLights[{arrayPos}].isCastingShadows";
-            Bias = $"allLights[{arrayPos}].bias";
-        }
-
-    }
+    }    
 }

--- a/src/Engine/Core/ShaderCodeBuilder.cs
+++ b/src/Engine/Core/ShaderCodeBuilder.cs
@@ -45,7 +45,7 @@ namespace Fusee.Engine.Core
             new[]
             {
                 new EffectParameterDeclaration { Name = RenderTargetTextureTypes.G_ALBEDO.ToString(), Value = srcTex},
-                new EffectParameterDeclaration { Name = "ScreenParams", Value = screenParams},
+                new EffectParameterDeclaration { Name = UniformNameDeclarations.ScreenParams, Value = screenParams},
             });
 
         }
@@ -86,14 +86,14 @@ namespace Fusee.Engine.Core
             },
             new[]
             {
-                new EffectParameterDeclaration { Name = RenderTargetTextureTypes.G_POSITION.ToString(), Value = geomPassRenderTarget.RenderTextures[(int)RenderTargetTextureTypes.G_POSITION]},
-                new EffectParameterDeclaration { Name = RenderTargetTextureTypes.G_NORMAL.ToString(), Value = geomPassRenderTarget.RenderTextures[(int)RenderTargetTextureTypes.G_NORMAL]},
-                new EffectParameterDeclaration { Name = RenderTargetTextureTypes.G_ALBEDO.ToString(), Value = geomPassRenderTarget.RenderTextures[(int)RenderTargetTextureTypes.G_ALBEDO]},
+                new EffectParameterDeclaration { Name = UniformNameDeclarations.DeferredRenderTextures[(int)RenderTargetTextureTypes.G_POSITION], Value = geomPassRenderTarget.RenderTextures[(int)RenderTargetTextureTypes.G_POSITION]},
+                new EffectParameterDeclaration { Name = UniformNameDeclarations.DeferredRenderTextures[(int)RenderTargetTextureTypes.G_NORMAL], Value = geomPassRenderTarget.RenderTextures[(int)RenderTargetTextureTypes.G_NORMAL]},
+                new EffectParameterDeclaration { Name = UniformNameDeclarations.DeferredRenderTextures[(int)RenderTargetTextureTypes.G_ALBEDO], Value = geomPassRenderTarget.RenderTextures[(int)RenderTargetTextureTypes.G_ALBEDO]},
 
-                new EffectParameterDeclaration { Name = "ScreenParams", Value = screenParams},
-                new EffectParameterDeclaration {Name = "SSAOKernel[0]", Value = ssaoKernel},
-                new EffectParameterDeclaration {Name = "NoiseTex", Value = ssaoNoiseTex},
-                new EffectParameterDeclaration {Name = "FUSEE_P", Value = float4x4.Identity},
+                new EffectParameterDeclaration {Name = UniformNameDeclarations.ScreenParams, Value = screenParams},
+                new EffectParameterDeclaration {Name = UniformNameDeclarations.SSAOKernel, Value = ssaoKernel},
+                new EffectParameterDeclaration {Name = UniformNameDeclarations.NoiseTex, Value = ssaoNoiseTex},
+                new EffectParameterDeclaration {Name = UniformNameDeclarations.Projection, Value = float4x4.Identity},
             });
 
         }
@@ -165,11 +165,11 @@ namespace Fusee.Engine.Core
             {
                 if (lc.Type != LightType.Point)
                 {
-                    effectParams.Add(new EffectParameterDeclaration { Name = "LightSpaceMatrix", Value = new float4x4[] { } });
-                    effectParams.Add(new EffectParameterDeclaration { Name = "ShadowMap", Value = (WritableTexture)shadowMap });
+                    effectParams.Add(new EffectParameterDeclaration { Name = UniformNameDeclarations.LightSpaceMatrix, Value = Array.Empty<float4x4>() });
+                    effectParams.Add(new EffectParameterDeclaration { Name = UniformNameDeclarations.ShadowMap, Value = (WritableTexture)shadowMap });
                 }
                 else
-                    effectParams.Add(new EffectParameterDeclaration { Name = "ShadowCubeMap", Value = (WritableCubeMap)shadowMap });
+                    effectParams.Add(new EffectParameterDeclaration { Name = UniformNameDeclarations.ShadowCubeMap, Value = (WritableCubeMap)shadowMap });
             }
 
             return new ShaderEffect(new[]
@@ -206,7 +206,7 @@ namespace Fusee.Engine.Core
         {
             var effectParams = DeferredLightingEffectParams(srcRenderTarget, backgroundColor);
 
-            effectParams.Add(new EffectParameterDeclaration { Name = "LightSpaceMatrix", Value = new float4x4[] { } });
+            effectParams.Add(new EffectParameterDeclaration { Name = UniformNameDeclarations.LightSpaceMatrix, Value = Array.Empty<float4x4>() });
             effectParams.Add(new EffectParameterDeclaration { Name = "ShadowMaps[0]", Value = shadowMaps });
             effectParams.Add(new EffectParameterDeclaration { Name = "ClipPlanes[0]", Value = clipPlanes });
 
@@ -238,8 +238,8 @@ namespace Fusee.Engine.Core
         {
             var effectParamDecls = new List<EffectParameterDeclaration>
             {
-                new EffectParameterDeclaration { Name = "FUSEE_M", Value = float4x4.Identity },
-                new EffectParameterDeclaration { Name = "FUSEE_V", Value = float4x4.Identity },
+                new EffectParameterDeclaration { Name = UniformNameDeclarations.Model, Value = float4x4.Identity },
+                new EffectParameterDeclaration { Name = UniformNameDeclarations.View, Value = float4x4.Identity },
                 new EffectParameterDeclaration { Name = "LightMatClipPlanes", Value = float2.One },
                 new EffectParameterDeclaration { Name = "LightPos", Value = float3.One },
                 new EffectParameterDeclaration { Name = $"LightSpaceMatrices[0]", Value = lightSpaceMatrices }
@@ -287,9 +287,9 @@ namespace Fusee.Engine.Core
             },
             new[]
             {
-                new EffectParameterDeclaration { Name = "FUSEE_M", Value = float4x4.Identity},
-                new EffectParameterDeclaration { Name = "FUSEE_MVP", Value = float4x4.Identity},
-                new EffectParameterDeclaration { Name = "LightSpaceMatrix", Value = float4x4.Identity},
+                new EffectParameterDeclaration { Name = UniformNameDeclarations.Model, Value = float4x4.Identity},
+                new EffectParameterDeclaration { Name = UniformNameDeclarations.ModelViewProjection, Value = float4x4.Identity},
+                new EffectParameterDeclaration { Name = UniformNameDeclarations.LightSpaceMatrix, Value = float4x4.Identity},
                 new EffectParameterDeclaration { Name = "LightType", Value = 0},
             });
         }
@@ -298,17 +298,17 @@ namespace Fusee.Engine.Core
         {
             return new List<EffectParameterDeclaration>()
             {
-                new EffectParameterDeclaration { Name = RenderTargetTextureTypes.G_POSITION.ToString(), Value = srcRenderTarget.RenderTextures[(int)RenderTargetTextureTypes.G_POSITION]},
-                new EffectParameterDeclaration { Name = RenderTargetTextureTypes.G_NORMAL.ToString(), Value = srcRenderTarget.RenderTextures[(int)RenderTargetTextureTypes.G_NORMAL]},
-                new EffectParameterDeclaration { Name = RenderTargetTextureTypes.G_ALBEDO.ToString(), Value = srcRenderTarget.RenderTextures[(int)RenderTargetTextureTypes.G_ALBEDO]},
-                new EffectParameterDeclaration { Name = RenderTargetTextureTypes.G_SSAO.ToString(), Value = srcRenderTarget.RenderTextures[(int)RenderTargetTextureTypes.G_SSAO]},
-                new EffectParameterDeclaration { Name = RenderTargetTextureTypes.G_SPECULAR.ToString(), Value = srcRenderTarget.RenderTextures[(int)RenderTargetTextureTypes.G_SPECULAR]},
-                new EffectParameterDeclaration { Name = "FUSEE_MVP", Value = float4x4.Identity},
-                new EffectParameterDeclaration { Name = "FUSEE_MV", Value = float4x4.Identity},
-                new EffectParameterDeclaration { Name = "FUSEE_IV", Value = float4x4.Identity},
-                new EffectParameterDeclaration { Name = "FUSEE_V", Value = float4x4.Identity},
-                new EffectParameterDeclaration { Name = "FUSEE_ITV", Value = float4x4.Identity},
-                new EffectParameterDeclaration { Name = "FUSEE_P", Value = float4x4.Identity},
+                new EffectParameterDeclaration { Name = UniformNameDeclarations.DeferredRenderTextures[(int)RenderTargetTextureTypes.G_POSITION], Value = srcRenderTarget.RenderTextures[(int)RenderTargetTextureTypes.G_POSITION]},
+                new EffectParameterDeclaration { Name = UniformNameDeclarations.DeferredRenderTextures[(int)RenderTargetTextureTypes.G_NORMAL], Value = srcRenderTarget.RenderTextures[(int)RenderTargetTextureTypes.G_NORMAL]},
+                new EffectParameterDeclaration { Name = UniformNameDeclarations.DeferredRenderTextures[(int)RenderTargetTextureTypes.G_ALBEDO], Value = srcRenderTarget.RenderTextures[(int)RenderTargetTextureTypes.G_ALBEDO]},
+                new EffectParameterDeclaration { Name = UniformNameDeclarations.DeferredRenderTextures[(int)RenderTargetTextureTypes.G_SSAO], Value = srcRenderTarget.RenderTextures[(int)RenderTargetTextureTypes.G_SSAO]},
+                new EffectParameterDeclaration { Name = UniformNameDeclarations.DeferredRenderTextures[(int)RenderTargetTextureTypes.G_SPECULAR], Value = srcRenderTarget.RenderTextures[(int)RenderTargetTextureTypes.G_SPECULAR]},
+                new EffectParameterDeclaration { Name = UniformNameDeclarations.ModelViewProjection, Value = float4x4.Identity},
+                new EffectParameterDeclaration { Name = UniformNameDeclarations.ModelView, Value = float4x4.Identity},
+                new EffectParameterDeclaration { Name = UniformNameDeclarations.IView, Value = float4x4.Identity},
+                new EffectParameterDeclaration { Name = UniformNameDeclarations.View, Value = float4x4.Identity},
+                new EffectParameterDeclaration { Name = UniformNameDeclarations.ITView, Value = float4x4.Identity},
+                new EffectParameterDeclaration { Name = UniformNameDeclarations.Projection, Value = float4x4.Identity},
                 new EffectParameterDeclaration { Name = "light.position", Value = new float3(0, 0, -1.0f)},
                 new EffectParameterDeclaration { Name = "light.positionWorldSpace", Value = new float3(0, 0, -1.0f)},
                 new EffectParameterDeclaration { Name = "light.intensities", Value = float4.Zero},
@@ -321,9 +321,9 @@ namespace Fusee.Engine.Core
                 new EffectParameterDeclaration { Name = "light.isActive", Value = 1},
                 new EffectParameterDeclaration { Name = "light.isCastingShadows", Value = 0},
                 new EffectParameterDeclaration { Name = "light.bias", Value = 0.0f},
-                new EffectParameterDeclaration { Name = "PassNo", Value = 0},
-                new EffectParameterDeclaration { Name = "BackgroundColor", Value = backgroundColor},
-                new EffectParameterDeclaration { Name = "SsaoOn", Value = 1},
+                new EffectParameterDeclaration { Name = UniformNameDeclarations.RenderPassNo, Value = 0},
+                new EffectParameterDeclaration { Name = UniformNameDeclarations.BackgroundColor, Value = backgroundColor},
+                new EffectParameterDeclaration { Name = UniformNameDeclarations.SsaoOn, Value = 1},
             };
         }
 
@@ -515,8 +515,10 @@ namespace Fusee.Engine.Core
                     }
                 },
                 effectParameters
-            );
-            ret.EffectProps = effectProps;
+            )
+            {
+                EffectProps = effectProps
+            };
             return ret;
         }
 
@@ -528,7 +530,7 @@ namespace Fusee.Engine.Core
         {
             var vertexShader = new List<string>
             {
-                HeaderShard.Version300Es(),
+                HeaderShard.Version300Es,
                 HeaderShard.DefineBones(effectProps, wc),
                 VertPropertiesShard.FuseeUniforms(effectProps),
                 VertPropertiesShard.InAndOutParams(effectProps),
@@ -544,15 +546,15 @@ namespace Fusee.Engine.Core
         {
             var pixelShader = new List<string>
             {
-                HeaderShard.Version300Es(),
-                HeaderShard.EsPrecisionHighpFloat(),
+                HeaderShard.Version300Es,
+                HeaderShard.EsPrecisionHighpFloat,
 
-                LightingShard.LightStructDeclaration(),
+                LightingShard.LightStructDeclaration,
 
                 FragPropertiesShard.InParams(effectProps),
                 FragPropertiesShard.FuseeMatrixUniforms(),
                 FragPropertiesShard.MaterialPropsUniforms(effectProps),
-                FragPropertiesShard.FixedNumberLightArray(),
+                FragPropertiesShard.FixedNumberLightArray,
                 FragPropertiesShard.ColorOut(),
                 LightingShard.AssembleLightingMethods(effectProps)
             };
@@ -567,8 +569,8 @@ namespace Fusee.Engine.Core
         {
             var protoPixelShader = new List<string>
             {
-                HeaderShard.Version300Es(),
-                HeaderShard.EsPrecisionHighpFloat(),
+                HeaderShard.Version300Es,
+                HeaderShard.EsPrecisionHighpFloat,
 
                 FragPropertiesShard.InParams(effectProps),
                 FragPropertiesShard.FuseeMatrixUniforms(),
@@ -581,15 +583,15 @@ namespace Fusee.Engine.Core
         private static string CreateDeferredLightingPixelShader(LightComponent lc, bool isCascaded = false, int numberOfCascades = 0, bool debugCascades = false)
         {
             var frag = new StringBuilder();
-            frag.Append(HeaderShard.Version300Es());
-            frag.Append("#extension GL_ARB_explicit_uniform_location : enable\n"); 
+            frag.Append(HeaderShard.Version300Es);
+            frag.Append("#extension GL_ARB_explicit_uniform_location : enable\n");
             frag.Append("#extension GL_ARB_gpu_shader5 : enable\n");
-            frag.Append(HeaderShard.EsPrecisionHighpFloat());
+            frag.Append(HeaderShard.EsPrecisionHighpFloat);
 
             frag.Append(FragPropertiesShard.DeferredTextureUniforms());
             frag.Append(FragPropertiesShard.FuseeMatrixUniforms());
 
-            frag.Append(LightingShard.LightStructDeclaration());
+            frag.Append(LightingShard.LightStructDeclaration);
             frag.Append(FragPropertiesShard.DeferredLightAndShadowUniforms(lc, isCascaded, numberOfCascades));
 
             frag.Append(GLSL.CreateIn(GLSL.Type.Vec2, VaryingNameDeclarations.TextureCoordinates));
@@ -617,6 +619,9 @@ namespace Fusee.Engine.Core
         }
 
         #endregion
+
+        
+
 
         private static IEnumerable<EffectParameterDeclaration> AssembleEffectParamers(MaterialComponent mc)
         {
@@ -746,59 +751,64 @@ namespace Fusee.Engine.Core
 
             for (int i = 0; i < LightingShard.NumberOfLightsForward; i++)
             {
+                if (!LightingShard.LightPararamStringsAllLights.ContainsKey(i))
+                {
+                    LightingShard.LightPararamStringsAllLights.Add(i, new LightParamStrings(i));
+                }
+
                 effectParameters.Add(new EffectParameterDeclaration
                 {
-                    Name = "allLights[" + i + "].position",
+                    Name = LightingShard.LightPararamStringsAllLights[i].PositionViewSpace,
                     Value = new float3(0, 0, -1.0f)
                 });
                 effectParameters.Add(new EffectParameterDeclaration
                 {
-                    Name = "allLights[" + i + "].intensities",
+                    Name = LightingShard.LightPararamStringsAllLights[i].Intensities,
                     Value = float4.Zero
                 });
                 effectParameters.Add(new EffectParameterDeclaration
                 {
-                    Name = "allLights[" + i + "].maxDistance",
+                    Name = LightingShard.LightPararamStringsAllLights[i].MaxDistance,
                     Value = 0.0f
                 });
                 effectParameters.Add(new EffectParameterDeclaration
                 {
-                    Name = "allLights[" + i + "].strength",
+                    Name = LightingShard.LightPararamStringsAllLights[i].Strength,
                     Value = 0.0f
                 });
                 effectParameters.Add(new EffectParameterDeclaration
                 {
-                    Name = "allLights[" + i + "].outerConeAngle",
+                    Name = LightingShard.LightPararamStringsAllLights[i].OuterAngle,
                     Value = 0.0f
                 });
                 effectParameters.Add(new EffectParameterDeclaration
                 {
-                    Name = "allLights[" + i + "].innerConeAngle",
+                    Name = LightingShard.LightPararamStringsAllLights[i].InnerAngle,
                     Value = 0.0f
                 });
                 effectParameters.Add(new EffectParameterDeclaration
                 {
-                    Name = "allLights[" + i + "].direction",
+                    Name = LightingShard.LightPararamStringsAllLights[i].Direction,
                     Value = float3.Zero
                 });
                 effectParameters.Add(new EffectParameterDeclaration
                 {
-                    Name = "allLights[" + i + "].lightType",
+                    Name = LightingShard.LightPararamStringsAllLights[i].LightType,
                     Value = 1
                 });
                 effectParameters.Add(new EffectParameterDeclaration
                 {
-                    Name = "allLights[" + i + "].isActive",
+                    Name = LightingShard.LightPararamStringsAllLights[i].IsActive,
                     Value = 1
                 });
                 effectParameters.Add(new EffectParameterDeclaration
                 {
-                    Name = "allLights[" + i + "].isCastingShadows",
+                    Name = LightingShard.LightPararamStringsAllLights[i].IsCastingShadows,
                     Value = 0
                 });
                 effectParameters.Add(new EffectParameterDeclaration
                 {
-                    Name = "allLights[" + i + "].bias",
+                    Name = LightingShard.LightPararamStringsAllLights[i].Bias,
                     Value = 0f
                 });
             }

--- a/src/Engine/Core/ShaderEffect.cs
+++ b/src/Engine/Core/ShaderEffect.cs
@@ -147,6 +147,8 @@ namespace Fusee.Engine.Core
         /// </summary>
         internal readonly Suid SessionUniqueIdentifier = Suid.GenerateSuid();
 
+        internal ShaderEffectEventArgs EffectEventArgs;
+
         /// <summary>
         /// The default (nullary) constructor to create a shader effect.
         /// </summary>
@@ -194,6 +196,8 @@ namespace Fusee.Engine.Core
                     ParamDecl.Add(param.Name, param.Value);
                 }
             }
+
+            EffectEventArgs = new ShaderEffectEventArgs(this, ShaderEffectChangedEnum.UNCHANGED);
         }
 
         /// <summary>
@@ -211,6 +215,8 @@ namespace Fusee.Engine.Core
         {
             ShaderEffectChanged?.Invoke(this, new ShaderEffectEventArgs(this, ShaderEffectChangedEnum.DISPOSE));
         }
+
+        
 
         /// <summary>
         /// Set effect parameter
@@ -231,13 +237,23 @@ namespace Fusee.Engine.Core
                     }
 
                     ParamDecl[name] = value;
-                    ShaderEffectChanged?.Invoke(this, new ShaderEffectEventArgs(this, ShaderEffectChangedEnum.UNIFORM_VAR_UPDATED, name, value));
+
+                    EffectEventArgs.Changed = ShaderEffectChangedEnum.UNIFORM_VAR_UPDATED;
+                    EffectEventArgs.ChangedEffectVarName = name;
+                    EffectEventArgs.ChangedEffectVarValue = value;
+
+                    ShaderEffectChanged?.Invoke(this, EffectEventArgs);
                 }
                 else
                 {
                     // not in Parameters yet, add it and call uniform_var_changed!
                     ParamDecl.Add(name, value);
-                    ShaderEffectChanged?.Invoke(this, new ShaderEffectEventArgs(this, ShaderEffectChangedEnum.UNIFORM_VAR_ADDED));
+
+                    EffectEventArgs.Changed = ShaderEffectChangedEnum.UNIFORM_VAR_ADDED;
+                    EffectEventArgs.ChangedEffectVarName = null;
+                    EffectEventArgs.ChangedEffectVarValue = null;
+
+                    ShaderEffectChanged?.Invoke(this, EffectEventArgs);
                 }
             }
         }
@@ -332,10 +348,10 @@ namespace Fusee.Engine.Core
         internal class ShaderEffectEventArgs : EventArgs
         {
             internal ShaderEffect Effect { get; }
-            internal ShaderEffectChangedEnum Changed { get; }
+            internal ShaderEffectChangedEnum Changed { get; set; }
             internal EffectParam EffectParameter { get; }
-            internal string ChangedEffectName { get; }
-            internal object ChangedEffectValue { get; }
+            internal string ChangedEffectVarName { get; set; }
+            internal object ChangedEffectVarValue { get; set; }
 
             internal ShaderEffectEventArgs(ShaderEffect effect, ShaderEffectChangedEnum changed, string changedName = null, object changedValue = null)
             {
@@ -344,16 +360,17 @@ namespace Fusee.Engine.Core
 
                 if (changedName == null || changedValue == null) return;
 
-                ChangedEffectName = changedName;
-                ChangedEffectValue = changedValue;
+                ChangedEffectVarName = changedName;
+                ChangedEffectVarValue = changedValue;
             }
         }
 
         internal enum ShaderEffectChangedEnum
         {            
             DISPOSE = 0,
-            UNIFORM_VAR_UPDATED,
-            UNIFORM_VAR_ADDED            
+            UNIFORM_VAR_UPDATED = 1,
+            UNIFORM_VAR_ADDED = 2,
+            UNCHANGED = 3
         }
     }
 
@@ -408,6 +425,8 @@ namespace Fusee.Engine.Core
                 GeometryShaderSrc[i] = effectPasses[i].GS;
                 //PixelShaderSrc is not set here because it gets built in a pre-pass, depending on whether we render deferred or forward.
             }
+
+            EffectEventArgs = new ShaderEffectEventArgs(this, ShaderEffectChangedEnum.UNCHANGED);
         }
 
         /// <summary>

--- a/src/Engine/Core/ShaderEffect.cs
+++ b/src/Engine/Core/ShaderEffect.cs
@@ -438,8 +438,8 @@ namespace Fusee.Engine.Core
                 {
                     var pxBody = new List<string>()
                     {
-                        LightingShard.LightStructDeclaration(),
-                        FragPropertiesShard.FixedNumberLightArray(),
+                        LightingShard.LightStructDeclaration,
+                        FragPropertiesShard.FixedNumberLightArray,
                         FragPropertiesShard.ColorOut(),
                         LightingShard.AssembleLightingMethods(EffectProps),
                         FragMainShard.ForwardLighting(EffectProps)

--- a/src/Engine/Core/ShaderEffect.cs
+++ b/src/Engine/Core/ShaderEffect.cs
@@ -225,15 +225,13 @@ namespace Fusee.Engine.Core
         /// <param name="value">Value of the uniform variable</param>
         public void SetEffectParam(string name, object value)
         {
-            object param;
-
             if (ParamDecl != null)
             {
-                if (ParamDecl.TryGetValue(name, out param))
-                {
-                    if (param != null)
+                if (ParamDecl.ContainsKey(name))
+                {                    
+                    if (ParamDecl[name] != null)
                     {// do nothing if new value = old value
-                        if (param.Equals(value)) return; // TODO: Write a better compare method! 
+                        if (ParamDecl[name].Equals(value)) return; // TODO: Write a better compare method! 
                     }
 
                     ParamDecl[name] = value;
@@ -243,7 +241,7 @@ namespace Fusee.Engine.Core
                     EffectEventArgs.ChangedEffectVarValue = value;
 
                     ShaderEffectChanged?.Invoke(this, EffectEventArgs);
-                }
+                }                
                 else
                 {
                     // not in Parameters yet, add it and call uniform_var_changed!

--- a/src/Engine/Core/ShaderEffect.cs
+++ b/src/Engine/Core/ShaderEffect.cs
@@ -458,12 +458,9 @@ namespace Fusee.Engine.Core
                         FragMainShard.RenderToGBuffer(EffectProps)
                     };
                     PixelShaderSrc[i] = _effectPasses[i].ProtoPS + string.Join("\n", pxBody);
-                    
-                    States[i] = new RenderStateSet
-                    {
-                        AlphaBlendEnable = false,
-                        ZEnable = true,
-                    };                    
+
+                    States[i].AlphaBlendEnable = false;
+                    States[i].ZEnable = true;
                 }
             }
         }

--- a/src/Engine/Core/ShaderEffectManager.cs
+++ b/src/Engine/Core/ShaderEffectManager.cs
@@ -31,7 +31,7 @@ namespace Fusee.Engine.Core
                     break;
                 case ShaderEffect.ShaderEffectChangedEnum.UNIFORM_VAR_UPDATED:
                     // ReSharper disable once InconsistentNaming
-                    _rc.HandleAndUpdateChangedButExisistingEffectVariable(senderSF, args.ChangedEffectName, args.ChangedEffectValue);
+                    _rc.HandleAndUpdateChangedButExisistingEffectVariable(senderSF, args.ChangedEffectVarName, args.ChangedEffectVarValue);
                     break;
                 case ShaderEffect.ShaderEffectChangedEnum.UNIFORM_VAR_ADDED:
                     // We need to recreate everything

--- a/src/Engine/Core/ShaderShards/AttributeLocations.cs
+++ b/src/Engine/Core/ShaderShards/AttributeLocations.cs
@@ -36,12 +36,12 @@
         public static readonly int BitangentAttribLocation = 5;
 
         /// <summary>
-        /// The boneweight attribute location index.
+        /// The bone weight attribute location index.
         /// </summary>
         public static readonly int BoneWeightAttribLocation = 6;
 
         /// <summary>
-        /// The boneindex attribute location index.
+        /// The bone index attribute location index.
         /// </summary>
         public static readonly int BoneIndexAttribLocation = 7;
     }

--- a/src/Engine/Core/ShaderShards/Fragment/FragMainShard.cs
+++ b/src/Engine/Core/ShaderShards/Fragment/FragMainShard.cs
@@ -65,7 +65,7 @@ namespace Fusee.Engine.Core.ShaderShards.Fragment
                         break;
                     case (int)RenderTargetTextureTypes.G_ALBEDO:
                         if (effectProps.MatProbs.HasDiffuseTexture)
-                            fragMainBody.Add($"{texName} = vec4(mix({UniformNameDeclarations.DiffuseColor}.xyz, texture(DiffuseTexture, {VaryingNameDeclarations.TextureCoordinates}).xyz, {UniformNameDeclarations.DiffuseMix}), 1.0);");
+                            fragMainBody.Add($"{texName} = vec4(mix({UniformNameDeclarations.DiffuseColor}.xyz, texture({UniformNameDeclarations.DiffuseTexture}, {VaryingNameDeclarations.TextureCoordinates}).xyz, {UniformNameDeclarations.DiffuseMix}), 1.0);");
                         else
                             fragMainBody.Add($"{texName} = vec4({UniformNameDeclarations.DiffuseColor}.xyz, 1.0);");
                         break;

--- a/src/Engine/Core/ShaderShards/Fragment/FragPropertiesShard.cs
+++ b/src/Engine/Core/ShaderShards/Fragment/FragPropertiesShard.cs
@@ -186,11 +186,11 @@ namespace Fusee.Engine.Core.ShaderShards.Fragment
                 if (lc.IsCastingShadows)
                 {
                     if (lc.Type != LightType.Point)
-                        uniforms.Add(GLSL.CreateUniform(GLSL.Type.Sampler2D, "ShadowMap"));                        
+                        uniforms.Add(GLSL.CreateUniform(GLSL.Type.Sampler2D, UniformNameDeclarations.ShadowMap));                        
                     else
-                        uniforms.Add(GLSL.CreateUniform(GLSL.Type.SamplerCube, "ShadowCubeMap"));                    
+                        uniforms.Add(GLSL.CreateUniform(GLSL.Type.SamplerCube, UniformNameDeclarations.ShadowCubeMap));                    
                 }
-                uniforms.Add(GLSL.CreateUniform(GLSL.Type.Mat4, "LightSpaceMatrix"));                
+                uniforms.Add(GLSL.CreateUniform(GLSL.Type.Mat4, UniformNameDeclarations.LightSpaceMatrix));                
             }
             else
             {
@@ -200,10 +200,10 @@ namespace Fusee.Engine.Core.ShaderShards.Fragment
                 uniforms.Add($"uniform {GLSL.DecodeType(GLSL.Type.Mat4)}[{numberOfCascades}] LightSpaceMatrices;\n");
             }
 
-            uniforms.Add(GLSL.CreateUniform(GLSL.Type.Int, "PassNo"));
-            uniforms.Add(GLSL.CreateUniform(GLSL.Type.Int, "SsaoOn"));
+            uniforms.Add(GLSL.CreateUniform(GLSL.Type.Int, UniformNameDeclarations.RenderPassNo));
+            uniforms.Add(GLSL.CreateUniform(GLSL.Type.Int, UniformNameDeclarations.SsaoOn));
 
-            uniforms.Add(GLSL.CreateUniform(GLSL.Type.Vec4, "BackgroundColor"));
+            uniforms.Add(GLSL.CreateUniform(GLSL.Type.Vec4, UniformNameDeclarations.BackgroundColor));
             return string.Join("\n", uniforms);
         }
 
@@ -211,9 +211,7 @@ namespace Fusee.Engine.Core.ShaderShards.Fragment
         /// Creates the "allLights" uniform array, as it is used in forward rendering.
         /// </summary>
         /// <returns></returns>
-        public static string FixedNumberLightArray()
-        {
-            return $"uniform Light allLights[{LightingShard.NumberOfLightsForward}];";
-        }        
+        public static string FixedNumberLightArray = $"uniform Light allLights[{LightingShard.NumberOfLightsForward}];";
+               
     }
 }

--- a/src/Engine/Core/ShaderShards/Fragment/LightingShard.cs
+++ b/src/Engine/Core/ShaderShards/Fragment/LightingShard.cs
@@ -13,15 +13,13 @@ namespace Fusee.Engine.Core.ShaderShards.Fragment
     public static class LightingShard
     {
         ///The maximal number of lights we can render when using the forward pipeline.
-        public const int NumberOfLightsForward = 8;
+        public const int NumberOfLightsForward = 8;        
 
         /// <summary>
         /// Struct, that describes a Light object in the shader code./>
         /// </summary>
         /// <returns></returns>
-        public static string LightStructDeclaration()
-        {
-            var lightStruct = @"
+        public static string LightStructDeclaration = @"
             struct Light 
             {
                 vec3 position;
@@ -37,10 +35,12 @@ namespace Fusee.Engine.Core.ShaderShards.Fragment
                 int isActive;
                 int isCastingShadows;
                 float bias;
-            };           
-            ";
-            return lightStruct;
-        }
+            };";
+
+        /// <summary>
+        /// Caches "allLight[i]." names (used as uniform parameters).
+        /// </summary>
+        internal static Dictionary<int, LightParamStrings> LightPararamStringsAllLights = new Dictionary<int, LightParamStrings>();
 
         /// <summary>
         /// Collects all lighting methods, dependent on what is defined in the given <see cref="ShaderEffectProps"/> and the LightingCalculationMethod.
@@ -368,8 +368,10 @@ namespace Fusee.Engine.Core.ShaderShards.Fragment
         /// </summary>
         public static string ApplyLightDeferred(LightComponent lc, bool isCascaded = false, int numberOfCascades = 0, bool debugCascades = false)
         {
-            var methodBody = new List<string>();
-            methodBody.Add($"vec3 normal = texture({RenderTargetTextureTypes.G_NORMAL.ToString()}, {VaryingNameDeclarations.TextureCoordinates}).rgb;");
+            var methodBody = new List<string>
+            {
+                $"vec3 normal = texture({UniformNameDeclarations.DeferredRenderTextures[(int)RenderTargetTextureTypes.G_NORMAL]}, {VaryingNameDeclarations.TextureCoordinates}).rgb;"
+            };
 
             //Do not do calculations for the background - is there a smarter way (stencil buffer)?
             //---------------------------------------
@@ -379,14 +381,14 @@ namespace Fusee.Engine.Core.ShaderShards.Fragment
             "if(normal.x == 0.0 && normal.y == 0.0 && normal.z == 0.0)",
             "{"
             });
-            methodBody.Add($"    {FragPropertiesShard.OutColorName} = BackgroundColor;");
+            methodBody.Add($"    {FragPropertiesShard.OutColorName} = {UniformNameDeclarations.BackgroundColor};");
             methodBody.Add(@"    return;");
             methodBody.Add("}");
 
-            methodBody.Add($"vec4 fragPos = texture({RenderTargetTextureTypes.G_POSITION.ToString()}, {VaryingNameDeclarations.TextureCoordinates});");
-            methodBody.Add($"vec4 diffuseColor = texture({RenderTargetTextureTypes.G_ALBEDO.ToString()}, {VaryingNameDeclarations.TextureCoordinates}).rgba;");
-            methodBody.Add($"vec3 occlusion = texture({RenderTargetTextureTypes.G_SSAO.ToString()}, {VaryingNameDeclarations.TextureCoordinates}).rgb;");
-            methodBody.Add($"vec3 specularVars = texture({RenderTargetTextureTypes.G_SPECULAR.ToString()}, {VaryingNameDeclarations.TextureCoordinates}).rgb;");
+            methodBody.Add($"vec4 fragPos = texture({UniformNameDeclarations.DeferredRenderTextures[(int)RenderTargetTextureTypes.G_POSITION]}, {VaryingNameDeclarations.TextureCoordinates});");
+            methodBody.Add($"vec4 diffuseColor = texture({UniformNameDeclarations.DeferredRenderTextures[(int)RenderTargetTextureTypes.G_ALBEDO]}, {VaryingNameDeclarations.TextureCoordinates}).rgba;");
+            methodBody.Add($"vec3 occlusion = texture({UniformNameDeclarations.DeferredRenderTextures[(int)RenderTargetTextureTypes.G_SSAO]}, {VaryingNameDeclarations.TextureCoordinates}).rgb;");
+            methodBody.Add($"vec3 specularVars = texture({UniformNameDeclarations.DeferredRenderTextures[(int)RenderTargetTextureTypes.G_SPECULAR]}, {VaryingNameDeclarations.TextureCoordinates}).rgb;");
 
             //Lighting calculation
             //-------------------------            
@@ -396,11 +398,11 @@ namespace Fusee.Engine.Core.ShaderShards.Fragment
             "// then calculate lighting as usual",
             "vec3 lighting = vec3(0,0,0);",
             "",
-            "if(PassNo == 0)",
+            $"if({UniformNameDeclarations.RenderPassNo} == 0)",
             "{",
             "   vec3 ambient = ambientLighting(0.2, diffuseColor).xyz;",
                 "",
-            "   if(SsaoOn == 1)",
+            $"   if({UniformNameDeclarations.SsaoOn} == 1)",
             "      ambient *= occlusion;",
 
             "   lighting += ambient;",
@@ -730,6 +732,40 @@ namespace Fusee.Engine.Core.ShaderShards.Fragment
                       
                 ");
             return frag.ToString();
+        }
+    }
+
+    internal struct LightParamStrings
+    {
+        public string PositionViewSpace;
+        public string PositionWorldSpace;
+        public string Intensities;
+        public string MaxDistance;
+        public string Strength;
+        public string OuterAngle;
+        public string InnerAngle;
+        public string Direction;
+        public string DirectionWorldSpace;
+        public string LightType;
+        public string IsActive;
+        public string IsCastingShadows;
+        public string Bias;
+
+        public LightParamStrings(int arrayPos)
+        {
+            PositionViewSpace = $"allLights[{arrayPos}].position";
+            PositionWorldSpace = $"allLights[{arrayPos}].positionWorldSpace";
+            Intensities = $"allLights[{arrayPos}].intensities";
+            MaxDistance = $"allLights[{arrayPos}].maxDistance";
+            Strength = $"allLights[{arrayPos}].strength";
+            OuterAngle = $"allLights[{arrayPos}].outerConeAngle";
+            InnerAngle = $"allLights[{arrayPos}].innerConeAngle";
+            Direction = $"allLights[{arrayPos}].direction";
+            DirectionWorldSpace = $"allLights[{arrayPos}].directionWorldSpace";
+            LightType = $"allLights[{arrayPos}].lightType";
+            IsActive = $"allLights[{arrayPos}].isActive";
+            IsCastingShadows = $"allLights[{arrayPos}].isCastingShadows";
+            Bias = $"allLights[{arrayPos}].bias";
         }
     }
 }

--- a/src/Engine/Core/ShaderShards/GLSL.cs
+++ b/src/Engine/Core/ShaderShards/GLSL.cs
@@ -5,7 +5,7 @@ using System.Linq;
 namespace Fusee.Engine.Core.ShaderShards
 {
     // ReSharper disable once InconsistentNaming
-    internal class GLSL
+    internal static class GLSL
     {
         internal enum Type
         {

--- a/src/Engine/Core/ShaderShards/HeaderShard.cs
+++ b/src/Engine/Core/ShaderShards/HeaderShard.cs
@@ -15,18 +15,13 @@ namespace Fusee.Engine.Core.ShaderShards
         /// <summary>
         /// Sets the precision to highp float.
         /// </summary>
-        public static string EsPrecisionHighpFloat()
-        {
-            return "precision highp float; \n";
-        }
+        public static string EsPrecisionHighpFloat = "precision highp float; \n";       
 
         /// <summary>
         /// Sets the version to 300es.
         /// </summary>
-        public static string Version300Es()
-        {
-            return "#version 300 es\n";
-        }
+        public static string Version300Es = "#version 300 es\n";
+        
 
         /// <summary>
         /// Sets preprocessor that defines the bone count.

--- a/src/Engine/Core/ShaderShards/Includes.cs
+++ b/src/Engine/Core/ShaderShards/Includes.cs
@@ -18,7 +18,7 @@ namespace Fusee.Engine.Core.ShaderShards
         /// <param name="rawShaderString">The raw shader string that is to be parsed.</param>
         /// <returns></returns>
         public static string ParseIncludes(string rawShaderString)
-        {           
+        {
             var fields = GetFieldValues(typeof(UniformNameDeclarations));
 
             var refinedShader = new List<string>();

--- a/src/Engine/Core/ShaderShards/ShaderShardUtil.cs
+++ b/src/Engine/Core/ShaderShards/ShaderShardUtil.cs
@@ -28,7 +28,7 @@ namespace Fusee.Engine.Core.ShaderShards
     /// Collection of bools, describing the mesh properties.
     /// </summary>
     public struct MeshProps
-    {        
+    {
         /// <summary>
         /// Does this mesh have normals?
         /// </summary>
@@ -98,7 +98,7 @@ namespace Fusee.Engine.Core.ShaderShards
         /// <summary>
         /// Does this material have a bump map?
         /// </summary>
-        public bool HasBump;        
+        public bool HasBump;
     }
 
     /// <summary>
@@ -109,13 +109,13 @@ namespace Fusee.Engine.Core.ShaderShards
         /// <summary>
         /// The Standard material.
         /// </summary>
-        Standard,   
-        
+        Standard,
+
         /// <summary>
         /// A material for physically based lighting.
         /// </summary>
         MaterialPbr
-    }    
+    }
 
     /// <summary>
     /// Provides utility methods to write and use Shader Shards.
@@ -141,14 +141,14 @@ namespace Fusee.Engine.Core.ShaderShards
         /// <param name="wc">The weights.</param>
         /// <returns></returns>
         public static ShaderEffectProps CollectEffectProps(Mesh mesh, MaterialComponent mc, WeightComponent wc = null)
-        {           
+        {
             return new ShaderEffectProps()
             {
                 MatType = AnalyzeMaterialType(mc),
                 MatProbs = AnalzyeMaterialParams(mc),
                 MeshProbs = AnalyzeMesh(mesh, wc),
-                
-            };            
+
+            };
         }
 
         private static MaterialProps AnalzyeMaterialParams(MaterialComponent mc)
@@ -161,7 +161,7 @@ namespace Fusee.Engine.Core.ShaderShards
                 HasSpecularTexture = mc.HasSpecular && mc.Specular.Texture != null,
                 HasEmissive = mc.HasEmissive,
                 HasEmissiveTexture = mc.HasEmissive && mc.Emissive.Texture != null,
-                HasBump = mc.HasBump                
+                HasBump = mc.HasBump
             };
         }
 
@@ -177,7 +177,7 @@ namespace Fusee.Engine.Core.ShaderShards
         private static MeshProps AnalyzeMesh(Mesh mesh, WeightComponent wc = null)
         {
             return new MeshProps
-            {                
+            {
                 HasNormals = mesh == null || mesh.Normals != null && mesh.Normals.Length > 0,
                 HasUVs = mesh == null || mesh.UVs != null && mesh.UVs.Length > 0,
                 HasColors = false,

--- a/src/Engine/Core/ShaderShards/UniformNameDeclarations.cs
+++ b/src/Engine/Core/ShaderShards/UniformNameDeclarations.cs
@@ -4,7 +4,6 @@ using System.Collections.Generic;
 
 namespace Fusee.Engine.Core.ShaderShards
 {
-    //TODO: define names for "standard" varying parameters?
     /// <summary>
     /// Collection of uniform parameter names, as they should be used in the Shader Shards to make them compatible to each other.
     /// </summary>
@@ -138,91 +137,145 @@ namespace Fusee.Engine.Core.ShaderShards
 
         #endregion
 
+        #region SSAO
+
         /// <summary>
-        /// The var name for the uniform DiffuseColor variable within the pixel shaders
+        /// The var name for the uniform SSAOKernel[0] variable.
+        /// </summary>
+        public static string SSAOKernel { get; } = "SSAOKernel[0]";
+
+        /// <summary>
+        /// The var name for the uniform NoiseTex variable, needed to calculate SSAO.
+        /// </summary>
+        public static string NoiseTex { get; } = "NoiseTex";
+
+        /// <summary>
+        /// The var name for the uniform SsaoOn variable.
+        /// </summary>
+        public static string SsaoOn { get; } = "SsaoOn";
+
+        #endregion
+
+        #region Shadow mapping
+
+        /// <summary>
+        /// The var name for the uniform LightSpaceMatrix.
+        /// </summary>
+        public static string LightSpaceMatrix { get; } = "LightSpaceMatrix";
+
+        /// <summary>
+        /// The var name for the uniform ShadowMap.
+        /// </summary>
+        public static string ShadowMap { get; } = "ShadowMap";
+
+        /// <summary>
+        /// The var name for the uniform ShadowCubeMap.
+        /// </summary>
+        public static string ShadowCubeMap { get; } = "ShadowCubeMap";
+
+        #endregion
+
+
+        /// <summary>
+        /// The var name for the uniform PassNo variable.
+        /// </summary>
+        public static string RenderPassNo { get; } = "PassNo";
+
+        /// <summary>
+        /// The var name for the uniform BackgroundColor.
+        /// </summary>
+        public static string BackgroundColor { get; } = "BackgroundColor";
+
+        /// <summary>
+        /// The var name for the uniform ScreenParams (width and height of the window).
+        /// </summary>
+        public static string ScreenParams { get; } = "ScreenParams";
+
+        /// <summary>
+        /// The var name for the uniform DiffuseColor variable within the pixel shaders.
         /// </summary>
         public static string AmbientStrengthName { get; } = "AmbientStrength";
 
         /// <summary>
-        /// The var name for the uniform DiffuseColor variable within the pixel shaders
+        /// The var name for the uniform DiffuseColor variable within the pixel shaders.
         /// </summary>
         public static string DiffuseColor { get; } = "DiffuseColor";
 
         /// <summary>
-        /// The var name for the uniform SpecularColor variable within the pixel shaders
+        /// The var name for the uniform SpecularColor variable within the pixel shaders.
         /// </summary>
         public static string SpecularColor { get; } = "SpecularColor";
 
         /// <summary>
-        /// The var name for the uniform EmissiveColor variable within the pixel shaders
+        /// The var name for the uniform EmissiveColor variable within the pixel shaders.
         /// </summary>
         public static string EmissiveColorName { get; } = "EmissiveColor";
 
         /// <summary>
-        /// The var name for the uniform DiffuseTexture variable within the pixel shaders
+        /// The var name for the uniform DiffuseTexture variable within the pixel shaders.
         /// </summary>
         public static string DiffuseTexture { get; } = "DiffuseTexture";
 
         /// <summary>
-        /// The var name for the uniform SpecularTexture variable within the pixel shaders
+        /// The var name for the uniform SpecularTexture variable within the pixel shaders.
         /// </summary>
         public static string SpecularTextureName { get; } = "SpecularTexture";
 
         /// <summary>
-        /// The var name for the uniform EmissiveTexture variable within the pixel shaders
+        /// The var name for the uniform EmissiveTexture variable within the pixel shaders.
         /// </summary>
         public static string EmissiveTextureName { get; } = "EmissiveTexture";
 
         /// <summary>
-        /// The var name for the uniform BumpTexture variable within the pixel shaders
+        /// The var name for the uniform BumpTexture variable within the pixel shaders.
         /// </summary>
         public static string BumpTextureName { get; } = "BumpTexture";
 
         /// <summary>
-        /// The var name for the uniform DiffuseMix variable within the pixel shaders
+        /// The var name for the uniform DiffuseMix variable within the pixel shaders.
         /// </summary>
         public static string DiffuseMix { get; } = "DiffuseMix";
 
         /// <summary>
-        /// The var name for the uniform SpecularMix variable within the pixel shaders
+        /// The var name for the uniform SpecularMix variable within the pixel shaders.
         /// </summary>
         public static string SpecularMixName { get; } = "SpecularMix";
 
         /// <summary>
-        /// The var name for the uniform EmissiveMix variable within the pixel shaders
+        /// The var name for the uniform EmissiveMix variable within the pixel shaders.
         /// </summary>
         public static string EmissiveMixName { get; } = "EmissiveMix";
 
         /// <summary>
-        /// The var name for the uniform SpecularShininess variable within the pixel shaders
+        /// The var name for the uniform SpecularShininess variable within the pixel shaders.
         /// </summary>
         public static string SpecularShininessName { get; } = "SpecularShininess";
 
         /// <summary>
-        /// The var name for the uniform SpecularIntensity variable within the pixel shaders
+        /// The var name for the uniform SpecularIntensity variable within the pixel shaders.
         /// </summary>
         public static string SpecularStrength { get; } = "SpecularIntensity";
 
         /// <summary>
-        /// [PBR (Cook-Torrance) only] Describes the roughness of the material
+        /// [PBR (Cook-Torrance) only] Describes the roughness of the material.
         /// </summary>       
         public static string RoughnessValue { get; } = "RoughnessValue";
 
         /// <summary>
-        /// [PBR (Cook-Torrance) only] This float describes the fresnel reflectance of the material
+        /// [PBR (Cook-Torrance) only] This float describes the fresnel reflectance of the material.
         /// </summary>        
         public static string FresnelReflectance { get; } = "FresnelReflectance";
 
         /// <summary>
-        /// [PBR (Cook-Torrance) only] This float describes the diffuse fraction of the material
+        /// [PBR (Cook-Torrance) only] This float describes the diffuse fraction of the material.
         /// </summary>       
         public static string DiffuseFraction { get; } = "DiffuseFraction";
 
         /// <summary>
-        /// The var name for the uniform BumpIntensity variable within the pixel shaders
+        /// The var name for the uniform BumpIntensity variable within the pixel shaders.
         /// </summary>
         public static string BumpIntensityName { get; } = "BumpIntensityName";
-      
+
         /// <summary>
         /// List of all possible render texture names.
         /// </summary>
@@ -234,6 +287,6 @@ namespace Fusee.Engine.Core.ShaderShards
             Enum.GetName(typeof(RenderTargetTextureTypes), 3),
             Enum.GetName(typeof(RenderTargetTextureTypes), 4),
             Enum.GetName(typeof(RenderTargetTextureTypes), 5),
-        };
+        };        
     }
 }

--- a/src/Math/Core/float3.cs
+++ b/src/Math/Core/float3.cs
@@ -8,7 +8,7 @@ namespace Fusee.Math.Core
     /// Represents a 3D vector using three single-precision floating-point numbers.
     /// </summary>
     /// <remarks>
-    /// The float3 structure is suitable for interoperation with unmanaged code requiring three consecutive floats.
+    /// The float3 structure is suitable for inter-operation with unmanaged code requiring three consecutive floats.
     /// </remarks>
     [ProtoContract]
     [StructLayout(LayoutKind.Sequential)]
@@ -895,7 +895,7 @@ namespace Fusee.Math.Core
         }
 
         /// <summary>
-        /// Multiplies two instances (componentwise).
+        /// Multiplies two instances (component-wise).
         /// </summary>
         /// <param name="vec1">The first instance.</param>
         /// <param name="vec2">The second instance.</param>
@@ -937,7 +937,7 @@ namespace Fusee.Math.Core
         /// <param name="left">The first instance.</param>
         /// <param name="right">The second instance.</param>
         /// <returns>
-        /// True, if left does not equa lright; false otherwise.
+        /// True, if left does not equal right; false otherwise.
         /// </returns>
         public static bool operator !=(float3 left, float3 right)
         {

--- a/src/Math/Core/float4x4.cs
+++ b/src/Math/Core/float4x4.cs
@@ -1233,7 +1233,7 @@ namespace Fusee.Math.Core
         /// <param name="left">The left operand of the addition.</param>
         /// <param name="right">The right operand of the addition.</param>
         /// <returns>A new instance that is the result of the addition.</returns>
-        public static float4x4 Add(float4x4 left, float4x4 right)
+        public static float4x4 Add(in float4x4 left, in float4x4 right)
         {
             return new float4x4(left.M11 + right.M11, left.M12 + right.M12, left.M13 + right.M13, left.M14 + right.M14,
                                 left.M21 + right.M21, left.M22 + right.M22, left.M23 + right.M23, left.M24 + right.M24,
@@ -1247,7 +1247,7 @@ namespace Fusee.Math.Core
         /// <param name="left">The left operand of the subtraction.</param>
         /// <param name="right">The right operand of the subtraction.</param>
         /// <returns>A new instance that is the result of the subtraction.</returns>
-        public static float4x4 Subtract(float4x4 left, float4x4 right)
+        public static float4x4 Subtract(in float4x4 left, in float4x4 right)
         {
             return new float4x4(left.M11 - right.M11, left.M12 - right.M12, left.M13 - right.M13, left.M14 - right.M14,
                                 left.M21 - right.M21, left.M22 - right.M22, left.M23 - right.M23, left.M24 - right.M24,
@@ -1265,7 +1265,7 @@ namespace Fusee.Math.Core
         /// <param name="left">The left operand of the multiplication.</param>
         /// <param name="right">The right operand of the multiplication.</param>
         /// <returns>A new instance that is the result of the multiplication</returns>
-        public static float4x4 Mult(float4x4 left, float4x4 right)
+        public static float4x4 Mult(in float4x4 left, in float4x4 right)
         {
             if (left == Identity) return right;
             if (right == Identity) return left;

--- a/src/Serialization/MaterialComponent.cs
+++ b/src/Serialization/MaterialComponent.cs
@@ -1,5 +1,6 @@
 ﻿using Fusee.Math.Core;
 using ProtoBuf;
+using System;
 
 namespace Fusee.Serialization
 {
@@ -11,10 +12,10 @@ namespace Fusee.Serialization
     // taken from http://www.codeproject.com/Articles/642677/Protobuf-net-the-unofficial-manual
     // Here is where I start disliking Protobuf...Note-to-self: Write own serialization
     [ProtoInclude(100, typeof(SpecularChannelContainer))]
-    public class MatChannelContainer
+    public class MatChannelContainer : IEquatable<MatChannelContainer>
     {
         /// <summary>
-        /// The color of the light componennt.
+        /// The color of the light component.
         /// </summary>
         [ProtoMember(1)]
         public float4 Color;
@@ -30,13 +31,98 @@ namespace Fusee.Serialization
         /// </summary>
         [ProtoMember(3)]
         public float Mix;
+
+        #region equals
+
+        /// <summary>
+        /// Compares two instances for equality.
+        /// </summary>
+        /// <param name="lhs">The first instance.</param>
+        /// <param name="rhs">The second instance.</param>
+        /// <returns>
+        /// True, if left does equal right; false otherwise.
+        /// </returns>
+        public static bool operator ==(MatChannelContainer lhs, MatChannelContainer rhs)
+        {
+            // Check for null on left side.
+            if (lhs is null)
+            {
+                if (rhs is null)
+                    return true;
+
+                return false;
+            }
+            // Equals handles case of null on right side.
+            return lhs.Equals(rhs);
+        }
+
+
+        /// <summary>
+        /// Compares two instances for inequality.
+        /// </summary>
+        /// <param name="lhs">The first instance.</param>
+        /// <param name="rhs">The second instance.</param>
+        /// <returns>
+        /// True, if left does not equal right; false otherwise.
+        /// </returns>
+        public static bool operator !=(MatChannelContainer lhs, MatChannelContainer rhs)
+        {
+            return !(lhs == rhs);
+        }
+
+        /// <summary>
+        /// Indicates whether the MatChannelContainer is equal to another one.
+        /// </summary>
+        /// <param name="other">The MatChannelContainer to compare with this one.</param>
+        /// <returns>
+        /// true if the current MatChannelContainer is equal to the other; otherwise, false.
+        /// </returns>
+        public bool Equals(MatChannelContainer other)
+        {
+            if (other == null)
+                return false;
+
+            return other.Color == Color && other.Texture == Texture && other.Mix == Mix;
+        }
+
+        /// <summary>
+        /// Indicates whether this instance and a specified object are equal.
+        /// </summary>
+        /// <param name="obj">The object to compare to.</param>
+        /// <returns>
+        /// True if the instances are equal; false otherwise.
+        /// </returns>
+        public override bool Equals(object obj)
+        {
+            if ((obj is null) || !GetType().Equals(obj.GetType()))
+                return false;
+            else
+                return Equals((MatChannelContainer)obj);
+        }
+
+        /// <summary>
+        /// Returns the hash for this instance.
+        /// </summary>        
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                int hash = 17;
+                hash = hash * 29 + Color.GetHashCode();
+                hash = hash * 29 + Mix.GetHashCode();
+                hash = Texture == null ? hash * 29 + 0 : hash * 29 + Texture.GetHashCode();
+                return hash;
+            }
+        }
+
+        #endregion
     }
 
     /// <summary>
     /// The specular channel definition. 
     /// </summary>
     [ProtoContract]
-    public class SpecularChannelContainer : MatChannelContainer
+    public class SpecularChannelContainer : MatChannelContainer, IEquatable<SpecularChannelContainer>
     {
         /// <summary>
         /// The material's shininess.
@@ -49,34 +135,203 @@ namespace Fusee.Serialization
         /// </summary>
         [ProtoMember(2)]
         public float Intensity;
+
+        #region equals
+
+        /// <summary>
+        /// Compares two instances for equality.
+        /// </summary>
+        /// <param name="lhs">The first instance.</param>
+        /// <param name="rhs">The second instance.</param>
+        /// <returns>
+        /// True, if left does equal right; false otherwise.
+        /// </returns>
+        public static bool operator ==(SpecularChannelContainer lhs, SpecularChannelContainer rhs)
+        {
+            // Check for null on left side.
+            if (lhs is null)
+            {
+                if (rhs is null)
+                    return true;
+
+                return false;
+            }
+            // Equals handles case of null on right side.
+            return lhs.Equals(rhs);
+        }
+
+        /// <summary>
+        /// Compares two instances for inequality.
+        /// </summary>
+        /// <param name="lhs">The first instance.</param>
+        /// <param name="rhs">The second instance.</param>
+        /// <returns>
+        /// True, if left does not equal right; false otherwise.
+        /// </returns>
+        public static bool operator !=(SpecularChannelContainer lhs, SpecularChannelContainer rhs)
+        {
+            return !(lhs == rhs);
+        }
+
+        /// <summary>
+        /// Indicates whether the SpecularChannelContainer is equal to another one.
+        /// </summary>
+        /// <param name="other">The SpecularChannelContainer to compare with this one.</param>
+        /// <returns>
+        /// true if the current SpecularChannelContainer is equal to the other; otherwise, false.
+        /// </returns>
+        public bool Equals(SpecularChannelContainer other)
+        {
+            if (other is null)
+                return false;
+            return other.Shininess == Shininess && other.Intensity == Intensity;
+        }
+
+        /// <summary>
+        /// Indicates whether this instance and a specified object are equal.
+        /// </summary>
+        /// <param name="obj">The object to compare to.</param>
+        /// <returns>
+        /// True if the instances are equal; false otherwise.
+        /// </returns>
+        public override bool Equals(object obj)
+        {
+            if ((obj is null) || !GetType().Equals(obj.GetType()))
+                return false;
+            else
+                return Equals((SpecularChannelContainer)obj);
+        }
+
+        /// <summary>
+        /// Returns the hash for this instance.
+        /// </summary>        
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                int hash = 17;
+                hash = hash * 29 + Color.GetHashCode();
+                hash = hash * 29 + Mix.GetHashCode();
+                hash = Texture == null ? hash * 29 + 0 : hash * 29 + Texture.GetHashCode();
+                hash = hash * 29 + Shininess.GetHashCode();
+                hash = hash * 29 + Intensity.GetHashCode();
+                return hash;
+            }
+        }
+
+        #endregion
     }
 
     /// <summary>
     /// If used, the material shows bumps defined by a normal map (a texture).
     /// </summary>
     [ProtoContract]
-    public class BumpChannelContainer
+    public class BumpChannelContainer : IEquatable<BumpChannelContainer>
     {
         /// <summary>
         /// The texture to read the normal information from.
         /// </summary>
-        [ProtoMember(1)] 
+        [ProtoMember(1)]
         public string Texture;
 
         /// <summary>
         /// The intensity of the bumps.
         /// </summary>
-        [ProtoMember(2)] 
+        [ProtoMember(2)]
         public float Intensity;
+
+        #region equals
+
+        /// <summary>
+        /// Compares two instances for equality.
+        /// </summary>
+        /// <param name="lhs">The first instance.</param>
+        /// <param name="rhs">The second instance.</param>
+        /// <returns>
+        /// True, if left does equal right; false otherwise.
+        /// </returns>
+        public static bool operator ==(BumpChannelContainer lhs, BumpChannelContainer rhs)
+        {
+            // Check for null on left side.
+            if (lhs is null)
+            {
+                if (rhs is null)
+                    return true;
+
+                return false;
+            }
+            // Equals handles case of null on right side.
+            return lhs.Equals(rhs);
+        }
+
+        /// <summary>
+        /// Compares two instances for inequality.
+        /// </summary>
+        /// <param name="lhs">The first instance.</param>
+        /// <param name="rhs">The second instance.</param>
+        /// <returns>
+        /// True, if left does not equal right; false otherwise.
+        /// </returns>
+        public static bool operator !=(BumpChannelContainer lhs, BumpChannelContainer rhs)
+        {
+            return !(lhs == rhs);
+        }
+
+        /// <summary>
+        /// Indicates whether the BumpChannelContainer is equal to another one.
+        /// </summary>
+        /// <param name="other">The BumpChannelContainer to compare with this one.</param>
+        /// <returns>
+        /// true if the current BumpChannelContainer is equal to the other; otherwise, false.
+        /// </returns>
+        public bool Equals(BumpChannelContainer other)
+        {
+            if (other is null)
+                return false;
+            return other.Texture == Texture && other.Intensity == Intensity;
+        }
+
+        /// <summary>
+        /// Indicates whether this instance and a specified object are equal.
+        /// </summary>
+        /// <param name="obj">The object to compare to.</param>
+        /// <returns>
+        /// True if the instances are equal; false otherwise.
+        /// </returns>
+        public override bool Equals(object obj)
+        {
+            if ((obj is null) || !GetType().Equals(obj.GetType()))
+                return false;
+            else
+                return Equals((BumpChannelContainer)obj);
+
+        }
+
+        /// <summary>
+        /// Returns the hash for this instance.
+        /// </summary>        
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                int hash = 17;
+                hash = Texture == null ? hash * 29 + 0 : hash * 29 + Texture.GetHashCode();
+                hash = hash * 29 + Intensity.GetHashCode();
+                return hash;
+            }
+        }
+
+        #endregion
+
     }
 
     /// <summary>
     /// Material definition. If contained within a node, the node's (and potentially child node's)
-    /// geometry is rendered with the speicified material.
+    /// geometry is rendered with the specified material.
     /// </summary>
-    [ProtoContract]   
+    [ProtoContract]
     [ProtoInclude(201, typeof(MaterialPBRComponent))]
-    public class MaterialComponent : SceneComponentContainer
+    public class MaterialComponent : SceneComponentContainer, IEquatable<MaterialComponent>
     {
         #region Diffuse
         /// <summary>
@@ -85,12 +340,12 @@ namespace Fusee.Serialization
         /// <value>
         /// <c>true</c> if this instance has a diffuse channel; otherwise, <c>false</c>.
         /// </value>
-        public bool HasDiffuse { get { return Diffuse != null; }}
+        public bool HasDiffuse { get { return Diffuse != null; } }
 
         /// <summary>
         /// The diffuse channel.
         /// </summary>
-        [ProtoMember(1)] 
+        [ProtoMember(1)]
         public MatChannelContainer Diffuse;
         #endregion
 
@@ -141,5 +396,106 @@ namespace Fusee.Serialization
         [ProtoMember(4)]
         public BumpChannelContainer Bump;
         #endregion
+
+        #region equals
+
+        /// <summary>
+        /// Compares two instances for equality.
+        /// </summary>
+        /// <param name="lhs">The first instance.</param>
+        /// <param name="rhs">The second instance.</param>
+        /// <returns>
+        /// True, if left does equal right; false otherwise.
+        /// </returns>
+        public static bool operator ==(MaterialComponent lhs, MaterialComponent rhs)
+        {
+            // Check for null on left side.
+            if (lhs is null)
+            {
+                if (lhs is null)
+                    return true;
+
+                return false;
+            }
+            // Equals handles case of null on right side.
+            return lhs.Equals(rhs);
+        }
+
+        /// <summary>
+        /// Compares two instances for inequality.
+        /// </summary>
+        /// <param name="lhs">The first instance.</param>
+        /// <param name="rhs">The second instance.</param>
+        /// <returns>
+        /// True, if left does not equal right; false otherwise.
+        /// </returns>
+        public static bool operator !=(MaterialComponent lhs, MaterialComponent rhs)
+        {
+            return !(lhs == rhs);
+        }
+
+        /// <summary>
+        /// Returns the hash for this instance.
+        /// </summary>        
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                int hash = 17;
+                hash = hash * 29 + HasDiffuse.GetHashCode();
+                hash = Diffuse == null ? hash * 29 + 0 : hash * 29 + Diffuse.GetHashCode();
+
+                hash = hash * 29 + HasSpecular.GetHashCode();
+                hash = Specular == null ? hash * 29 + 0 : hash * 29 + Specular.GetHashCode();
+
+                hash = hash * 29 + HasEmissive.GetHashCode();
+                hash = Emissive == null ? hash * 29 + 0 : hash * 29 + Emissive.GetHashCode();
+
+                hash = hash * 29 + HasBump.GetHashCode();
+                hash = Bump == null ? hash * 29 + 0 : hash * 29 + Bump.GetHashCode();
+
+                return hash;
+            }
+        }
+
+        /// <summary>
+        /// Indicates whether the MaterialComponent is equal to another one.
+        /// </summary>
+        /// <param name="other">The MaterialComponent to compare with this one.</param>
+        /// <returns>
+        /// true if the current MaterialComponent is equal to the other; otherwise, false.
+        /// </returns>
+        public bool Equals(MaterialComponent other)
+        {
+            if (other is null)
+                return false;
+
+            return
+                HasDiffuse == other.HasDiffuse &&
+                Diffuse == other.Diffuse &&
+                HasSpecular == other.HasSpecular &&
+                Specular == other.Specular &&
+                HasEmissive == other.HasEmissive &&
+                Emissive == other.Emissive &&
+                HasBump == other.HasBump &&
+                Bump == other.Bump;
+        }
+
+        /// <summary>
+        /// Indicates whether this instance and a specified object are equal.
+        /// </summary>
+        /// <param name="obj">The object to compare to.</param>
+        /// <returns>
+        /// True if the instances are equal; false otherwise.
+        /// </returns>
+        public override bool Equals(object obj)
+        {
+            if ((obj == null) || !GetType().Equals(obj.GetType()))
+                return false;
+            else
+                return Equals((MatChannelContainer)obj);
+        }
+
+        #endregion  
     }
 }

--- a/src/Serialization/MaterialPBRComponent.cs
+++ b/src/Serialization/MaterialPBRComponent.cs
@@ -1,4 +1,5 @@
 ﻿using ProtoBuf;
+using System;
 
 namespace Fusee.Serialization
 {
@@ -8,7 +9,7 @@ namespace Fusee.Serialization
     /// </summary>
     [ProtoContract]
     // ReSharper disable once InconsistentNaming
-    public class MaterialPBRComponent : MaterialComponent
+    public class MaterialPBRComponent : MaterialComponent, IEquatable<MaterialPBRComponent>
     {
         /// <summary>
         /// This float describes the roughness of the material
@@ -28,5 +29,113 @@ namespace Fusee.Serialization
         [ProtoMember(3)]
         public float DiffuseFraction;
 
+        #region equals
+
+        /// <summary>
+        /// Compares two instances for equality.
+        /// </summary>
+        /// <param name="lhs">The first instance.</param>
+        /// <param name="rhs">The second instance.</param>
+        /// <returns>
+        /// True, if left does equal right; false otherwise.
+        /// </returns>
+        public static bool operator ==(MaterialPBRComponent lhs, MaterialPBRComponent rhs)
+        {
+            // Check for null on left side.
+            if (lhs is null)
+            {
+                if (lhs is null)
+                    return true;
+
+                return false;
+            }
+            // Equals handles case of null on right side.
+            return lhs.Equals(rhs);
+        }
+
+
+        /// <summary>
+        /// Compares two instances for inequality.
+        /// </summary>
+        /// <param name="lhs">The first instance.</param>
+        /// <param name="rhs">The second instance.</param>
+        /// <returns>
+        /// True, if left does not equal right; false otherwise.
+        /// </returns>
+        public static bool operator !=(MaterialPBRComponent lhs, MaterialPBRComponent rhs)
+        {
+            return !(lhs == rhs);
+        }
+
+        /// <summary>
+        /// Returns the hash for this instance.
+        /// </summary>        
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                int hash = 17;
+                hash = hash * 29 + HasDiffuse.GetHashCode();
+                hash = Diffuse == null ? hash * 29 + 0 : hash * 29 + Diffuse.GetHashCode();
+
+                hash = hash * 29 + HasSpecular.GetHashCode();
+                hash = Specular == null ? hash * 29 + 0 : hash * 29 + Specular.GetHashCode();
+
+                hash = hash * 29 + HasEmissive.GetHashCode();
+                hash = Emissive == null ? hash * 29 + 0 : hash * 29 + Emissive.GetHashCode();
+
+                hash = hash * 29 + HasBump.GetHashCode();
+                hash = Bump == null ? hash * 29 + 0 : hash * 29 + Bump.GetHashCode();
+
+                hash = hash * 29 + RoughnessValue.GetHashCode();
+                hash = hash * 29 + FresnelReflectance.GetHashCode();
+                hash = hash * 29 + DiffuseFraction.GetHashCode();
+
+                return hash;
+            }
+        }
+
+        /// <summary>
+        /// Indicates whether the MaterialPBRComponent is equal to another one.
+        /// </summary>
+        /// <param name="other">The MaterialPBRComponent to compare with this one.</param>
+        /// <returns>
+        /// true if the current MaterialPBRComponent is equal to the other; otherwise, false.
+        /// </returns>
+        public bool Equals(MaterialPBRComponent other)
+        {
+            if (other == null)
+                return false;
+
+            return
+                HasDiffuse == other.HasDiffuse &&
+                Diffuse == other.Diffuse &&
+                HasSpecular == other.HasSpecular &&
+                Specular == other.Specular &&
+                HasEmissive == other.HasEmissive &&
+                Emissive == other.Emissive &&
+                HasBump == other.HasBump &&
+                Bump == other.Bump &&
+                RoughnessValue == other.RoughnessValue &&
+                FresnelReflectance == other.FresnelReflectance &&
+                DiffuseFraction == other.DiffuseFraction;
+        }
+
+        /// <summary>
+        /// Indicates whether this instance and a specified object are equal.
+        /// </summary>
+        /// <param name="obj">The object to compare to.</param>
+        /// <returns>
+        /// True if the instances are equal; false otherwise.
+        /// </returns>
+        public override bool Equals(object obj)
+        {
+            if ((obj == null) || !GetType().Equals(obj.GetType()))
+                return false;
+            else
+                return Equals((MaterialPBRComponent)obj);
+        }
+
+        #endregion
     }
 }


### PR DESCRIPTION
### Summary

1. Eliminated unnecessary instantiating of ShaderEffectEventArgs.
2. SetFXParam and SetEffectParam use ContainsKey instead of TryGetValue at places where the acual value isn't needed.
3. Reworked Render State management.
4. Better caching of "allLights[i]." shader variable names.
5. Implemented IEquatable in MaterialComponents and -Containers.
6. Using "in" when passing float4x4 to Add, Subtract and Mult.

### Notes

#### 5. Implemented IEquatable in MaterialComponents and -Containers

The reason for this was the conversion from ``MaterialComponent`` to ``ShaderEffectComponent``. 
``ConvertSceneGraph`` contains dictionaries holding all previously encountered MaterialComponents but wasn't able to correctly fill and read from the dictionaries (e.g. >300 ShaderEffects in SimpleDeferred even though the Scene has only one Material in its untextured version).

For implementing ``GetHashCode`` I used some prime number magic suggested [here](https://stackoverflow.com/questions/263400/what-is-the-best-algorithm-for-overriding-gethashcode). It seems to work altough I'm not sure whether it is a good idea to use the same prime numbers for all methods (further insights are welcome).

#### 3. Reworked Render State management

This was mandatory to fullfill the following requirements:

1. A user should be able to set a render state on the ``RenderContext`` and overwrite all behaviour comming from ``ShaderEffects``.
3. ``ShaderEffects`` should be able to set render states for nodes containing them and also for their children (if the children do not have the same state set to another value).
5. ``SceneRenderers`` should be able to manage the whole render state, whether it was changed by a user or a ``ShaderEffect``.

This lead to the following changes:

- Render states can be _locked_ by the user. This disables all changes comming from ``ShaderEffects`` and the ``SceneRenderer`` (if not particulary managed in the ``SceneRenderer`` in another way - see ``SceneRendererDeferred`` where we need to unlock the states for a few passes).

- ``RenderContext.CurrentRenderState`` keeps track of the states at all times and is used to determine if we need to call ``RenderContextImp.SetRenderState`` (expensive call on the GPU) or not.

- The ``SceneRenderer`` keeps track of states it needs to reset while traversing up and down the Scene Graph (adding another ``CollapsableStateStack`` to the ``RendererState``).

Those changes will fix #188
