### PR TITLE
Set ParamDecl in ShaderEffect to be internal instead of public

### DIFF
--- a/src/Engine/Core/Scene/ShaderEffect.cs
+++ b/src/Engine/Core/Scene/ShaderEffect.cs
@@ -116,7 +116,7 @@ namespace Fusee.Engine.Core.Scene
         /// <summary>
         /// The ShaderEffect'S uniform parameters and their values.
         /// </summary>
-        public Dictionary<string, object> ParamDecl { get; protected set; }
+        internal Dictionary<string, object> ParamDecl { get; set; }
 
         /// <summary>
         /// List of <see cref="RenderStateSet"/>


### PR DESCRIPTION
- Made the `ParamDecl` Dictonary in `ShaderEffect` internal since users should not have access to it. All manipulation should be done via `SetEffectParam([..])`.