### PR TITLE
patch/ShaderEffectsMemoryLeak

### DIFF
--- a/src/Engine/Core/EffectManager.cs
+++ b/src/Engine/Core/EffectManager.cs
@@ -13,11 +13,6 @@ namespace Fusee.Engine.Core
 
         private readonly Dictionary<Suid, Effect> _allEffects = new Dictionary<Suid, Effect>();
 
-        private void Remove(Effect ef)
-        {
-            _rc.RemoveShader(ef);
-        }
-
         private void EffectChanged(object sender, EffectManagerEventArgs args)
         {
             if (args == null || sender == null) return;
@@ -28,7 +23,7 @@ namespace Fusee.Engine.Core
             switch (args.Changed)
             {
                 case UniformChangedEnum.Dispose:
-                    Remove(senderSF);
+                    _effectsToBeDeleted.Push(senderSF);
                     break;
                 case UniformChangedEnum.Update:
                     _rc.UpdateParameterInCompiledEffect(senderSF, args.ChangedUniformName, args.ChangedUniformValue);
@@ -74,7 +69,7 @@ namespace Fusee.Engine.Core
                 // remove one Effect from _allEffects
                 _allEffects.Remove(tmPop.SessionUniqueIdentifier);
                 // Remove one Effect from Memory
-                Remove(tmPop);
+                _rc.RemoveShader(tmPop);
             }
         }
 

--- a/src/Engine/Core/RenderContext.cs
+++ b/src/Engine/Core/RenderContext.cs
@@ -1188,8 +1188,13 @@ namespace Fusee.Engine.Core
         {
             if (!_allCompiledEffects.TryGetValue(ef, out CompiledEffects compiledEffect)) return;
 
-            _rci.RemoveShader(compiledEffect.ForwardFx?.GpuHandle);
-            _rci.RemoveShader(compiledEffect.DeferredFx?.GpuHandle);
+            _allCompiledEffects.Remove(ef);
+
+            if (compiledEffect.ForwardFx != null)
+                _rci.RemoveShader(compiledEffect.ForwardFx?.GpuHandle);
+
+            if (compiledEffect.DeferredFx != null)
+                _rci.RemoveShader(compiledEffect.DeferredFx?.GpuHandle);
         }
 
         /// <summary>


### PR DESCRIPTION
RenderContext and EffectManager both kept references to ShaderEffects that were supposed to be deleted. They were only removed from GPU memory.