### PR TITLE
Build Artifacts

### DIFF
--- a/.github/workflows/dotnetcore-wasm.yml
+++ b/.github/workflows/dotnetcore-wasm.yml
@@ -34,3 +34,9 @@ jobs:
 
     - name: Math tests
       run: dotnet test -c Release src/Tests/Math/Core/Fusee.Test.Math.Core.csproj
+      
+    - name: Upload Example-Artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        name: examples
+        path: bin/Release/Examples/**/WebAsm/

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -39,4 +39,4 @@ jobs:
       uses: actions/upload-artifact@v2
       with:
         name: build-result
-        path: bin/Release/
+        path: bin/Release/Examples/**/Desktop/

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -35,8 +35,20 @@ jobs:
     - name: Math tests
       run: dotnet test -c Release src/Tests/Math/Core/Fusee.Test.Math.Core.csproj
     
-    - name: Upload Build Results
+    - name: Upload Player-Artifact
       uses: actions/upload-artifact@v2
       with:
-        name: build-result
+        name: player
+        path: bin/Release/Player/Desktop/
+
+    - name: Upload Tool-Artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        name: tools
+        path: bin/Release/Tools/
+
+    - name: Upload Example-Artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        name: examples
         path: bin/Release/Examples/**/Desktop/

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -34,3 +34,9 @@ jobs:
 
     - name: Math tests
       run: dotnet test -c Release src/Tests/Math/Core/Fusee.Test.Math.Core.csproj
+    
+    - name: Upload Build Results
+      uses: actions/upload-artifact@v2
+      with:
+        name: build-result
+        path: bin/Release/


### PR DESCRIPTION
For now just a little quality of life change, when debugging the automatic builds. But when we update the website we can use the WASM artifacts there.