### PR TITLE
.fus files with textures now load from subfolders. Fixes #202

### DIFF
--- a/Examples/Complete/AdvancedUI/Desktop/Main.cs
+++ b/Examples/Complete/AdvancedUI/Desktop/Main.cs
@@ -37,7 +37,7 @@ namespace Fusee.Examples.AdvancedUI.Desktop
                     Decoder = (string id, object storage) =>
                     {
                         if (!Path.GetExtension(id).Contains("fus", System.StringComparison.OrdinalIgnoreCase)) return null;
-                        return FusSceneConverter.ConvertFrom(ProtoBuf.Serializer.Deserialize<FusFile>((Stream)storage));
+                        return FusSceneConverter.ConvertFrom(ProtoBuf.Serializer.Deserialize<FusFile>((Stream)storage), id);
                     },
 
                     Checker = id => Path.GetExtension(id).Contains("fus", System.StringComparison.OrdinalIgnoreCase)

--- a/Examples/Complete/BoneAnimation/Desktop/Main.cs
+++ b/Examples/Complete/BoneAnimation/Desktop/Main.cs
@@ -37,7 +37,7 @@ namespace Fusee.Examples.Bone.Desktop
                     Decoder = (string id, object storage) =>
                     {
                         if (!Path.GetExtension(id).Contains("fus", System.StringComparison.OrdinalIgnoreCase)) return null;
-                        return FusSceneConverter.ConvertFrom(ProtoBuf.Serializer.Deserialize<FusFile>((Stream)storage));
+                        return FusSceneConverter.ConvertFrom(ProtoBuf.Serializer.Deserialize<FusFile>((Stream)storage), id);
                     },
                     Checker = id => Path.GetExtension(id).Contains("fus", System.StringComparison.OrdinalIgnoreCase)
                 });

--- a/Examples/Complete/Camera/Desktop/Main.cs
+++ b/Examples/Complete/Camera/Desktop/Main.cs
@@ -40,7 +40,7 @@ namespace Fusee.Examples.Camera.Desktop
                     Decoder = (string id, object storage) =>
                     {
                         if (!Path.GetExtension(id).Contains("fus", StringComparison.OrdinalIgnoreCase)) return null;
-                        return FusSceneConverter.ConvertFrom(ProtoBuf.Serializer.Deserialize<FusFile>((Stream)storage));
+                        return FusSceneConverter.ConvertFrom(ProtoBuf.Serializer.Deserialize<FusFile>((Stream)storage), id);
                     },
                     Checker = id => Path.GetExtension(id).Contains("fus", StringComparison.OrdinalIgnoreCase)
                 });

--- a/Examples/Complete/GeometryEditing/Desktop/Main.cs
+++ b/Examples/Complete/GeometryEditing/Desktop/Main.cs
@@ -37,7 +37,7 @@ namespace Fusee.Examples.GeometryEditing.Desktop
                     Decoder = (string id, object storage) =>
                     {
                         if (!Path.GetExtension(id).Contains("fus", System.StringComparison.OrdinalIgnoreCase)) return null;
-                        return FusSceneConverter.ConvertFrom(ProtoBuf.Serializer.Deserialize<FusFile>((Stream)storage));
+                        return FusSceneConverter.ConvertFrom(ProtoBuf.Serializer.Deserialize<FusFile>((Stream)storage), id);
                     },
                     Checker = id => Path.GetExtension(id).Contains("fus", System.StringComparison.OrdinalIgnoreCase)
                 });

--- a/Examples/Complete/Materials/Desktop/Main.cs
+++ b/Examples/Complete/Materials/Desktop/Main.cs
@@ -36,7 +36,7 @@ namespace Fusee.Examples.Materials.Desktop
                     Decoder = (string id, object storage) =>
                     {
                         if (!Path.GetExtension(id).Contains("fus", System.StringComparison.OrdinalIgnoreCase)) return null;
-                        return FusSceneConverter.ConvertFrom(ProtoBuf.Serializer.Deserialize<FusFile>((Stream)storage));
+                        return FusSceneConverter.ConvertFrom(ProtoBuf.Serializer.Deserialize<FusFile>((Stream)storage), id);
                     },
                     Checker = id => Path.GetExtension(id).Contains("fus", System.StringComparison.OrdinalIgnoreCase)
                 });

--- a/Examples/Complete/MeshingAround/Desktop/Main.cs
+++ b/Examples/Complete/MeshingAround/Desktop/Main.cs
@@ -36,7 +36,7 @@ namespace Fusee.Examples.MeshingAround.Desktop
                     Decoder = (string id, object storage) =>
                     {
                         if (!Path.GetExtension(id).Contains("fus", System.StringComparison.OrdinalIgnoreCase)) return null;
-                        return FusSceneConverter.ConvertFrom(ProtoBuf.Serializer.Deserialize<FusFile>((Stream)storage));
+                        return FusSceneConverter.ConvertFrom(ProtoBuf.Serializer.Deserialize<FusFile>((Stream)storage), id);
                     },
                     Checker = id => Path.GetExtension(id).Contains("fus", System.StringComparison.OrdinalIgnoreCase)
                 });

--- a/Examples/Complete/NormalMap/Desktop/Main.cs
+++ b/Examples/Complete/NormalMap/Desktop/Main.cs
@@ -37,7 +37,7 @@ namespace Fusee.Examples.NormalMap.Desktop
                     Decoder = (string id, object storage) =>
                     {
                         if (!Path.GetExtension(id).Contains("fus", System.StringComparison.OrdinalIgnoreCase)) return null;
-                        return FusSceneConverter.ConvertFrom(ProtoBuf.Serializer.Deserialize<FusFile>((Stream)storage));
+                        return FusSceneConverter.ConvertFrom(ProtoBuf.Serializer.Deserialize<FusFile>((Stream)storage), id);
                     },
                     Checker = id => Path.GetExtension(id).Contains("fus", System.StringComparison.OrdinalIgnoreCase)
                 });

--- a/Examples/Complete/Picking/Desktop/Main.cs
+++ b/Examples/Complete/Picking/Desktop/Main.cs
@@ -37,7 +37,7 @@ namespace Fusee.Examples.Picking.Desktop
                     Decoder = (string id, object storage) =>
                     {
                         if (!Path.GetExtension(id).Contains("fus", System.StringComparison.OrdinalIgnoreCase)) return null;
-                        return FusSceneConverter.ConvertFrom(ProtoBuf.Serializer.Deserialize<FusFile>((Stream)storage));
+                        return FusSceneConverter.ConvertFrom(ProtoBuf.Serializer.Deserialize<FusFile>((Stream)storage), id);
                     },
                     Checker = id => Path.GetExtension(id).Contains("fus", System.StringComparison.OrdinalIgnoreCase)
                 });

--- a/Examples/Complete/Simple/Desktop/Main.cs
+++ b/Examples/Complete/Simple/Desktop/Main.cs
@@ -37,7 +37,7 @@ namespace Fusee.Examples.Simple.Desktop
                     Decoder = (string id, object storage) =>
                     {
                         if (!Path.GetExtension(id).Contains("fus", System.StringComparison.OrdinalIgnoreCase)) return null;
-                        return FusSceneConverter.ConvertFrom(ProtoBuf.Serializer.Deserialize<FusFile>((Stream)storage));
+                        return FusSceneConverter.ConvertFrom(ProtoBuf.Serializer.Deserialize<FusFile>((Stream)storage), id);
                     },
                     Checker = id => Path.GetExtension(id).Contains("fus", System.StringComparison.OrdinalIgnoreCase)
                 });

--- a/Examples/Complete/SimpleDeferred/Desktop/Main.cs
+++ b/Examples/Complete/SimpleDeferred/Desktop/Main.cs
@@ -37,7 +37,7 @@ namespace Fusee.Examples.SimpleDeferred.Desktop
                     Decoder = (string id, object storage) =>
                     {
                         if (!Path.GetExtension(id).Contains("fus", System.StringComparison.OrdinalIgnoreCase)) return null;
-                        return FusSceneConverter.ConvertFrom(ProtoBuf.Serializer.Deserialize<FusFile>((Stream)storage));
+                        return FusSceneConverter.ConvertFrom(ProtoBuf.Serializer.Deserialize<FusFile>((Stream)storage), id);
                     },
                     Checker = id => Path.GetExtension(id).Contains("fus", System.StringComparison.OrdinalIgnoreCase)
                 });

--- a/Examples/Complete/ThreeDFont/Desktop/Main.cs
+++ b/Examples/Complete/ThreeDFont/Desktop/Main.cs
@@ -36,7 +36,7 @@ namespace Fusee.Examples.ThreeDFont.Desktop
                     Decoder = (string id, object storage) =>
                     {
                         if (!Path.GetExtension(id).Contains("fus", System.StringComparison.OrdinalIgnoreCase)) return null;
-                        return FusSceneConverter.ConvertFrom(ProtoBuf.Serializer.Deserialize<FusFile>((Stream)storage));
+                        return FusSceneConverter.ConvertFrom(ProtoBuf.Serializer.Deserialize<FusFile>((Stream)storage), id);
                     },
                     Checker = id => Path.GetExtension(id).Contains("fus", System.StringComparison.OrdinalIgnoreCase)
                 });

--- a/Examples/Complete/UI/Desktop/Main.cs
+++ b/Examples/Complete/UI/Desktop/Main.cs
@@ -37,7 +37,7 @@ namespace Fusee.Examples.UI.Desktop
                     Decoder = (string id, object storage) =>
                     {
                         if (!Path.GetExtension(id).Contains("fus", System.StringComparison.OrdinalIgnoreCase)) return null;
-                        return FusSceneConverter.ConvertFrom(ProtoBuf.Serializer.Deserialize<FusFile>((Stream)storage));
+                        return FusSceneConverter.ConvertFrom(ProtoBuf.Serializer.Deserialize<FusFile>((Stream)storage), id);
                     },
                     Checker = id => Path.GetExtension(id).Contains("fus", System.StringComparison.OrdinalIgnoreCase)
                 });

--- a/src/Engine/Core/FusSceneConverter.cs
+++ b/src/Engine/Core/FusSceneConverter.cs
@@ -56,22 +56,22 @@ namespace Fusee.Engine.Core
                     {
                         if (matcomp.HasAlbedo)
                         {
-                            matcomp.Albedo.Texture = fus.Header.LoadPath + "/" + matcomp.Albedo.Texture;
+                            matcomp.Albedo.Texture = Path.Combine(fus.Header.LoadPath, matcomp.Albedo.Texture);
                         }
 
                         if (matcomp.HasEmissive)
                         {
-                            matcomp.Emissive.Texture = fus.Header.LoadPath + "/" + matcomp.Emissive.Texture;
+                            matcomp.Emissive.Texture = Path.Combine(fus.Header.LoadPath, matcomp.Emissive.Texture);
                         }
 
                         if (matcomp.HasNormalMap)
                         {
-                            matcomp.NormalMap.Texture = fus.Header.LoadPath + "/" + matcomp.NormalMap.Texture;
+                            matcomp.NormalMap.Texture = Path.Combine(fus.Header.LoadPath, matcomp.NormalMap.Texture);
                         }
 
                         if (matcomp.HasSpecular)
                         {
-                            matcomp.Specular.Texture = fus.Header.LoadPath + "/" + matcomp.Specular.Texture;
+                            matcomp.Specular.Texture = Path.Combine(fus.Header.LoadPath, matcomp.Specular.Texture);
                         }
                     }
                 }

--- a/src/Engine/Core/FusSceneConverter.cs
+++ b/src/Engine/Core/FusSceneConverter.cs
@@ -5,7 +5,9 @@ using Fusee.Math.Core;
 using Fusee.Serialization;
 using Fusee.Serialization.V1;
 using Fusee.Xene;
+using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 
 namespace Fusee.Engine.Core
@@ -20,7 +22,7 @@ namespace Fusee.Engine.Core
         /// Traverses the given SceneContainer and creates new high level graph <see cref="Scene"/> by converting and/or splitting its components into the high level equivalents.
         /// </summary>
         /// <param name="fus">The FusFile to convert.</param>
-        public static SceneContainer ConvertFrom(FusFile fus)
+        public static SceneContainer ConvertFrom(FusFile fus, string id = null)
         {
             if (fus == null)
             {
@@ -35,8 +37,46 @@ namespace Fusee.Engine.Core
                 return new SceneContainer();
             }
 
+            // if id is given set fields in FusFile
+            if (!string.IsNullOrEmpty(id))
+            {
+                fus.Header.LoadFilename = Path.GetFileName(id);
+                fus.Header.LoadPath = Path.GetDirectoryName(id);
+            }
+
             var instance = new FusFileToSceneConvertV1();
             var payload = (FusScene)fus.Contents;
+
+            // if path is set, update path dependent payload
+            if (!string.IsNullOrEmpty(fus.Header.LoadPath))
+            {
+                for (int i = 0; i < payload.ComponentList.Count; i++)
+                {
+                    if (payload.ComponentList[i] is FusMaterial matcomp)
+                    {
+                        if (matcomp.HasAlbedo)
+                        {
+                            matcomp.Albedo.Texture = fus.Header.LoadPath + "/" + matcomp.Albedo.Texture;
+                        }
+
+                        if (matcomp.HasEmissive)
+                        {
+                            matcomp.Emissive.Texture = fus.Header.LoadPath + "/" + matcomp.Emissive.Texture;
+                        }
+
+                        if (matcomp.HasNormalMap)
+                        {
+                            matcomp.NormalMap.Texture = fus.Header.LoadPath + "/" + matcomp.NormalMap.Texture;
+                        }
+
+                        if (matcomp.HasSpecular)
+                        {
+                            matcomp.Specular.Texture = fus.Header.LoadPath + "/" + matcomp.Specular.Texture;
+                        }
+                    }
+                }
+            }
+
             var converted = instance.Convert(payload);
 
             converted.Header = new SceneHeader

--- a/src/Engine/Player/Desktop/Main.cs
+++ b/src/Engine/Player/Desktop/Main.cs
@@ -141,7 +141,7 @@ namespace Fusee.Engine.Player.Desktop
                     {
                         if (!Path.GetExtension(id).Contains("fus", StringComparison.OrdinalIgnoreCase)) return null;
 
-                        return FusSceneConverter.ConvertFrom(ProtoBuf.Serializer.Deserialize<FusFile>((Stream)storage));
+                        return FusSceneConverter.ConvertFrom(ProtoBuf.Serializer.Deserialize<FusFile>((Stream)storage), id);
                     },
                     Checker = id => Path.GetExtension(id).Contains("fus", StringComparison.OrdinalIgnoreCase)
                 });

--- a/src/Serialization/FusFile.cs
+++ b/src/Serialization/FusFile.cs
@@ -39,8 +39,8 @@ namespace Fusee.Serialization
         /// The path this file was loaded from.
         /// </summary>
         [ProtoIgnore]
-        public string LoadPath;        
-        
+        public string LoadPath;
+
         /// <summary>
         /// The filename this file was loaded from.
         /// </summary>

--- a/src/Serialization/FusFile.cs
+++ b/src/Serialization/FusFile.cs
@@ -1,4 +1,4 @@
-﻿using ProtoBuf;
+using ProtoBuf;
 using System;
 using System.Collections.Generic;
 using System.Text;
@@ -34,6 +34,18 @@ namespace Fusee.Serialization
         /// </summary>
         [ProtoMember(4)]
         public string CreationDate;
+
+        /// <summary>
+        /// The path this file was loaded from.
+        /// </summary>
+        [ProtoIgnore]
+        public string LoadPath;        
+        
+        /// <summary>
+        /// The filename this file was loaded from.
+        /// </summary>
+        [ProtoIgnore]
+        public string LoadFilename;
     }
 
 

--- a/src/Tools/CmdLine/Verbs/Player.cs
+++ b/src/Tools/CmdLine/Verbs/Player.cs
@@ -194,7 +194,7 @@ namespace Fusee.Tools.CmdLine.Verbs
                     {
                         if (!Path.GetExtension(id).Contains("fus", StringComparison.OrdinalIgnoreCase)) return null;
 
-                        return FusSceneConverter.ConvertFrom(ProtoBuf.Serializer.Deserialize<FusFile>((Stream)storage));
+                        return FusSceneConverter.ConvertFrom(ProtoBuf.Serializer.Deserialize<FusFile>((Stream)storage), id);
                     },
                     Checker = id => Path.GetExtension(id).Contains("fus", StringComparison.OrdinalIgnoreCase)
                 });


### PR DESCRIPTION
This is a semi-breaking change since FusSceneConverter does not automatically know the path of the files origin and so cannot fix the component paths.
Applications should not break but need to be changed to include the `id` in their call to FusSceneConverter like in any of the example changes, this is just to not break existing applications and should be enforced in 0.9.

Fixes #202 