### PR TITLE
Patch/color management

### DIFF
--- a/Examples/Complete/AdvancedUI/Core/AdvancedUI.cs
+++ b/Examples/Complete/AdvancedUI/Core/AdvancedUI.cs
@@ -1,4 +1,5 @@
-﻿using Fusee.Base.Core;
+﻿using Fusee.Base.Common;
+using Fusee.Base.Core;
 using Fusee.Engine.Common;
 using Fusee.Engine.Core;
 using Fusee.Engine.Core.Effects;
@@ -80,7 +81,7 @@ namespace Fusee.Examples.AdvancedUI.Core
                                 Translation = new float3(0,0,0),
                                 Scale = new float3(1, 1, 1)
                             },
-                            MakeEffect.FromDiffuseSpecularNormalTexture(new float4(0.90980f, 0.35686f, 0.35686f,1), float4.Zero, 20, paperTex, 1.0f, float2.One, 0.5f)                            
+                            MakeEffect.FromDiffuseSpecularNormalTexture(new float4(0.90980f, 0.35686f, 0.35686f,1).LinearColorFromSRgb(), float4.Zero, 20, paperTex, 1.0f, float2.One, 0.5f)                            
                             //sphere
                         }
                     },
@@ -95,7 +96,7 @@ namespace Fusee.Examples.AdvancedUI.Core
                                 Translation = new float3(0,0,0),
                                 Scale = new float3(1, 1, 1)
                             },
-                            MakeEffect.FromDiffuseSpecular(new float4(0, 0, 1,1), float4.Zero, 20),
+                            MakeEffect.FromDiffuseSpecular(new float4(0, 0, 1, 1).LinearColorFromSRgb(), float4.Zero, 20),
                             line
                         }
                     }
@@ -465,14 +466,14 @@ namespace Fusee.Examples.AdvancedUI.Core
         public void BtnLogoEnter(CodeComponent sender)
         {
             var effect = _gui.Children.FindNodes(node => node.Name == "fuseeLogo").First().GetComponent<ShaderEffect>();
-            effect.SetFxParam(UniformNameDeclarations.Albedo, new float4(0.0f, 0.0f, 0.0f, 1f));
+            effect.SetFxParam(UniformNameDeclarations.Albedo, ColorUint.Black);
             effect.SetFxParam(UniformNameDeclarations.AlbedoMix, 0.8f);
         }
 
         public void BtnLogoExit(CodeComponent sender)
         {
             var effect = _gui.Children.FindNodes(node => node.Name == "fuseeLogo").First().GetComponent<ShaderEffect>();
-            effect.SetFxParam(UniformNameDeclarations.Albedo, float4.One);
+            effect.SetFxParam(UniformNameDeclarations.Albedo, ColorUint.White);
             effect.SetFxParam(UniformNameDeclarations.AlbedoMix, 1f);
         }
 

--- a/Examples/Complete/AdvancedUI/Core/AdvancedUI.cs
+++ b/Examples/Complete/AdvancedUI/Core/AdvancedUI.cs
@@ -96,7 +96,7 @@ namespace Fusee.Examples.AdvancedUI.Core
                                 Translation = new float3(0,0,0),
                                 Scale = new float3(1, 1, 1)
                             },
-                            MakeEffect.FromDiffuseSpecular(new float4(0, 0, 1, 1).LinearColorFromSRgb(), float4.Zero, 20),
+                            MakeEffect.FromDiffuseSpecular(new float4(0, 0, 1, 1).LinearColorFromSRgb(), float4.Zero, 20, 1.0f),
                             line
                         }
                     }
@@ -466,7 +466,7 @@ namespace Fusee.Examples.AdvancedUI.Core
         public void BtnLogoEnter(CodeComponent sender)
         {
             var effect = _gui.Children.FindNodes(node => node.Name == "fuseeLogo").First().GetComponent<ShaderEffect>();
-            effect.SetFxParam(UniformNameDeclarations.Albedo, ColorUint.Black);
+            effect.SetFxParam(UniformNameDeclarations.Albedo, (float4)ColorUint.Black);
             effect.SetFxParam(UniformNameDeclarations.AlbedoMix, 0.8f);
         }
 

--- a/Examples/Complete/AdvancedUI/Core/UIHelper.cs
+++ b/Examples/Complete/AdvancedUI/Core/UIHelper.cs
@@ -49,7 +49,7 @@ namespace Fusee.Examples.AdvancedUI.Core
         internal static readonly float4 Yellow = new float4(0.89411f, 0.63137f, 0.31372f, alphaVis).LinearColorFromSRgb();
         internal static readonly float4 Gray = new float4(0.47843f, 0.52549f, 0.54901f, alphaVis).LinearColorFromSRgb();
 
-        internal static readonly float4 White = ColorUint.White;
+        internal static readonly float4 White = (float4)ColorUint.White;
 
         private static readonly Texture _frameToCheck = new Texture(AssetStorage.Get<ImageData>("frame_yellow.png"), false, TextureFilterMode.Linear);
         private static readonly Texture _frameDiscarded = new Texture(AssetStorage.Get<ImageData>("frame_gray.png"), false, TextureFilterMode.Linear);
@@ -60,11 +60,11 @@ namespace Fusee.Examples.AdvancedUI.Core
         private static readonly Texture _iconRecognizedML = new Texture(AssetStorage.Get<ImageData>("check-circle.png"), false, TextureFilterMode.Linear);
         private static readonly Texture _iconConfirmed = new Texture(AssetStorage.Get<ImageData>("check-circle_filled.png"), false, TextureFilterMode.Linear);
 
-        internal static readonly SurfaceEffect GreenEffect = MakeEffect.FromDiffuseSpecular(Green, float4.Zero, 20f, 0f);
-        internal static readonly SurfaceEffect YellowEffect = MakeEffect.FromDiffuseSpecular(Yellow, float4.Zero, 20f, 0f);
-        internal static readonly SurfaceEffect GrayEffect = MakeEffect.FromDiffuseSpecular(Gray, float4.Zero, 20f, 0f);
+        internal static readonly SurfaceEffect GreenEffect = MakeEffect.FromDiffuseSpecular(Green, float4.Zero);
+        internal static readonly SurfaceEffect YellowEffect = MakeEffect.FromDiffuseSpecular(Yellow, float4.Zero);
+        internal static readonly SurfaceEffect GrayEffect = MakeEffect.FromDiffuseSpecular(Gray, float4.Zero);
 
-        internal static readonly SurfaceEffect OccludedDummyEffect = MakeEffect.FromDiffuseSpecular(ColorUint.White, float4.Zero, 20, 0);
+        internal static readonly SurfaceEffect OccludedDummyEffect = MakeEffect.FromDiffuseSpecular((float4)ColorUint.White, float4.Zero);
 
         private static readonly float _circleThickness = 0.04f;
         internal static float LineThickness = 0.02f;
@@ -151,7 +151,7 @@ namespace Fusee.Examples.AdvancedUI.Core
                 },
                 UIElementPosition.CalcOffsets(AnchorPos.StretchAll, new float2(0.5f, 0.07f), AnnotationDim.y, AnnotationDim.x, new float2(2.5f, 0.35f)),
                 RalewayFontMap,
-                ColorUint.Black,
+                (float4)ColorUint.Black,
                 HorizontalTextAlignment.Center,
                 VerticalTextAlignment.Center);
 
@@ -229,7 +229,7 @@ namespace Fusee.Examples.AdvancedUI.Core
                     {
                         Name = "circle" + "_XForm",
                     },
-                    MakeEffect.FromDiffuseSpecular(col, float4.Zero, 20, 0),
+                    MakeEffect.FromDiffuseSpecular(col, float4.Zero),
                     new Circle(false, 30,100,_circleThickness)
                 }
             };
@@ -278,7 +278,7 @@ namespace Fusee.Examples.AdvancedUI.Core
                     {
                         Name = "line" + "_XForm",
                     },
-                    MakeEffect.FromDiffuseSpecular(col, float4.Zero, 20, 0),
+                    MakeEffect.FromDiffuseSpecular(col, float4.Zero),
                 }
             };
         }

--- a/Examples/Complete/AdvancedUI/Core/UIHelper.cs
+++ b/Examples/Complete/AdvancedUI/Core/UIHelper.cs
@@ -45,11 +45,11 @@ namespace Fusee.Examples.AdvancedUI.Core
         internal static float alphaInv = 0.5f;
         internal static float alphaVis = 1f;
 
-        internal static readonly float4 Green = new float4(0.14117f, 0.76078f, 0.48627f, alphaVis);
-        internal static readonly float4 Yellow = new float4(0.89411f, 0.63137f, 0.31372f, alphaVis);
-        internal static readonly float4 Gray = new float4(0.47843f, 0.52549f, 0.54901f, alphaVis);
+        internal static readonly float4 Green = new float4(0.14117f, 0.76078f, 0.48627f, alphaVis).LinearColorFromSRgb();
+        internal static readonly float4 Yellow = new float4(0.89411f, 0.63137f, 0.31372f, alphaVis).LinearColorFromSRgb();
+        internal static readonly float4 Gray = new float4(0.47843f, 0.52549f, 0.54901f, alphaVis).LinearColorFromSRgb();
 
-        internal static readonly float4 White = new float4(1, 1, 1, 1);
+        internal static readonly float4 White = ColorUint.White;
 
         private static readonly Texture _frameToCheck = new Texture(AssetStorage.Get<ImageData>("frame_yellow.png"), false, TextureFilterMode.Linear);
         private static readonly Texture _frameDiscarded = new Texture(AssetStorage.Get<ImageData>("frame_gray.png"), false, TextureFilterMode.Linear);
@@ -64,7 +64,7 @@ namespace Fusee.Examples.AdvancedUI.Core
         internal static readonly SurfaceEffect YellowEffect = MakeEffect.FromDiffuseSpecular(Yellow, float4.Zero, 20f, 0f);
         internal static readonly SurfaceEffect GrayEffect = MakeEffect.FromDiffuseSpecular(Gray, float4.Zero, 20f, 0f);
 
-        internal static readonly SurfaceEffect OccludedDummyEffect = MakeEffect.FromDiffuseSpecular(new float4(1, 1, 1, 1), float4.Zero, 20, 0);
+        internal static readonly SurfaceEffect OccludedDummyEffect = MakeEffect.FromDiffuseSpecular(ColorUint.White, float4.Zero, 20, 0);
 
         private static readonly float _circleThickness = 0.04f;
         internal static float LineThickness = 0.02f;
@@ -151,7 +151,7 @@ namespace Fusee.Examples.AdvancedUI.Core
                 },
                 UIElementPosition.CalcOffsets(AnchorPos.StretchAll, new float2(0.5f, 0.07f), AnnotationDim.y, AnnotationDim.x, new float2(2.5f, 0.35f)),
                 RalewayFontMap,
-                ColorUint.Tofloat4(ColorUint.Black),
+                ColorUint.Black,
                 HorizontalTextAlignment.Center,
                 VerticalTextAlignment.Center);
 

--- a/Examples/Complete/BoneAnimation/Core/Bone.cs
+++ b/Examples/Complete/BoneAnimation/Core/Bone.cs
@@ -51,7 +51,7 @@ namespace Fusee.Examples.Bone.Core
             _offsetInit = float2.Zero;
 
             // Set the clear color for the back buffer to white (100% intensity in all color channels R, G, B, A).
-            RC.ClearColor = new float4(1, 1, 1, 1);
+            RC.ClearColor = float4.One;
 
             // Load the standard model
 

--- a/Examples/Complete/BoneAnimation/Core/Bone.cs
+++ b/Examples/Complete/BoneAnimation/Core/Bone.cs
@@ -2,10 +2,14 @@
 using Fusee.Base.Core;
 using Fusee.Engine.Common;
 using Fusee.Engine.Core;
+using Fusee.Engine.Core.Effects;
 using Fusee.Engine.Core.Scene;
 using Fusee.Engine.Core.ShaderShards;
 using Fusee.Engine.GUI;
 using Fusee.Math.Core;
+using Fusee.Xene;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace Fusee.Examples.Bone.Core
 {
@@ -56,6 +60,7 @@ namespace Fusee.Examples.Bone.Core
             // Load the standard model
 
             _scene = AssetStorage.Get<SceneContainer>("BoneAnim.fus");
+            _gui = CreateGui();
 
             #region LEGACY CODE - REFERENCE ONLY!
             /*
@@ -311,6 +316,100 @@ namespace Fusee.Examples.Bone.Core
 
             // Swap buffers: Show the contents of the backbuffer (containing the currently rendered frame) on the front buffer.
             Present();
+        }
+
+        private SceneContainer CreateGui()
+        {
+            var vsTex = AssetStorage.Get<string>("texture.vert");
+            var psTex = AssetStorage.Get<string>("texture.frag");
+            var psText = AssetStorage.Get<string>("text.frag");
+
+            var canvasWidth = Width / 100f;
+            var canvasHeight = Height / 100f;
+
+            var btnFuseeLogo = new GUIButton
+            {
+                Name = "Canvas_Button"
+            };
+            btnFuseeLogo.OnMouseEnter += BtnLogoEnter;
+            btnFuseeLogo.OnMouseExit += BtnLogoExit;
+            btnFuseeLogo.OnMouseDown += BtnLogoDown;
+
+            var guiFuseeLogo = new Texture(AssetStorage.Get<ImageData>("FuseeText.png"));
+            var fuseeLogo = new TextureNode(
+                "fuseeLogo",
+                vsTex,
+                psTex,
+                //Set the albedo texture you want to use.
+                guiFuseeLogo,
+                //Define anchor points. They are given in percent, seen from the lower left corner, respectively to the width/height of the parent.
+                //In this setup the element will stretch horizontally but stay the same vertically if the parent element is scaled.
+                UIElementPosition.GetAnchors(AnchorPos.TopTopLeft),
+                //Define Offset and therefor the size of the element.
+                UIElementPosition.CalcOffsets(AnchorPos.TopTopLeft, new float2(0, canvasHeight - 0.5f), canvasHeight, canvasWidth, new float2(1.75f, 0.5f)),
+                float2.One
+                );
+            fuseeLogo.AddComponent(btnFuseeLogo);
+
+            var fontLato = AssetStorage.Get<Font>("Lato-Black.ttf");
+            var guiLatoBlack = new FontMap(fontLato, 24);
+
+            var text = new TextNode(
+                "FUSEE Picking Example",
+                "ButtonText",
+                vsTex,
+                psText,
+                UIElementPosition.GetAnchors(AnchorPos.StretchHorizontal),
+                UIElementPosition.CalcOffsets(AnchorPos.StretchHorizontal, new float2(canvasWidth / 2 - 4, 0), canvasHeight, canvasWidth, new float2(8, 1)),
+                guiLatoBlack,
+                (float4)ColorUint.Greenery,
+                HorizontalTextAlignment.Center,
+                VerticalTextAlignment.Center);
+
+            var canvas = new CanvasNode(
+                "Canvas",
+                CanvasRenderMode.Screen,
+                new MinMaxRect
+                {
+                    Min = new float2(-canvasWidth / 2, -canvasHeight / 2f),
+                    Max = new float2(canvasWidth / 2, canvasHeight / 2f)
+                })
+            {
+                Children = new ChildList()
+                {
+                    //Simple Texture Node, contains the fusee logo.
+                    fuseeLogo,
+                    text
+                }
+            };
+
+            return new SceneContainer
+            {
+                Children = new List<SceneNode>
+                {
+                    //Add canvas.
+                    canvas
+                }
+            };
+        }
+
+        public void BtnLogoEnter(CodeComponent sender)
+        {
+            var effect = _gui.Children.FindNodes(node => node.Name == "fuseeLogo").First().GetComponent<ShaderEffect>();
+            effect.SetFxParam(UniformNameDeclarations.Albedo, (float4)ColorUint.Black);
+            effect.SetFxParam(UniformNameDeclarations.AlbedoMix, 0.8f);
+        }
+
+        public void BtnLogoExit(CodeComponent sender)
+        {
+            var effect = _gui.Children.FindNodes(node => node.Name == "fuseeLogo").First().GetComponent<ShaderEffect>();
+            effect.SetFxParam(UniformNameDeclarations.Albedo, float4.One);
+            effect.SetFxParam(UniformNameDeclarations.AlbedoMix, 1f);
+        }
+
+        public void BtnLogoDown(CodeComponent sender)
+        {
+            OpenLink("http://fusee3d.org");
         }
     }
 }

--- a/Examples/Complete/Camera/Core/Camera.cs
+++ b/Examples/Complete/Camera/Core/Camera.cs
@@ -294,7 +294,7 @@ namespace Fusee.Examples.Camera.Core
                 UIElementPosition.GetAnchors(AnchorPos.StretchHorizontal),
                 UIElementPosition.CalcOffsets(AnchorPos.StretchHorizontal, new float2(canvasWidth / 2 - 4, 0), canvasHeight, canvasWidth, new float2(8, 1)),
                 guiLatoBlack,
-                ColorUint.Tofloat4(ColorUint.Greenery),
+                ColorUint.Greenery,
                 HorizontalTextAlignment.Center,
                 VerticalTextAlignment.Center);
 
@@ -339,7 +339,7 @@ namespace Fusee.Examples.Camera.Core
         public void BtnLogoEnter(CodeComponent sender)
         {
             ShaderEffect effect = _gui.Children.FindNodes(node => node.Name == "fuseeLogo").First().GetComponent<ShaderEffect>();
-            effect.SetFxParam(UniformNameDeclarations.Albedo, new float4(0.0f, 0.0f, 0.0f, 1f));
+            effect.SetFxParam(UniformNameDeclarations.Albedo, ColorUint.Black);
             effect.SetFxParam(UniformNameDeclarations.AlbedoMix, 0.8f);
         }
 

--- a/Examples/Complete/Camera/Core/Camera.cs
+++ b/Examples/Complete/Camera/Core/Camera.cs
@@ -11,7 +11,6 @@ using Fusee.Math.Core;
 using Fusee.Xene;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading.Tasks;
 using static Fusee.Engine.Core.Input;
 using static Fusee.Engine.Core.Time;
 
@@ -20,11 +19,6 @@ namespace Fusee.Examples.Camera.Core
     [FuseeApplication(Name = "FUSEE Camera Example", Description = " ")]
     public class CameraExample : RenderCanvas
     {
-        // angle variables
-        private readonly float _rotAngle = M.PiOver4;
-        private float3 _rotAxis;
-        private float3 _rotPivot;
-
         private SceneContainer _rocketScene;
         private SceneRendererForward _sceneRenderer;
 
@@ -87,7 +81,7 @@ namespace Fusee.Examples.Camera.Core
                 Name = "Frustum",
                 Components = new List<SceneComponent>()
                 {
-                    MakeEffect.FromDiffuseSpecular(new float4(1,1,0,1), float4.Zero, 0),
+                    MakeEffect.FromDiffuseSpecular(new float4(1,1,0,1), float4.Zero),
                     _frustum
                 }
             };
@@ -99,7 +93,7 @@ namespace Fusee.Examples.Camera.Core
                 {
                     _mainCamTransform,
                     _mainCam,
-                    MakeEffect.FromDiffuseSpecular(new float4(1,0,0,1), float4.Zero, 10),
+                    MakeEffect.FromDiffuseSpecular(new float4(1,0,0,1), float4.Zero),
                     new Cube(),
 
                 },
@@ -144,11 +138,8 @@ namespace Fusee.Examples.Camera.Core
 
             // Load the rocket model            
             _rocketScene = AssetStorage.Get<SceneContainer>("rnd.fus");
-            //_rocketScene = Rocket.Build();
-
 
             _cubeOneTransform = _rocketScene.Children[0].GetComponent<Transform>();
-            //_cubeOneTransform.Rotate(new float3(0, M.PiOver4, 0));
 
             _rocketScene.Children.Add(cam);
             _rocketScene.Children.Add(cam1);
@@ -157,9 +148,6 @@ namespace Fusee.Examples.Camera.Core
             // Wrap a SceneRenderer around the model.
             _sceneRenderer = new SceneRendererForward(_rocketScene);
             _guiRenderer = new SceneRendererForward(_gui);
-
-            _rotAxis = float3.UnitY * float4x4.CreateRotationYZ(new float2(M.PiOver4, M.PiOver4));
-            _rotPivot = _rocketScene.Children[1].GetComponent<Transform>().Translation;
         }
 
         // RenderAFrame is called once a frame
@@ -294,7 +282,7 @@ namespace Fusee.Examples.Camera.Core
                 UIElementPosition.GetAnchors(AnchorPos.StretchHorizontal),
                 UIElementPosition.CalcOffsets(AnchorPos.StretchHorizontal, new float2(canvasWidth / 2 - 4, 0), canvasHeight, canvasWidth, new float2(8, 1)),
                 guiLatoBlack,
-                ColorUint.Greenery,
+                (float4)ColorUint.Greenery,
                 HorizontalTextAlignment.Center,
                 VerticalTextAlignment.Center);
 
@@ -339,7 +327,7 @@ namespace Fusee.Examples.Camera.Core
         public void BtnLogoEnter(CodeComponent sender)
         {
             ShaderEffect effect = _gui.Children.FindNodes(node => node.Name == "fuseeLogo").First().GetComponent<ShaderEffect>();
-            effect.SetFxParam(UniformNameDeclarations.Albedo, ColorUint.Black);
+            effect.SetFxParam(UniformNameDeclarations.Albedo, (float4)ColorUint.Black);
             effect.SetFxParam(UniformNameDeclarations.AlbedoMix, 0.8f);
         }
 

--- a/Examples/Complete/GeometryEditing/Core/GeometryEditing.cs
+++ b/Examples/Complete/GeometryEditing/Core/GeometryEditing.cs
@@ -21,8 +21,8 @@ namespace Fusee.Examples.GeometryEditing.Core
     [FuseeApplication(Name = "FUSEE Geometry Editing Example", Description = "Example App to show basic geometry editing in FUSEE")]
     public class GeometryEditing : RenderCanvas
     {
-        private readonly float4 _selectedColor = new float4(0.7f, 0.3f, 0, 1.0f);
-        private readonly float4 _defaultColor = new float4(0.5f, 0.5f, 0.5f, 1.0f);
+        private readonly float4 _selectedColor = new float4(0.7f, 0.3f, 0, 1.0f).LinearColorFromSRgb();
+        private readonly float4 _defaultColor = new float4(0.5f, 0.5f, 0.5f, 1.0f).LinearColorFromSRgb();
 
         // angle and camera variables
         private static float _angleHorz = M.PiOver6 * 2.0f, _angleVert = -M.PiOver6 * 0.5f, _angleVelHorz, _angleVelVert, _angleRoll, _angleRollInit, _zoomVel, _zoom = 8, _xPos, _yPos;

--- a/Examples/Complete/GeometryEditing/Core/GeometryEditing.cs
+++ b/Examples/Complete/GeometryEditing/Core/GeometryEditing.cs
@@ -402,7 +402,7 @@ namespace Fusee.Examples.GeometryEditing.Core
             };
 
             sceneNodeContainer.Components.Add(translationComponent);
-            sceneNodeContainer.Components.Add(MakeEffect.FromDiffuseSpecular(_defaultColor, float4.Zero, 0, 0));
+            sceneNodeContainer.Components.Add(MakeEffect.FromDiffuseSpecular(_defaultColor, float4.Zero));
             sceneNodeContainer.Components.Add(meshComponent);
 
             _parentNode.Children.Add(sceneNodeContainer);

--- a/Examples/Complete/Integrations/Core/Main.cs
+++ b/Examples/Complete/Integrations/Core/Main.cs
@@ -199,7 +199,7 @@ namespace Fusee.Examples.Integrations.Core
                 UIElementPosition.GetAnchors(AnchorPos.StretchHorizontal),
                 UIElementPosition.CalcOffsets(AnchorPos.StretchHorizontal, new float2(canvasWidth / 2 - 4, 0), canvasHeight, canvasWidth, new float2(8, 1)),
                 guiLatoBlack,
-                ColorUint.Greenery,
+                (float4)ColorUint.Greenery,
                 HorizontalTextAlignment.Center,
                 VerticalTextAlignment.Center);
 
@@ -233,7 +233,7 @@ namespace Fusee.Examples.Integrations.Core
         public void BtnLogoEnter(CodeComponent sender)
         {
             var effect = _gui.Children.FindNodes(node => node.Name == "fuseeLogo").First().GetComponent<Effect>();
-            effect.SetFxParam(UniformNameDeclarations.Albedo, ColorUint.Black);
+            effect.SetFxParam(UniformNameDeclarations.Albedo, (float4)ColorUint.Black);
             effect.SetFxParam(UniformNameDeclarations.AlbedoMix, 0.8f);
         }
 

--- a/Examples/Complete/Integrations/Core/Main.cs
+++ b/Examples/Complete/Integrations/Core/Main.cs
@@ -199,7 +199,7 @@ namespace Fusee.Examples.Integrations.Core
                 UIElementPosition.GetAnchors(AnchorPos.StretchHorizontal),
                 UIElementPosition.CalcOffsets(AnchorPos.StretchHorizontal, new float2(canvasWidth / 2 - 4, 0), canvasHeight, canvasWidth, new float2(8, 1)),
                 guiLatoBlack,
-                ColorUint.Tofloat4(ColorUint.Greenery),
+                ColorUint.Greenery,
                 HorizontalTextAlignment.Center,
                 VerticalTextAlignment.Center);
 
@@ -233,7 +233,7 @@ namespace Fusee.Examples.Integrations.Core
         public void BtnLogoEnter(CodeComponent sender)
         {
             var effect = _gui.Children.FindNodes(node => node.Name == "fuseeLogo").First().GetComponent<Effect>();
-            effect.SetFxParam(UniformNameDeclarations.Albedo, new float4(0.0f, 0.0f, 0.0f, 1f));
+            effect.SetFxParam(UniformNameDeclarations.Albedo, ColorUint.Black);
             effect.SetFxParam(UniformNameDeclarations.AlbedoMix, 0.8f);
         }
 

--- a/Examples/Complete/Materials/Core/Materials.cs
+++ b/Examples/Complete/Materials/Core/Materials.cs
@@ -1,4 +1,5 @@
-﻿using Fusee.Base.Core;
+﻿using Fusee.Base.Common;
+using Fusee.Base.Core;
 using Fusee.Engine.Common;
 using Fusee.Engine.Core;
 using Fusee.Engine.Core.Primitives;
@@ -66,7 +67,7 @@ namespace Fusee.Examples.Materials.Core
                             UIElementPosition.GetAnchors(AnchorPos.DownDownLeft),
                             UIElementPosition.CalcOffsets(AnchorPos.DownDownLeft, new float2(-11, -5), canvasHeight, canvasWidth, new float2(12, 1)),
                             fontLatoMap,
-                            new float4(1,1,0,1),
+                            new float4(1, 1, 0, 1).LinearColorFromSRgb(),
                             HorizontalTextAlignment.Left,
                             VerticalTextAlignment.Center)
                         }
@@ -91,7 +92,7 @@ namespace Fusee.Examples.Materials.Core
                                 MinMaxRect.FromCenterSize(float2.Zero, float2.One),
                                 new MinMaxRect(),
                                 fontLatoMap,
-                                new float4(0,0,0,1),
+                                ColorUint.Black,
                                 HorizontalTextAlignment.Left,
                                 VerticalTextAlignment.Center),new TextNode(
                                 "NOT YET IMPLEMENTED",
@@ -130,7 +131,7 @@ namespace Fusee.Examples.Materials.Core
                                 MinMaxRect.FromCenterSize(float2.Zero, float2.One),
                                 new MinMaxRect(),
                                 fontLatoMap,
-                                new float4(0,0,0,1),
+                                ColorUint.Black,
                                 HorizontalTextAlignment.Left,
                                 VerticalTextAlignment.Center)
                         }
@@ -155,7 +156,7 @@ namespace Fusee.Examples.Materials.Core
                                 MinMaxRect.FromCenterSize(float2.Zero, float2.One),
                                 new MinMaxRect(),
                                 fontLatoMap,
-                                new float4(0,0,0,1),
+                                ColorUint.Black,
                                 HorizontalTextAlignment.Left,
                                 VerticalTextAlignment.Center)
                         }
@@ -180,7 +181,7 @@ namespace Fusee.Examples.Materials.Core
                                 MinMaxRect.FromCenterSize(float2.Zero, float2.One),
                                 new MinMaxRect(),
                                 fontLatoMap,
-                                new float4(0,0,0,1),
+                                ColorUint.Black,
                                 HorizontalTextAlignment.Left,
                                 VerticalTextAlignment.Center),
                                 new TextNode(
@@ -195,7 +196,7 @@ namespace Fusee.Examples.Materials.Core
                                     Min = new float2(0, -1.25f)
                                 },
                                 fontLatoMap,
-                                new float4(1,0,0,0.75f),
+                                new float4(1,0,0,0.75f).LinearColorFromSRgb(),
                                 HorizontalTextAlignment.Left,
                                 VerticalTextAlignment.Center)
                         }
@@ -220,7 +221,7 @@ namespace Fusee.Examples.Materials.Core
                                 MinMaxRect.FromCenterSize(float2.Zero, float2.One),
                                 new MinMaxRect(),
                                 fontLatoMap,
-                                new float4(0,0,0,1),
+                                ColorUint.Black,
                                 HorizontalTextAlignment.Left,
                                 VerticalTextAlignment.Center)
                         }
@@ -245,7 +246,7 @@ namespace Fusee.Examples.Materials.Core
                                         MinMaxRect.FromCenterSize(float2.Zero, float2.One),
                                         new MinMaxRect(),
                                         fontLatoMap,
-                                        new float4(0,0,0,1),
+                                        ColorUint.Black,
                                         HorizontalTextAlignment.Left,
                                         VerticalTextAlignment.Center),
                                       new TextNode(
@@ -260,7 +261,7 @@ namespace Fusee.Examples.Materials.Core
                                             Min = new float2(0, -1.25f)
                                         },
                                         fontLatoMap,
-                                        new float4(1,0,0,0.75f),
+                                        new float4(1,0,0,0.75f).LinearColorFromSRgb(),
                                         HorizontalTextAlignment.Left,
                                         VerticalTextAlignment.Center)
                                 }
@@ -285,7 +286,7 @@ namespace Fusee.Examples.Materials.Core
                                         MinMaxRect.FromCenterSize(float2.Zero, float2.One),
                                         new MinMaxRect(),
                                         fontLatoMap,
-                                        new float4(0,0,0,1),
+                                        ColorUint.Black,
                                         HorizontalTextAlignment.Left,
                                         VerticalTextAlignment.Center),
                                      new TextNode(
@@ -300,7 +301,7 @@ namespace Fusee.Examples.Materials.Core
                                             Min = new float2(0, -1.75f)
                                         },
                                         fontLatoMap,
-                                        new float4(1,0,0,0.75f),
+                                        new float4(1,0,0,0.75f).LinearColorFromSRgb(),
                                         HorizontalTextAlignment.Left,
                                         VerticalTextAlignment.Center)
                                 }
@@ -332,7 +333,7 @@ namespace Fusee.Examples.Materials.Core
                                         Translation = new float3(-15, 0, 0)
                                     },
                                     MakeEffect.FromDiffuseSpecularTexture(
-                                        albedoColor : float4.One * 0.25f,
+                                        albedoColor : (float4.One * 0.25f).LinearColorFromSRgb(),
                                         emissionColor: float4.Zero,
                                         shininess : 25f,
                                         albedoTex : albedoTex,
@@ -362,7 +363,7 @@ namespace Fusee.Examples.Materials.Core
                                         Translation = new float3(-10, 0, 0)
                                     },
                                     MakeEffect.FromDiffuseSpecular(
-                                    albedoColor: new float4(0.39f, 0.19f, 0, 1),
+                                    albedoColor: new float4(0.39f, 0.19f, 0, 1).LinearColorFromSRgb(),
                                     emissionColor: float4.Zero,
                                     shininess: 25.0f,
                                     specularStrength: 1f),
@@ -380,7 +381,7 @@ namespace Fusee.Examples.Materials.Core
                                     },
                                     MakeEffect.FromDiffuseSpecularAlbedoTexture
                                     (
-                                        albedoColor: new float4(0.39f, 0.19f, 0, 1),
+                                        albedoColor: new float4(0.39f, 0.19f, 0, 1).LinearColorFromSRgb(),
                                         emissionColor: float4.Zero,
                                         shininess: 256.0f,
                                         albedoTex: albedoTex,
@@ -447,7 +448,7 @@ namespace Fusee.Examples.Materials.Core
                                         Translation = new float3(5, 0, 0)
                                     },
                                     MakeEffect.FromDiffuseSpecularTexture(
-                                            albedoColor: float4.One * 0.25f,
+                                            albedoColor: (float4.One * 0.25f).LinearColorFromSRgb(),
                                             emissionColor: float4.Zero,
                                             shininess: 200f,
                                             albedoTex : albedoTex,
@@ -470,7 +471,7 @@ namespace Fusee.Examples.Materials.Core
                                         Translation = new float3(10, 0, 0)
                                     },
                                     MakeEffect.FromDiffuseSpecularAlbedoTexture(
-                                    albedoColor: new float4(0.39f, 0.19f, 0, 1),
+                                    albedoColor: new float4(0.39f, 0.19f, 0, 1).LinearColorFromSRgb(),
                                     emissionColor: float4.Zero,
                                     shininess: 256.0f,
                                     albedoTex: albedoTex,
@@ -490,7 +491,7 @@ namespace Fusee.Examples.Materials.Core
                                         Translation = new float3(15, 0, 0)
                                     },
                                     MakeEffect.FromDiffuseSpecularAlbedoTexture(
-                                    albedoColor: new float4(0.39f, 0.19f, 0, 1),
+                                    albedoColor: new float4(0.39f, 0.19f, 0, 1).LinearColorFromSRgb(),
                                     emissionColor: float4.Zero,
                                     shininess: 256.0f,
                                     albedoTex: albedoTex,

--- a/Examples/Complete/Materials/Core/Materials.cs
+++ b/Examples/Complete/Materials/Core/Materials.cs
@@ -92,7 +92,7 @@ namespace Fusee.Examples.Materials.Core
                                 MinMaxRect.FromCenterSize(float2.Zero, float2.One),
                                 new MinMaxRect(),
                                 fontLatoMap,
-                                ColorUint.Black,
+                                (float4)ColorUint.Black,
                                 HorizontalTextAlignment.Left,
                                 VerticalTextAlignment.Center),new TextNode(
                                 "NOT YET IMPLEMENTED",
@@ -131,7 +131,7 @@ namespace Fusee.Examples.Materials.Core
                                 MinMaxRect.FromCenterSize(float2.Zero, float2.One),
                                 new MinMaxRect(),
                                 fontLatoMap,
-                                ColorUint.Black,
+                                (float4)ColorUint.Black,
                                 HorizontalTextAlignment.Left,
                                 VerticalTextAlignment.Center)
                         }
@@ -156,7 +156,7 @@ namespace Fusee.Examples.Materials.Core
                                 MinMaxRect.FromCenterSize(float2.Zero, float2.One),
                                 new MinMaxRect(),
                                 fontLatoMap,
-                                ColorUint.Black,
+                                (float4)ColorUint.Black,
                                 HorizontalTextAlignment.Left,
                                 VerticalTextAlignment.Center)
                         }
@@ -181,7 +181,7 @@ namespace Fusee.Examples.Materials.Core
                                 MinMaxRect.FromCenterSize(float2.Zero, float2.One),
                                 new MinMaxRect(),
                                 fontLatoMap,
-                                ColorUint.Black,
+                                (float4)ColorUint.Black,
                                 HorizontalTextAlignment.Left,
                                 VerticalTextAlignment.Center),
                                 new TextNode(
@@ -221,7 +221,7 @@ namespace Fusee.Examples.Materials.Core
                                 MinMaxRect.FromCenterSize(float2.Zero, float2.One),
                                 new MinMaxRect(),
                                 fontLatoMap,
-                                ColorUint.Black,
+                                (float4)ColorUint.Black,
                                 HorizontalTextAlignment.Left,
                                 VerticalTextAlignment.Center)
                         }
@@ -246,7 +246,7 @@ namespace Fusee.Examples.Materials.Core
                                         MinMaxRect.FromCenterSize(float2.Zero, float2.One),
                                         new MinMaxRect(),
                                         fontLatoMap,
-                                        ColorUint.Black,
+                                        (float4)ColorUint.Black,
                                         HorizontalTextAlignment.Left,
                                         VerticalTextAlignment.Center),
                                       new TextNode(
@@ -286,7 +286,7 @@ namespace Fusee.Examples.Materials.Core
                                         MinMaxRect.FromCenterSize(float2.Zero, float2.One),
                                         new MinMaxRect(),
                                         fontLatoMap,
-                                        ColorUint.Black,
+                                        (float4)ColorUint.Black,
                                         HorizontalTextAlignment.Left,
                                         VerticalTextAlignment.Center),
                                      new TextNode(
@@ -434,7 +434,7 @@ namespace Fusee.Examples.Materials.Core
                                         Name = "specular texture - not impl.",
                                         Translation = new float3(0, 0, 0)
                                     },
-                                    MakeEffect.FromDiffuseSpecular(float4.One, float4.Zero, 85),
+                                    MakeEffect.FromDiffuseSpecular(float4.One, float4.Zero, 85, 0.5f),
                                     icosphereWithTangents
                                 }
                             },

--- a/Examples/Complete/Picking/Core/Picking.cs
+++ b/Examples/Complete/Picking/Core/Picking.cs
@@ -151,7 +151,7 @@ namespace Fusee.Examples.Picking.Core
                     {
                         var ef = newPick.Node.GetComponent<DefaultSurfaceEffect>();
                         _oldColor = ef.SurfaceInput.Albedo;
-                        ef.SurfaceInput.Albedo = ColorUint.Tofloat4(ColorUint.LawnGreen);
+                        ef.SurfaceInput.Albedo = ColorUint.LawnGreen;
                     }
                     _currentPick = newPick;
                 }
@@ -228,7 +228,7 @@ namespace Fusee.Examples.Picking.Core
                 UIElementPosition.GetAnchors(AnchorPos.StretchHorizontal),
                 UIElementPosition.CalcOffsets(AnchorPos.StretchHorizontal, new float2(canvasWidth / 2 - 4, 0), canvasHeight, canvasWidth, new float2(8, 1)),
                 guiLatoBlack,
-                ColorUint.Tofloat4(ColorUint.Greenery),
+                ColorUint.Greenery,
                 HorizontalTextAlignment.Center,
                 VerticalTextAlignment.Center);
 
@@ -262,7 +262,7 @@ namespace Fusee.Examples.Picking.Core
         public void BtnLogoEnter(CodeComponent sender)
         {
             var effect = _gui.Children.FindNodes(node => node.Name == "fuseeLogo").First().GetComponent<ShaderEffect>();
-            effect.SetFxParam(UniformNameDeclarations.Albedo, new float4(0.0f, 0.0f, 0.0f, 1f));
+            effect.SetFxParam(UniformNameDeclarations.Albedo, ColorUint.Black);
             effect.SetFxParam(UniformNameDeclarations.AlbedoMix, 0.8f);
         }
 
@@ -296,7 +296,7 @@ namespace Fusee.Examples.Picking.Core
                         Components = new List<SceneComponent>
                         {
                            new Transform { Scale = float3.One },
-                           MakeEffect.FromDiffuseSpecular(ColorUint.Tofloat4(ColorUint.Red), float4.Zero, 4.0f, 1f),
+                           MakeEffect.FromDiffuseSpecular(ColorUint.Red, float4.Zero, 4.0f, 1f),
                            CreateCuboid(new float3(100, 20, 100))
                         },
                         Children = new ChildList
@@ -307,7 +307,7 @@ namespace Fusee.Examples.Picking.Core
                                 Components = new List<SceneComponent>
                                 {
                                    new Transform {Translation=new float3(0, 60, 0),  Scale = float3.One },
-                                   MakeEffect.FromDiffuseSpecular(ColorUint.Tofloat4(ColorUint.Green), float4.Zero, 4.0f, 1f),
+                                   MakeEffect.FromDiffuseSpecular(ColorUint.Green, float4.Zero, 4.0f, 1f),
                                    CreateCuboid(new float3(20, 100, 20))
                                 },
                                 Children = new ChildList
@@ -327,7 +327,7 @@ namespace Fusee.Examples.Picking.Core
                                                 Components = new List<SceneComponent>
                                                 {
                                                     new Transform {Translation=new float3(0, 40, 0),  Scale = float3.One },
-                                                    MakeEffect.FromDiffuseSpecular(ColorUint.Tofloat4(ColorUint.Yellow), float4.Zero, 4.0f, 1f),
+                                                    MakeEffect.FromDiffuseSpecular(ColorUint.Yellow, float4.Zero, 4.0f, 1f),
                                                     CreateCuboid(new float3(20, 100, 20))
                                                 },
                                                 Children = new ChildList
@@ -347,7 +347,7 @@ namespace Fusee.Examples.Picking.Core
                                                                 Components = new List<SceneComponent>
                                                                 {
                                                                     new Transform {Translation=new float3(0, 40, 0),  Scale = float3.One },
-                                                                    MakeEffect.FromDiffuseSpecular(ColorUint.Tofloat4(ColorUint.Blue), float4.Zero, 4.0f, 1f),
+                                                                    MakeEffect.FromDiffuseSpecular(ColorUint.Blue, float4.Zero, 4.0f, 1f),
                                                                     CreateCuboid(new float3(20, 100, 20))
                                                                 }
                                                             },

--- a/Examples/Complete/Picking/Core/Picking.cs
+++ b/Examples/Complete/Picking/Core/Picking.cs
@@ -151,7 +151,7 @@ namespace Fusee.Examples.Picking.Core
                     {
                         var ef = newPick.Node.GetComponent<DefaultSurfaceEffect>();
                         _oldColor = ef.SurfaceInput.Albedo;
-                        ef.SurfaceInput.Albedo = ColorUint.LawnGreen;
+                        ef.SurfaceInput.Albedo = (float4)ColorUint.LawnGreen;
                     }
                     _currentPick = newPick;
                 }
@@ -228,7 +228,7 @@ namespace Fusee.Examples.Picking.Core
                 UIElementPosition.GetAnchors(AnchorPos.StretchHorizontal),
                 UIElementPosition.CalcOffsets(AnchorPos.StretchHorizontal, new float2(canvasWidth / 2 - 4, 0), canvasHeight, canvasWidth, new float2(8, 1)),
                 guiLatoBlack,
-                ColorUint.Greenery,
+                (float4)ColorUint.Greenery,
                 HorizontalTextAlignment.Center,
                 VerticalTextAlignment.Center);
 
@@ -262,7 +262,7 @@ namespace Fusee.Examples.Picking.Core
         public void BtnLogoEnter(CodeComponent sender)
         {
             var effect = _gui.Children.FindNodes(node => node.Name == "fuseeLogo").First().GetComponent<ShaderEffect>();
-            effect.SetFxParam(UniformNameDeclarations.Albedo, ColorUint.Black);
+            effect.SetFxParam(UniformNameDeclarations.Albedo, (float4)ColorUint.Black);
             effect.SetFxParam(UniformNameDeclarations.AlbedoMix, 0.8f);
         }
 
@@ -296,7 +296,7 @@ namespace Fusee.Examples.Picking.Core
                         Components = new List<SceneComponent>
                         {
                            new Transform { Scale = float3.One },
-                           MakeEffect.FromDiffuseSpecular(ColorUint.Red, float4.Zero, 4.0f, 1f),
+                           MakeEffect.FromDiffuseSpecular((float4)ColorUint.Red, float4.Zero, 4.0f, 1f),
                            CreateCuboid(new float3(100, 20, 100))
                         },
                         Children = new ChildList
@@ -307,7 +307,7 @@ namespace Fusee.Examples.Picking.Core
                                 Components = new List<SceneComponent>
                                 {
                                    new Transform {Translation=new float3(0, 60, 0),  Scale = float3.One },
-                                   MakeEffect.FromDiffuseSpecular(ColorUint.Green, float4.Zero, 4.0f, 1f),
+                                   MakeEffect.FromDiffuseSpecular((float4)ColorUint.Green, float4.Zero, 4.0f, 1f),
                                    CreateCuboid(new float3(20, 100, 20))
                                 },
                                 Children = new ChildList
@@ -327,7 +327,7 @@ namespace Fusee.Examples.Picking.Core
                                                 Components = new List<SceneComponent>
                                                 {
                                                     new Transform {Translation=new float3(0, 40, 0),  Scale = float3.One },
-                                                    MakeEffect.FromDiffuseSpecular(ColorUint.Yellow, float4.Zero, 4.0f, 1f),
+                                                    MakeEffect.FromDiffuseSpecular((float4)ColorUint.Yellow, float4.Zero, 4.0f, 1f),
                                                     CreateCuboid(new float3(20, 100, 20))
                                                 },
                                                 Children = new ChildList
@@ -347,7 +347,7 @@ namespace Fusee.Examples.Picking.Core
                                                                 Components = new List<SceneComponent>
                                                                 {
                                                                     new Transform {Translation=new float3(0, 40, 0),  Scale = float3.One },
-                                                                    MakeEffect.FromDiffuseSpecular(ColorUint.Blue, float4.Zero, 4.0f, 1f),
+                                                                    MakeEffect.FromDiffuseSpecular((float4)ColorUint.Blue, float4.Zero, 4.0f, 1f),
                                                                     CreateCuboid(new float3(20, 100, 20))
                                                                 }
                                                             },

--- a/Examples/Complete/RenderLayer/Core/Example.cs
+++ b/Examples/Complete/RenderLayer/Core/Example.cs
@@ -114,20 +114,24 @@ namespace Fusee.Examples.RenderLayerEx.Core
             var cam = new SceneNode();
             cam.AddComponent(new Transform { Translation = new float3(0, 1.7f, -16), Rotation = new float3(0, 0, 0) });
 
-            var cam1 = new Camera(ProjectionMethod.Perspective, 1, 1000, M.PiOver4);
-            cam1.Viewport = new float4(0, 0, 50, 100);
-            cam1.BackgroundColor = new float4(new float4(1, 0.8f, 0.8f, 1));
-            cam1.Layer = 1;
-            cam1.FrustumCullingOn = false;
-            cam1.RenderLayer = RenderLayers.Layer01;
+            var cam1 = new Camera(ProjectionMethod.Perspective, 1, 1000, M.PiOver4)
+            {
+                Viewport = new float4(0, 0, 50, 100),
+                BackgroundColor = new float4(1, 0.8f, 0.8f, 1),
+                Layer = 1,
+                FrustumCullingOn = false,
+                RenderLayer = RenderLayers.Layer01
+            };
             cam.AddComponent(cam1);
 
-            var cam2 = new Camera(ProjectionMethod.Perspective, 1, 1000, M.PiOver4);
-            cam2.Viewport = new float4(50, 0, 50, 100);
-            cam2.BackgroundColor = new float4(new float4(0.8f, 1, 0.8f, 1));
-            cam2.Layer = 1;
-            cam2.FrustumCullingOn = false;
-            cam2.RenderLayer = RenderLayers.Layer02;
+            var cam2 = new Camera(ProjectionMethod.Perspective, 1, 1000, M.PiOver4)
+            {
+                Viewport = new float4(50, 0, 50, 100),
+                BackgroundColor = new float4(0.8f, 1, 0.8f, 1),
+                Layer = 1,
+                FrustumCullingOn = false,
+                RenderLayer = RenderLayers.Layer02
+            };
             cam.AddComponent(cam2);
 
             _scene.Children.Add(cam);

--- a/Examples/Complete/Simple/Core/Simple.cs
+++ b/Examples/Complete/Simple/Core/Simple.cs
@@ -175,7 +175,7 @@ namespace Fusee.Examples.Simple.Core
                 UIElementPosition.GetAnchors(AnchorPos.StretchHorizontal),
                 UIElementPosition.CalcOffsets(AnchorPos.StretchHorizontal, new float2(canvasWidth / 2 - 4, 0), canvasHeight, canvasWidth, new float2(8, 1)),
                 guiLatoBlack,
-                ColorUint.Greenery,
+                (float4)ColorUint.Greenery,
                 HorizontalTextAlignment.Center,
                 VerticalTextAlignment.Center);
 
@@ -209,7 +209,7 @@ namespace Fusee.Examples.Simple.Core
         public void BtnLogoEnter(CodeComponent sender)
         {
             var effect = _gui.Children.FindNodes(node => node.Name == "fuseeLogo").First().GetComponent<Effect>();
-            effect.SetFxParam(UniformNameDeclarations.Albedo, ColorUint.Black);
+            effect.SetFxParam(UniformNameDeclarations.Albedo, (float4)ColorUint.Black);
             effect.SetFxParam(UniformNameDeclarations.AlbedoMix, 0.8f);
         }
 

--- a/Examples/Complete/Simple/Core/Simple.cs
+++ b/Examples/Complete/Simple/Core/Simple.cs
@@ -175,7 +175,7 @@ namespace Fusee.Examples.Simple.Core
                 UIElementPosition.GetAnchors(AnchorPos.StretchHorizontal),
                 UIElementPosition.CalcOffsets(AnchorPos.StretchHorizontal, new float2(canvasWidth / 2 - 4, 0), canvasHeight, canvasWidth, new float2(8, 1)),
                 guiLatoBlack,
-                ColorUint.Tofloat4(ColorUint.Greenery),
+                ColorUint.Greenery,
                 HorizontalTextAlignment.Center,
                 VerticalTextAlignment.Center);
 
@@ -209,7 +209,7 @@ namespace Fusee.Examples.Simple.Core
         public void BtnLogoEnter(CodeComponent sender)
         {
             var effect = _gui.Children.FindNodes(node => node.Name == "fuseeLogo").First().GetComponent<Effect>();
-            effect.SetFxParam(UniformNameDeclarations.Albedo, new float4(0.0f, 0.0f, 0.0f, 1f));
+            effect.SetFxParam(UniformNameDeclarations.Albedo, ColorUint.Black);
             effect.SetFxParam(UniformNameDeclarations.AlbedoMix, 0.8f);
         }
 

--- a/Examples/Complete/SimpleDeferred/Core/SimpleDeferred.cs
+++ b/Examples/Complete/SimpleDeferred/Core/SimpleDeferred.cs
@@ -316,7 +316,7 @@ namespace Fusee.Examples.SimpleDeferred.Core
                 UIElementPosition.GetAnchors(AnchorPos.StretchHorizontal),
                 UIElementPosition.CalcOffsets(AnchorPos.StretchHorizontal, new float2(canvasWidth / 2 - 4, 0), canvasHeight, canvasWidth, new float2(8, 1)),
                 guiLatoBlack,
-                ColorUint.Greenery,
+                (float4)ColorUint.Greenery,
                 HorizontalTextAlignment.Center,
                 VerticalTextAlignment.Center);
 
@@ -365,7 +365,7 @@ namespace Fusee.Examples.SimpleDeferred.Core
         public void BtnLogoEnter(CodeComponent sender)
         {
             var effect = _gui.Children.FindNodes(node => node.Name == "fuseeLogo").First().GetComponent<Effect>();
-            effect.SetFxParam(UniformNameDeclarations.Albedo, ColorUint.Black);
+            effect.SetFxParam(UniformNameDeclarations.Albedo, (float4)ColorUint.Black);
             effect.SetFxParam(UniformNameDeclarations.AlbedoMix, 0.8f);
         }
 

--- a/Examples/Complete/SimpleDeferred/Core/SimpleDeferred.cs
+++ b/Examples/Complete/SimpleDeferred/Core/SimpleDeferred.cs
@@ -316,7 +316,7 @@ namespace Fusee.Examples.SimpleDeferred.Core
                 UIElementPosition.GetAnchors(AnchorPos.StretchHorizontal),
                 UIElementPosition.CalcOffsets(AnchorPos.StretchHorizontal, new float2(canvasWidth / 2 - 4, 0), canvasHeight, canvasWidth, new float2(8, 1)),
                 guiLatoBlack,
-                ColorUint.Tofloat4(ColorUint.Greenery),
+                ColorUint.Greenery,
                 HorizontalTextAlignment.Center,
                 VerticalTextAlignment.Center);
 
@@ -365,7 +365,7 @@ namespace Fusee.Examples.SimpleDeferred.Core
         public void BtnLogoEnter(CodeComponent sender)
         {
             var effect = _gui.Children.FindNodes(node => node.Name == "fuseeLogo").First().GetComponent<Effect>();
-            effect.SetFxParam(UniformNameDeclarations.Albedo, new float4(0.0f, 0.0f, 0.0f, 1f));
+            effect.SetFxParam(UniformNameDeclarations.Albedo, ColorUint.Black);
             effect.SetFxParam(UniformNameDeclarations.AlbedoMix, 0.8f);
         }
 

--- a/Examples/Complete/SurfaceEffects/Core/SurfaceEffects.cs
+++ b/Examples/Complete/SurfaceEffects/Core/SurfaceEffects.cs
@@ -8,7 +8,9 @@ using Fusee.Engine.Core.ShaderShards;
 using Fusee.Engine.GUI;
 using Fusee.Math.Core;
 using Fusee.Xene;
+using System;
 using System.Collections.Generic;
+using System.Drawing;
 using System.Linq;
 using static Fusee.Engine.Core.Input;
 using static Fusee.Engine.Core.Time;
@@ -46,6 +48,26 @@ namespace Fusee.Examples.SurfaceEffects.Core
 
         private DefaultSurfaceEffect _testFx;
 
+
+        //vec3 decodeSRGB(vec3 screenRGB)
+        //{
+        //    vec3 a = screenRGB / 12.92;
+        //    vec3 b = pow((screenRGB + 0.055) / 1.055, vec3(2.4));
+        //    vec3 c = step(vec3(0.04045), screenRGB);
+        //    return mix(a, b, c);
+        //}
+
+        private float3 ToLinear(float3 sRGBCol)
+        {
+            float3 a = sRGBCol / 12.92f;
+
+            float3 zwerg = (sRGBCol + 0.055f) / 1.055f;
+
+            float3 b = new float3(MathF.Pow(zwerg.r, 2.4f), MathF.Pow(zwerg.g, 2.4f), MathF.Pow(zwerg.b, 2.4f));
+            float3 c = float3.Step(new float3(0.04045f, 0.04045f, 0.04045f), sRGBCol);
+            return float3.Lerp(a, b, c);
+        }
+
         // Init is called on startup.
         public override void Init()
         {
@@ -80,7 +102,7 @@ namespace Fusee.Examples.SurfaceEffects.Core
 
             _gold_brdfFx = MakeEffect.FromBRDF
             (
-                albedoColor: new float4(1.0f, 227f / 256f, 157f / 256, 1.0f),
+                albedoColor: new float4(ToLinear(new float3(1.0f, 227f / 256f, 157f / 256)), 1.0f),
                 emissionColor: new float4(0, 0, 0, 0),
                 roughness: 0.2f,
                 metallic: 1,
@@ -91,7 +113,15 @@ namespace Fusee.Examples.SurfaceEffects.Core
 
             _paint_brdfFx = MakeEffect.FromBRDF
             (
-                albedoColor: new float4(0.0f, 231f / 256f, 1f, 1.0f),
+                //Photoshop RGB
+                albedoColor: new float4(ToLinear(new float3(0.44f, 0.533f, 0.156f)), 1.0f),
+
+                //Blender RGB
+                //new float4(0.161431f, 0.246197f, 0.021525f, 1.0f),
+
+                //FUSEE Greenery
+                //new float4(ToLinear(ColorUint.Greenery.Tofloat4().rgb), 1.0f),
+
                 emissionColor: new float4(),
                 roughness: 0.05f,
                 metallic: 0,
@@ -102,7 +132,7 @@ namespace Fusee.Examples.SurfaceEffects.Core
 
             _rubber_brdfFx = MakeEffect.FromBRDF
             (
-                albedoColor: new float4(214f / 256f, 84f / 256f, 68f / 256f, 1.0f),
+                albedoColor: new float4(ToLinear(new float3(214f / 256f, 84f / 256f, 68f / 256f)), 1.0f),
                 emissionColor: new float4(),
                 roughness: 1.0f,
                 metallic: 0,
@@ -113,7 +143,7 @@ namespace Fusee.Examples.SurfaceEffects.Core
 
             _subsurf_brdfFx = MakeEffect.FromBRDF
             (
-                albedoColor: new float4(255f / 256f, 234f / 256f, 215f / 256f, 1.0f),
+                albedoColor: new float4(ToLinear(new float3(255f / 256f, 234f / 256f, 215f / 256f)), 1.0f),
                 emissionColor: new float4(),
                 roughness: 0.508f,
                 metallic: 0,

--- a/Examples/Complete/SurfaceEffects/Core/SurfaceEffects.cs
+++ b/Examples/Complete/SurfaceEffects/Core/SurfaceEffects.cs
@@ -10,7 +10,6 @@ using Fusee.Math.Core;
 using Fusee.Xene;
 using System;
 using System.Collections.Generic;
-using System.Drawing;
 using System.Linq;
 using static Fusee.Engine.Core.Input;
 using static Fusee.Engine.Core.Time;
@@ -48,26 +47,6 @@ namespace Fusee.Examples.SurfaceEffects.Core
 
         private DefaultSurfaceEffect _testFx;
 
-
-        //vec3 decodeSRGB(vec3 screenRGB)
-        //{
-        //    vec3 a = screenRGB / 12.92;
-        //    vec3 b = pow((screenRGB + 0.055) / 1.055, vec3(2.4));
-        //    vec3 c = step(vec3(0.04045), screenRGB);
-        //    return mix(a, b, c);
-        //}
-
-        private float3 ToLinear(float3 sRGBCol)
-        {
-            float3 a = sRGBCol / 12.92f;
-
-            float3 zwerg = (sRGBCol + 0.055f) / 1.055f;
-
-            float3 b = new float3(MathF.Pow(zwerg.r, 2.4f), MathF.Pow(zwerg.g, 2.4f), MathF.Pow(zwerg.b, 2.4f));
-            float3 c = float3.Step(new float3(0.04045f, 0.04045f, 0.04045f), sRGBCol);
-            return float3.Lerp(a, b, c);
-        }
-
         // Init is called on startup.
         public override void Init()
         {
@@ -102,7 +81,7 @@ namespace Fusee.Examples.SurfaceEffects.Core
 
             _gold_brdfFx = MakeEffect.FromBRDF
             (
-                albedoColor: new float4(ToLinear(new float3(1.0f, 227f / 256f, 157f / 256)), 1.0f),
+                albedoColor: new float4(1.0f, 227f / 256f, 157f / 256, 1.0f).LinearColorFromSRgb(),
                 emissionColor: new float4(0, 0, 0, 0),
                 roughness: 0.2f,
                 metallic: 1,
@@ -113,26 +92,19 @@ namespace Fusee.Examples.SurfaceEffects.Core
 
             _paint_brdfFx = MakeEffect.FromBRDF
             (
-                //Photoshop RGB
-                albedoColor: new float4(ToLinear(new float3(0.44f, 0.533f, 0.156f)), 1.0f),
-
-                //Blender RGB
-                //new float4(0.161431f, 0.246197f, 0.021525f, 1.0f),
-
-                //FUSEE Greenery
-                //new float4(ToLinear(ColorUint.Greenery.Tofloat4().rgb), 1.0f),
-
+                //ColorUint.Greenery, 
+                new float4(float4.LinearColorFromSRgb(0x708828FF)),
                 emissionColor: new float4(),
                 roughness: 0.05f,
                 metallic: 0,
                 specular: 1f,
                 ior: 1.46f,
                 subsurface: 0
-            );
+            );;
 
             _rubber_brdfFx = MakeEffect.FromBRDF
             (
-                albedoColor: new float4(ToLinear(new float3(214f / 256f, 84f / 256f, 68f / 256f)), 1.0f),
+                albedoColor: new float4(214f / 256f, 84f / 256f, 68f / 256f, 1.0f).LinearColorFromSRgb(),
                 emissionColor: new float4(),
                 roughness: 1.0f,
                 metallic: 0,
@@ -143,7 +115,7 @@ namespace Fusee.Examples.SurfaceEffects.Core
 
             _subsurf_brdfFx = MakeEffect.FromBRDF
             (
-                albedoColor: new float4(ToLinear(new float3(255f / 256f, 234f / 256f, 215f / 256f)), 1.0f),
+                albedoColor: new float4(255f / 256f, 234f / 256f, 215f / 256f, 1.0f).LinearColorFromSRgb(),
                 emissionColor: new float4(),
                 roughness: 0.508f,
                 metallic: 0,
@@ -295,7 +267,7 @@ namespace Fusee.Examples.SurfaceEffects.Core
                 UIElementPosition.GetAnchors(AnchorPos.StretchHorizontal),
                 UIElementPosition.CalcOffsets(AnchorPos.StretchHorizontal, new float2(canvasWidth / 2 - 4, 0), canvasHeight, canvasWidth, new float2(8, 1)),
                 guiLatoBlack,
-                ColorUint.Tofloat4(ColorUint.Greenery),
+                ColorUint.Greenery,
                 HorizontalTextAlignment.Center,
                 VerticalTextAlignment.Center);
 
@@ -329,7 +301,7 @@ namespace Fusee.Examples.SurfaceEffects.Core
         public void BtnLogoEnter(CodeComponent sender)
         {
             var effect = _gui.Children.FindNodes(node => node.Name == "fuseeLogo").First().GetComponent<Effect>();
-            effect.SetFxParam(UniformNameDeclarations.Albedo, new float4(0.0f, 0.0f, 0.0f, 1f));
+            effect.SetFxParam(UniformNameDeclarations.Albedo, ColorUint.Black);
             effect.SetFxParam(UniformNameDeclarations.AlbedoMix, 0.8f);
         }
 

--- a/Examples/Complete/SurfaceEffects/Core/SurfaceEffects.cs
+++ b/Examples/Complete/SurfaceEffects/Core/SurfaceEffects.cs
@@ -267,7 +267,7 @@ namespace Fusee.Examples.SurfaceEffects.Core
                 UIElementPosition.GetAnchors(AnchorPos.StretchHorizontal),
                 UIElementPosition.CalcOffsets(AnchorPos.StretchHorizontal, new float2(canvasWidth / 2 - 4, 0), canvasHeight, canvasWidth, new float2(8, 1)),
                 guiLatoBlack,
-                ColorUint.Greenery,
+                (float4)ColorUint.Greenery,
                 HorizontalTextAlignment.Center,
                 VerticalTextAlignment.Center);
 
@@ -301,7 +301,7 @@ namespace Fusee.Examples.SurfaceEffects.Core
         public void BtnLogoEnter(CodeComponent sender)
         {
             var effect = _gui.Children.FindNodes(node => node.Name == "fuseeLogo").First().GetComponent<Effect>();
-            effect.SetFxParam(UniformNameDeclarations.Albedo, ColorUint.Black);
+            effect.SetFxParam(UniformNameDeclarations.Albedo, (float4)ColorUint.Black);
             effect.SetFxParam(UniformNameDeclarations.AlbedoMix, 0.8f);
         }
 

--- a/Examples/Complete/SurfaceEffects/Core/SurfaceEffects.cs
+++ b/Examples/Complete/SurfaceEffects/Core/SurfaceEffects.cs
@@ -100,7 +100,7 @@ namespace Fusee.Examples.SurfaceEffects.Core
                 specular: 1f,
                 ior: 1.46f,
                 subsurface: 0
-            );;
+            ); ;
 
             _rubber_brdfFx = MakeEffect.FromBRDF
             (

--- a/Examples/Complete/ThreeDFont/Core/ThreeDFontHelper.cs
+++ b/Examples/Complete/ThreeDFont/Core/ThreeDFontHelper.cs
@@ -17,7 +17,7 @@ namespace Fusee.Examples.ThreeDFont.Core
             _font = font;
         }
 
-        //Reads all curves from a given text and retruns them as a List of Curves.
+        //Reads all curves from a given text and returns them as a List of Curves.
         private IList<Curve> GetTextCurves()
         {
             var curves = new List<Curve>();

--- a/Examples/Complete/UI/Core/UI.cs
+++ b/Examples/Complete/UI/Core/UI.cs
@@ -51,8 +51,8 @@ namespace Fusee.Examples.UI.Core
         private readonly float zFar = 1000;
         private readonly float fov = M.PiOver4;
 
-        private readonly float4 _canvasDefaultColor = new float4(1, 0f, 0f, 1);
-        private readonly float4 _canvasHoverColor = new float4(1, 0.4f, 0.1f, 1);
+        private readonly float4 _canvasDefaultColor = ColorUint.Red;
+        private readonly float4 _canvasHoverColor = ColorUint.OrangeRed;
 
         private GUIText _fpsText;
 
@@ -85,7 +85,7 @@ namespace Fusee.Examples.UI.Core
                     Max = new float2(0, 1)
                 },
                  _fontMap,
-                ColorUint.Tofloat4(ColorUint.White),
+                ColorUint.White,
                 HorizontalTextAlignment.Center,
                 VerticalTextAlignment.Center
             );
@@ -107,7 +107,7 @@ namespace Fusee.Examples.UI.Core
                     Max = new float2(-1f, -0.5f)
                 },
                 _fontMap,
-                ColorUint.Tofloat4(ColorUint.Greenery),
+                ColorUint.Greenery,
                 HorizontalTextAlignment.Center,
                 VerticalTextAlignment.Center);
 
@@ -251,7 +251,7 @@ namespace Fusee.Examples.UI.Core
                 }
             };
 
-            canvas.AddComponent(MakeEffect.FromDiffuseSpecular(new float4(1, 0, 0, 1), float4.Zero, 0, 0));
+            canvas.AddComponent(MakeEffect.FromDiffuseSpecular(ColorUint.Red, float4.Zero, 0, 0));
             canvas.AddComponent(new Plane());
             canvas.AddComponent(_btnCanvas);
 

--- a/Examples/Complete/UI/Core/UI.cs
+++ b/Examples/Complete/UI/Core/UI.cs
@@ -11,7 +11,6 @@ using Fusee.Xene;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
-using System.Threading.Tasks;
 using FontMap = Fusee.Engine.Core.FontMap;
 
 namespace Fusee.Examples.UI.Core
@@ -37,11 +36,8 @@ namespace Fusee.Examples.UI.Core
         private GUIButton _btnCat;
 
         private FontMap _fontMap;
-        private FontMap _fontMap1;
-
         private readonly CanvasRenderMode _canvasRenderMode = CanvasRenderMode.Screen;
         private float _initWindowWidth;
-        private float _initWindowHeight;
         private float _initCanvasWidth;
         private float _initCanvasHeight;
         private float _canvasWidth = 16;
@@ -51,8 +47,8 @@ namespace Fusee.Examples.UI.Core
         private readonly float zFar = 1000;
         private readonly float fov = M.PiOver4;
 
-        private readonly float4 _canvasDefaultColor = ColorUint.Red;
-        private readonly float4 _canvasHoverColor = ColorUint.OrangeRed;
+        private readonly float4 _canvasDefaultColor = (float4)ColorUint.Red;
+        private readonly float4 _canvasHoverColor = (float4)ColorUint.OrangeRed;
 
         private GUIText _fpsText;
 
@@ -85,7 +81,7 @@ namespace Fusee.Examples.UI.Core
                     Max = new float2(0, 1)
                 },
                  _fontMap,
-                ColorUint.White,
+                (float4)ColorUint.White,
                 HorizontalTextAlignment.Center,
                 VerticalTextAlignment.Center
             );
@@ -107,7 +103,7 @@ namespace Fusee.Examples.UI.Core
                     Max = new float2(-1f, -0.5f)
                 },
                 _fontMap,
-                ColorUint.Greenery,
+                (float4)ColorUint.Greenery,
                 HorizontalTextAlignment.Center,
                 VerticalTextAlignment.Center);
 
@@ -251,7 +247,7 @@ namespace Fusee.Examples.UI.Core
                 }
             };
 
-            canvas.AddComponent(MakeEffect.FromDiffuseSpecular(ColorUint.Red, float4.Zero, 0, 0));
+            canvas.AddComponent(MakeEffect.FromDiffuseSpecular((float4)ColorUint.Red, float4.Zero));
             canvas.AddComponent(new Plane());
             canvas.AddComponent(_btnCanvas);
 
@@ -340,7 +336,6 @@ namespace Fusee.Examples.UI.Core
         public override void Init()
         {
             _initWindowWidth = Width;
-            _initWindowHeight = Height;
             if (_canvasRenderMode == CanvasRenderMode.Screen)
             {
                 _initCanvasWidth = Width / 100f;
@@ -356,7 +351,6 @@ namespace Fusee.Examples.UI.Core
 
             var fontLato = AssetStorage.Get<Font>("Lato-Black.ttf");
 
-            _fontMap1 = new FontMap(fontLato, 8);
             _fontMap = new FontMap(fontLato, 24);
 
             // Set the clear color for the back buffer to white (100% intensity in all color channels R, G, B, A).

--- a/src/Base/Common/ColorUint.cs
+++ b/src/Base/Common/ColorUint.cs
@@ -384,25 +384,25 @@ namespace Fusee.Base.Common
         }
 
         /// <summary>
-        /// Performs an implicit conversion from <see cref="T:Fusee.Engine.ColorUint"/> to <see cref="T:Fusee.Math.float3"/>.
+        /// Performs an explicit conversion from <see cref="T:Fusee.Engine.ColorUint"/> to <see cref="T:Fusee.Math.float3"/>.
         /// </summary>
         /// <param name="value">The color value. It is expected to be in SRgb color space - will be transformed to linear space in order to perform the lighting calculation correctly.</param>
         /// <returns>
         /// The result of the conversion.
         /// </returns>
-        public static implicit operator float3(ColorUint value)
+        public static explicit operator float3(ColorUint value)
         {
             return float3.LinearColorFromSRgb(Tofloat3(value));
         }
 
         /// <summary>
-        /// Performs an implicit conversion from <see cref="T:Fusee.Engine.ColorUint"/> to <see cref="T:Fusee.Math.float4"/>.
+        /// Performs an explicit conversion from <see cref="T:Fusee.Engine.ColorUint"/> to <see cref="T:Fusee.Math.float4"/>.
         /// </summary>
         /// <param name="value">The color value. It is expected to be in SRgb color space - will be transformed to linear space in order to perform the lighting calculation correctly.</param>
         /// <returns>
         /// The result of the conversion.
         /// </returns>
-        public static implicit operator float4(ColorUint value)
+        public static explicit operator float4(ColorUint value)
         {
             return float4.LinearColorFromSRgb(Tofloat4(value));
         }
@@ -414,7 +414,7 @@ namespace Fusee.Base.Common
         /// <returns>
         /// The result of the conversion.
         /// </returns>
-        public static implicit operator ColorUint(float3 value)
+        public static explicit operator ColorUint(float3 value)
         {
             return new ColorUint(value.x, value.y, value.z, 1f);
         }
@@ -426,7 +426,7 @@ namespace Fusee.Base.Common
         /// <returns>
         /// The result of the conversion.
         /// </returns>
-        public static implicit operator ColorUint(float4 value)
+        public static explicit operator ColorUint(float4 value)
         {
             return new ColorUint(value.x, value.y, value.z, value.w);
         }

--- a/src/Base/Common/ColorUint.cs
+++ b/src/Base/Common/ColorUint.cs
@@ -410,24 +410,26 @@ namespace Fusee.Base.Common
         /// <summary>
         /// Performs an explicit conversion from <see cref="T:Fusee.Math.float3"/> to <see cref="T:Fusee.Engine.ColorUint"/>.
         /// </summary>
-        /// <param name="value">The color value. It is expected to be in SRgb color space.</param>
+        /// <param name="value">The color value.</param>
         /// <returns>
         /// The result of the conversion.
         /// </returns>
         public static explicit operator ColorUint(float3 value)
         {
+            value = value.SRgbFromLinearColor();
             return new ColorUint(value.x, value.y, value.z, 1f);
         }
 
         /// <summary>
         /// Performs an explicit conversion from <see cref="T:Fusee.Math.float4"/> to <see cref="T:Fusee.Engine.ColorUint"/>.
         /// </summary>
-        /// <param name="value">The value. It is expected to be in SRgb color space.</param>
+        /// <param name="value">The color value.</param>
         /// <returns>
         /// The result of the conversion.
         /// </returns>
         public static explicit operator ColorUint(float4 value)
         {
+            value = value.SRgbFromLinearColor();
             return new ColorUint(value.x, value.y, value.z, value.w);
         }
 

--- a/src/Base/Common/ColorUint.cs
+++ b/src/Base/Common/ColorUint.cs
@@ -392,7 +392,7 @@ namespace Fusee.Base.Common
         /// </returns>
         public static implicit operator float3(ColorUint value)
         {
-            return float3.LinearColorFromSRgb(new float3(value.R / (float)byte.MaxValue, value.G / (float)byte.MaxValue, value.B / (float)byte.MaxValue));
+            return float3.LinearColorFromSRgb(Tofloat3(value));
         }
 
         /// <summary>
@@ -404,7 +404,7 @@ namespace Fusee.Base.Common
         /// </returns>
         public static implicit operator float4(ColorUint value)
         {
-            return float4.LinearColorFromSRgb(new float4(value.R / (float)byte.MaxValue, value.G / (float)byte.MaxValue, value.B / (float)byte.MaxValue, value.A / (float)byte.MaxValue));
+            return float4.LinearColorFromSRgb(Tofloat4(value));
         }
 
         /// <summary>

--- a/src/Base/Common/ColorUint.cs
+++ b/src/Base/Common/ColorUint.cs
@@ -1,6 +1,6 @@
-﻿using System;
+﻿using Fusee.Math.Core;
+using System;
 using System.Runtime.InteropServices;
-using Fusee.Math.Core;
 
 namespace Fusee.Base.Common
 {
@@ -383,39 +383,38 @@ namespace Fusee.Base.Common
                 this.A = copyFrom[index + 3];
         }
 
-
         /// <summary>
-        /// Performs an explicit conversion from <see cref="T:Fusee.Engine.ColorUint"/> to <see cref="T:Fusee.Math.float3"/>.
+        /// Performs an implicit conversion from <see cref="T:Fusee.Engine.ColorUint"/> to <see cref="T:Fusee.Math.float3"/>.
         /// </summary>
-        /// <param name="value">The value.</param>
+        /// <param name="value">The color value. It is expected to be in SRgb color space - will be transformed to linear space in order to perform the lighting calculation correctly.</param>
         /// <returns>
         /// The result of the conversion.
         /// </returns>
-        public static explicit operator float3(ColorUint value)
+        public static implicit operator float3(ColorUint value)
         {
-            return new float3((float)value.R / (float)byte.MaxValue, (float)value.G / (float)byte.MaxValue, (float)value.B / (float)byte.MaxValue);
+            return float3.LinearColorFromSRgb(new float3(value.R / (float)byte.MaxValue, value.G / (float)byte.MaxValue, value.B / (float)byte.MaxValue));
         }
 
         /// <summary>
-        /// Performs an explicit conversion from <see cref="T:Fusee.Engine.ColorUint"/> to <see cref="T:Fusee.Math.float4"/>.
+        /// Performs an implicit conversion from <see cref="T:Fusee.Engine.ColorUint"/> to <see cref="T:Fusee.Math.float4"/>.
         /// </summary>
-        /// <param name="value">The value.</param>
+        /// <param name="value">The color value. It is expected to be in SRgb color space - will be transformed to linear space in order to perform the lighting calculation correctly.</param>
         /// <returns>
         /// The result of the conversion.
         /// </returns>
-        public static explicit operator float4(ColorUint value)
+        public static implicit operator float4(ColorUint value)
         {
-            return new float4((float)value.R / (float)byte.MaxValue, (float)value.G / (float)byte.MaxValue, (float)value.B / (float)byte.MaxValue, (float)value.A / (float)byte.MaxValue);
+            return float4.LinearColorFromSRgb(new float4(value.R / (float)byte.MaxValue, value.G / (float)byte.MaxValue, value.B / (float)byte.MaxValue, value.A / (float)byte.MaxValue));
         }
 
         /// <summary>
         /// Performs an explicit conversion from <see cref="T:Fusee.Math.float3"/> to <see cref="T:Fusee.Engine.ColorUint"/>.
         /// </summary>
-        /// <param name="value">The value.</param>
+        /// <param name="value">The color value. It is expected to be in SRgb color space.</param>
         /// <returns>
         /// The result of the conversion.
         /// </returns>
-        public static explicit operator ColorUint(float3 value)
+        public static implicit operator ColorUint(float3 value)
         {
             return new ColorUint(value.x, value.y, value.z, 1f);
         }
@@ -423,11 +422,11 @@ namespace Fusee.Base.Common
         /// <summary>
         /// Performs an explicit conversion from <see cref="T:Fusee.Math.float4"/> to <see cref="T:Fusee.Engine.ColorUint"/>.
         /// </summary>
-        /// <param name="value">The value.</param>
+        /// <param name="value">The value. It is expected to be in SRgb color space.</param>
         /// <returns>
         /// The result of the conversion.
         /// </returns>
-        public static explicit operator ColorUint(float4 value)
+        public static implicit operator ColorUint(float4 value)
         {
             return new ColorUint(value.x, value.y, value.z, value.w);
         }
@@ -612,18 +611,6 @@ namespace Fusee.Base.Common
         }
 
         /// <summary>
-        /// Converts the color into a three component vector.
-        /// </summary>
-        /// <returns>
-        /// A three component vector containing the red, green, and blue components of the color.
-        /// </returns>
-        [Obsolete("Deprecated due to 'Impure Method Call Warning' and problems with JSIL. Use 'static float3 Tofloat3(ColorUint col)' instead!")]
-        public float3 Tofloat3()
-        {
-            return new float3((float)this.R / (float)byte.MaxValue, (float)this.G / (float)byte.MaxValue, (float)this.B / (float)byte.MaxValue);
-        }
-
-        /// <summary>
         /// Converts the Uint color into a three component vector.
         /// </summary>
         /// <param name="col">The color to convert.</param>
@@ -633,18 +620,6 @@ namespace Fusee.Base.Common
         public static float3 Tofloat3(ColorUint col)
         {
             return new float3((float)col.R / (float)byte.MaxValue, (float)col.G / (float)byte.MaxValue, (float)col.B / (float)byte.MaxValue);
-        }
-
-        /// <summary>
-        /// Converts the color into a four component vector.
-        /// </summary>
-        /// <returns>
-        /// A four component vector containing all four color components.
-        /// </returns>
-        [Obsolete("Deprecated due to 'Impure Method Call Warning' and problems with JSIL. Use 'static float3 Tofloat4(ColorUint col)' instead!")]
-        public float4 Tofloat4()
-        {
-            return new float4((float)this.R / (float)byte.MaxValue, (float)this.G / (float)byte.MaxValue, (float)this.B / (float)byte.MaxValue, (float)this.A / (float)byte.MaxValue);
         }
 
         /// <summary>

--- a/src/Engine/Core/Effects/Attributes.cs
+++ b/src/Engine/Core/Effects/Attributes.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 namespace Fusee.Engine.Core.Effects
 {
@@ -93,14 +93,19 @@ namespace Fusee.Engine.Core.Effects
         Method = 16,
 
         /// <summary>
+        /// The shader shard the surface output method of the source shader.
+        /// </summary>
+        SurfOut = 32,
+
+        /// <summary>
         /// The shader shard is, or is part of, the main method of the source shader.
         /// </summary>
-        Main = 31,
+        Main = 63,
 
         /// <summary>
         /// Describes a matrix, like the mvp matrix. 
         /// Those are uniforms in the shader code but should not be properties of a <see cref="SurfaceEffect"/> because they will be updated by the SceneRenderer.
         /// </summary>
-        Matrix = 62
+        Matrix = 127
     }
 }

--- a/src/Engine/Core/Effects/SurfaceEffect.cs
+++ b/src/Engine/Core/Effects/SurfaceEffect.cs
@@ -83,14 +83,14 @@ namespace Fusee.Engine.Core.Effects
         /// Shader Shard Method to modify the <see cref="SurfaceOutput"/>.
         /// </summary>
         [FxShader(ShaderCategory.Fragment)]
-        [FxShard(ShardCategory.Method)]
+        [FxShard(ShardCategory.SurfOut)]
         public static string SurfOutFragMethod;
 
         /// <summary>
         /// Shader Shard Method to modify the <see cref="SurfaceOutput"/>.
         /// </summary>
         [FxShader(ShaderCategory.Vertex)]
-        [FxShard(ShardCategory.Method)]
+        [FxShard(ShardCategory.SurfOut)]
         public static string SurfOutVertMethod;
         //======================================================//
 
@@ -217,6 +217,7 @@ namespace Fusee.Engine.Core.Effects
                     case ShardCategory.Main:
                     case ShardCategory.Property:
                     case ShardCategory.Method:
+                    case ShardCategory.SurfOut:
 
                         if (prop.GetAccessors(false).Any(x => x.IsStatic) && prop.PropertyType == typeof(string))
                             HandleShard(shaderAttribute.ShaderCategory, shardAttribute, (string)prop.GetValue(this));
@@ -285,6 +286,7 @@ namespace Fusee.Engine.Core.Effects
                     case ShardCategory.Main:
                     case ShardCategory.Property:
                     case ShardCategory.Method:
+                    case ShardCategory.SurfOut:
                         if (field.IsStatic && field.FieldType == typeof(string))
                         {
                             var val = (string)field.GetValue(this);

--- a/src/Engine/Core/FusSceneConverter.cs
+++ b/src/Engine/Core/FusSceneConverter.cs
@@ -525,37 +525,12 @@ namespace Fusee.Engine.Core
 
         #region Make Effect
 
-        private static float3 GammaCorrection(float3 color, float gamma)
-        {
-           
-            return new float3(MathF.Pow(color.r, gamma), MathF.Pow(color.g, gamma), MathF.Pow(color.b, gamma));
-        }
-
-        public static float Step(float edge, float val) 
-        {
-            return val < edge ? 0.0f : 1.0f;
-        }
-
-        public static float3 Step(float3 edge, float3 val)
-        {
-            return new float3(Step(edge.x, val.x), Step(edge.y, val.y), Step(edge.z, val.z));
-        }
-
         private static float3 EncodeSRGB(float3 linearRGB)
         {
             float3 a = 12.92f * linearRGB;
             float g = 1.0f / 2.4f;
-            float3 b = 1.055f * new float3(MathF.Pow(linearRGB.r, g), MathF.Pow(linearRGB.g, g), MathF.Pow(linearRGB.b, g)) - 0.055f;
-            float3 c = Step(new float3(0.0031308f, 0.0031308f, 0.0031308f), linearRGB);
-            return float3.Lerp(a, b, c);
-        }
-
-        private static float3 DecodeSRGB(float3 screenRGB)
-        {
-            float3 a = screenRGB / 12.92f;
-            float3 col = (screenRGB + 0.055f) / 1.055f;
-            float3 b = new float3(MathF.Pow(col.r, 2.4f), MathF.Pow(col.g, 2.4f), MathF.Pow(col.b, 2.4f));
-            float3 c = Step(new float3(0.04045f, 0.04045f, 0.04045f), screenRGB);
+            float3 b = 1.055f * new float3((float)System.Math.Pow(linearRGB.r, g), (float)System.Math.Pow(linearRGB.g, g), (float)System.Math.Pow(linearRGB.b, g)) - 0.055f;
+            float3 c = float3.Step(new float3(0.0031308f, 0.0031308f, 0.0031308f), linearRGB);
             return float3.Lerp(a, b, c);
         }
        
@@ -729,6 +704,15 @@ namespace Fusee.Engine.Core
             return _convertedScene;
         }
 
+        private static float3 DecodeSRGB(float3 screenRGB)
+        {
+            float3 a = screenRGB / 12.92f;
+            float3 col = (screenRGB + 0.055f) / 1.055f;
+            float3 b = new float3(MathF.Pow(col.r, 2.4f), MathF.Pow(col.g, 2.4f), MathF.Pow(col.b, 2.4f));
+            float3 c = float3.Step(new float3(0.04045f, 0.04045f, 0.04045f), screenRGB);
+            return float3.Lerp(a, b, c);
+        }
+
         #region Visitors
 
         /// <summary>
@@ -864,7 +848,7 @@ namespace Fusee.Engine.Core
                     var surfaceInput = (TextureInputBRDF)effect.SurfaceInput;
                     mat.Albedo = new AlbedoChannel()
                     {
-                        Color = surfaceInput.Albedo
+                        Color = new float4(DecodeSRGB(surfaceInput.Albedo.rgb), surfaceInput.Albedo.a)
                     };
 
                     if (surfaceInput.AlbedoTex != null)
@@ -898,7 +882,7 @@ namespace Fusee.Engine.Core
                     var surfaceInput = (BRDFInput)effect.SurfaceInput;
                     mat.Albedo = new AlbedoChannel()
                     {
-                        Color = surfaceInput.Albedo
+                        Color = new float4(DecodeSRGB(surfaceInput.Albedo.rgb), surfaceInput.Albedo.a)
                     };
                     mat.BRDF = new BRDFChannel()
                     {
@@ -925,7 +909,7 @@ namespace Fusee.Engine.Core
 
                     mat.Albedo = new AlbedoChannel()
                     {
-                        Color = surfaceInput.Albedo
+                        Color = new float4(DecodeSRGB(surfaceInput.Albedo.rgb), surfaceInput.Albedo.a)
                     };
 
                     if (surfaceInput.AlbedoTex != null)
@@ -955,7 +939,7 @@ namespace Fusee.Engine.Core
                     var surfaceInput = (SpecularInput)effect.SurfaceInput;
                     mat.Albedo = new AlbedoChannel()
                     {
-                        Color = surfaceInput.Albedo
+                        Color = new float4(DecodeSRGB(surfaceInput.Albedo.rgb), surfaceInput.Albedo.a)
                     };
 
                     mat.Specular = new SpecularChannel()

--- a/src/Engine/Core/FusSceneConverter.cs
+++ b/src/Engine/Core/FusSceneConverter.cs
@@ -583,7 +583,7 @@ namespace Fusee.Engine.Core
             else if (lightingSetup == LightingSetupFlags.BlinnPhong)
                 sfx = MakeEffect.FromDiffuseSpecular(m.Albedo.Color, emissive, m.Specular.Shininess, m.Specular.Strength);
             else if (lightingSetup == LightingSetupFlags.DiffuseOnly)
-                sfx = MakeEffect.FromDiffuseSpecular(m.Albedo.Color, emissive, 0, 0);
+                sfx = MakeEffect.FromDiffuseSpecular(m.Albedo.Color, emissive);
             else
                 throw new System.ArgumentException("Material couldn't be resolved.");
 
@@ -652,7 +652,7 @@ namespace Fusee.Engine.Core
             else if (lightingSetup == LightingSetupFlags.BRDF)
                 sfx = MakeEffect.FromBRDF(m.Albedo.Color, emissive, m.BRDF.Roughness, m.BRDF.Metallic, m.BRDF.Specular, m.BRDF.IOR, m.BRDF.Subsurface);
             else if (lightingSetup == LightingSetupFlags.DiffuseOnly)
-                sfx = MakeEffect.FromDiffuseSpecular(m.Albedo.Color, emissive, 0, 0);
+                sfx = MakeEffect.FromDiffuseSpecular(m.Albedo.Color, emissive);
             else
                 throw new System.ArgumentException("Material couldn't be resolved.");
 

--- a/src/Engine/Core/FusSceneConverter.cs
+++ b/src/Engine/Core/FusSceneConverter.cs
@@ -533,7 +533,7 @@ namespace Fusee.Engine.Core
             float3 c = float3.Step(new float3(0.0031308f, 0.0031308f, 0.0031308f), linearRGB);
             return float3.Lerp(a, b, c);
         }
-       
+
         private Effect LookupMaterial(FusMaterialStandard m)
         {
             if (_matMap.TryGetValue(m, out var sfx)) return sfx;

--- a/src/Engine/Core/FusSceneConverter.cs
+++ b/src/Engine/Core/FusSceneConverter.cs
@@ -7,7 +7,6 @@ using Fusee.Math.Core;
 using Fusee.Serialization;
 using Fusee.Serialization.V1;
 using Fusee.Xene;
-using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -15,7 +14,7 @@ using System.Linq;
 namespace Fusee.Engine.Core
 {
     /// <summary>
-    /// Use <see cref="ConvertFrom(FusFile)"/> and <see cref="ConvertTo(SceneContainer)"/>, to create new high/low level graph from a low/high level graph (made out of scene nodes and components)
+    /// Use <see cref="ConvertFrom(FusFile, string)"/> and <see cref="ConvertTo(SceneContainer)"/>, to create new high/low level graph from a low/high level graph (made out of scene nodes and components)
     /// in order to have each visited element converted and/or split into its high/low level, render-ready/serialization-ready components.
     /// </summary>
     public static class FusSceneConverter

--- a/src/Engine/Core/FusSceneConverter.cs
+++ b/src/Engine/Core/FusSceneConverter.cs
@@ -15,7 +15,7 @@ using System.Linq;
 namespace Fusee.Engine.Core
 {
     /// <summary>
-    /// Use <see cref="ConvertFrom(FusFile)"/> and <see cref="ConvertTo(SceneContainer)"/>, to create new high/low level graph from a low/high level graph (made out of scene nodes and components)
+    /// Use <see cref="ConvertFrom(FusFile, string)"/> and <see cref="ConvertTo(SceneContainer)"/>, to create new high/low level graph from a low/high level graph (made out of scene nodes and components)
     /// in order to have each visited element converted and/or split into its high/low level, render-ready/serialization-ready components.
     /// </summary>
     public static class FusSceneConverter
@@ -525,6 +525,40 @@ namespace Fusee.Engine.Core
 
         #region Make Effect
 
+        private static float3 GammaCorrection(float3 color, float gamma)
+        {
+           
+            return new float3(MathF.Pow(color.r, gamma), MathF.Pow(color.g, gamma), MathF.Pow(color.b, gamma));
+        }
+
+        public static float Step(float edge, float val) 
+        {
+            return val < edge ? 0.0f : 1.0f;
+        }
+
+        public static float3 Step(float3 edge, float3 val)
+        {
+            return new float3(Step(edge.x, val.x), Step(edge.y, val.y), Step(edge.z, val.z));
+        }
+
+        private static float3 EncodeSRGB(float3 linearRGB)
+        {
+            float3 a = 12.92f * linearRGB;
+            float g = 1.0f / 2.4f;
+            float3 b = 1.055f * new float3(MathF.Pow(linearRGB.r, g), MathF.Pow(linearRGB.g, g), MathF.Pow(linearRGB.b, g)) - 0.055f;
+            float3 c = Step(new float3(0.0031308f, 0.0031308f, 0.0031308f), linearRGB);
+            return float3.Lerp(a, b, c);
+        }
+
+        private static float3 DecodeSRGB(float3 screenRGB)
+        {
+            float3 a = screenRGB / 12.92f;
+            float3 col = (screenRGB + 0.055f) / 1.055f;
+            float3 b = new float3(MathF.Pow(col.r, 2.4f), MathF.Pow(col.g, 2.4f), MathF.Pow(col.b, 2.4f));
+            float3 c = Step(new float3(0.04045f, 0.04045f, 0.04045f), screenRGB);
+            return float3.Lerp(a, b, c);
+        }
+       
         private Effect LookupMaterial(FusMaterialStandard m)
         {
             if (_matMap.TryGetValue(m, out var sfx)) return sfx;
@@ -547,7 +581,7 @@ namespace Fusee.Engine.Core
                     };
                     _texMap.Add(m.Albedo.Texture, albedoTex);
                 }
-                sfx = MakeEffect.FromDiffuseSpecularAlbedoTexture(m.Albedo.Color, emissive, m.Specular.Shininess, albedoTex, m.Albedo.Mix, float2.One);
+                sfx = MakeEffect.FromDiffuseSpecularAlbedoTexture(new float4(EncodeSRGB(m.Albedo.Color.rgb), m.Albedo.Color.a), emissive, m.Specular.Shininess, albedoTex, m.Albedo.Mix, float2.One);
             }
             else if (!lightingSetup.HasFlag(LightingSetupFlags.AlbedoTex) && lightingSetup.HasFlag(LightingSetupFlags.NormalMap))
             {
@@ -559,7 +593,7 @@ namespace Fusee.Engine.Core
                     };
                     _texMap.Add(m.NormalMap.Texture, normalTex);
                 }
-                sfx = MakeEffect.FromDiffuseSpecularNormalTexture(m.Albedo.Color, emissive, m.Specular.Shininess, normalTex, m.NormalMap.Intensity, float2.One);
+                sfx = MakeEffect.FromDiffuseSpecularNormalTexture(new float4(EncodeSRGB(m.Albedo.Color.rgb), m.Albedo.Color.a), emissive, m.Specular.Shininess, normalTex, m.NormalMap.Intensity, float2.One);
             }
             else if (lightingSetup.HasFlag(LightingSetupFlags.AlbedoTex) && lightingSetup.HasFlag(LightingSetupFlags.NormalMap))
             {
@@ -579,12 +613,12 @@ namespace Fusee.Engine.Core
                     };
                     _texMap.Add(m.NormalMap.Texture, normalTex);
                 }
-                sfx = MakeEffect.FromDiffuseSpecularTexture(m.Albedo.Color, emissive, m.Specular.Shininess, albedoTex, normalTex, m.Albedo.Mix, float2.One, m.NormalMap.Intensity);
+                sfx = MakeEffect.FromDiffuseSpecularTexture(new float4(EncodeSRGB(m.Albedo.Color.rgb), m.Albedo.Color.a), emissive, m.Specular.Shininess, albedoTex, normalTex, m.Albedo.Mix, float2.One, m.NormalMap.Intensity);
             }
             else if (lightingSetup == LightingSetupFlags.BlinnPhong)
-                sfx = MakeEffect.FromDiffuseSpecular(m.Albedo.Color, emissive, m.Specular.Shininess, m.Specular.Strength);
+                sfx = MakeEffect.FromDiffuseSpecular(new float4(EncodeSRGB(m.Albedo.Color.rgb), m.Albedo.Color.a), emissive, m.Specular.Shininess, m.Specular.Strength);
             else if (lightingSetup == LightingSetupFlags.DiffuseOnly)
-                sfx = MakeEffect.FromDiffuseSpecular(m.Albedo.Color, emissive, 0, 0);
+                sfx = MakeEffect.FromDiffuseSpecular(new float4(EncodeSRGB(m.Albedo.Color.rgb), m.Albedo.Color.a), emissive, 0, 0);
             else
                 throw new System.ArgumentException("Material couldn't be resolved.");
 

--- a/src/Engine/Core/MakeEffect.cs
+++ b/src/Engine/Core/MakeEffect.cs
@@ -675,9 +675,6 @@ namespace Fusee.Engine.Core
             frag.Append(Lighting.BRDFSpecularComponent());
             frag.Append(Lighting.AttenuationPointComponent());
             frag.Append(Lighting.AttenuationConeComponent());
-            frag.Append(Lighting.GammaCorrection());
-            frag.Append(Lighting.EncodeSRGB());
-            frag.Append(Lighting.DecodeSRGB());
 
             frag.Append(Lighting.ApplyLightDeferred(lc, isCascaded, numberOfCascades, debugCascades));
 

--- a/src/Engine/Core/MakeEffect.cs
+++ b/src/Engine/Core/MakeEffect.cs
@@ -675,6 +675,9 @@ namespace Fusee.Engine.Core
             frag.Append(Lighting.BRDFSpecularComponent());
             frag.Append(Lighting.AttenuationPointComponent());
             frag.Append(Lighting.AttenuationConeComponent());
+            frag.Append(Lighting.GammaCorrection());
+            frag.Append(Lighting.EncodeSRGB());
+            frag.Append(Lighting.DecodeSRGB());
 
             frag.Append(Lighting.ApplyLightDeferred(lc, isCascaded, numberOfCascades, debugCascades));
 

--- a/src/Engine/Core/MakeEffect.cs
+++ b/src/Engine/Core/MakeEffect.cs
@@ -21,7 +21,7 @@ namespace Fusee.Engine.Core
         /// <summary>
         /// The default <see cref="Effect"/>, that is used if a <see cref="SceneNode"/> has a mesh but no effect.
         /// </summary>
-        public static SurfaceEffect Default { get; } = FromDiffuseSpecular(new float4(0.5f, 0.5f, 0.5f, 1.0f), new float4(), 22);
+        public static SurfaceEffect Default { get; } = FromDiffuseSpecular(new float4(0.5f, 0.5f, 0.5f, 1.0f), new float4(), 22, 1.0f);
 
         #region Deferred
 
@@ -404,7 +404,7 @@ namespace Fusee.Engine.Core
         /// <param name="shininess">The resulting effect's shininess.</param>
         /// <param name="specularStrength">The resulting effects specular intensity.</param>
         /// <returns>A ShaderEffect ready to use as a component in scene graphs.</returns>
-        public static DefaultSurfaceEffect FromDiffuseSpecular(float4 albedoColor, float4 emissionColor, float shininess, float specularStrength = 0.5f)
+        public static DefaultSurfaceEffect FromDiffuseSpecular(float4 albedoColor, float4 emissionColor, float shininess = 255, float specularStrength = 0.0f)
         {
             var input = new SpecularInput()
             {

--- a/src/Engine/Core/RenderContext.cs
+++ b/src/Engine/Core/RenderContext.cs
@@ -268,21 +268,21 @@ namespace Fusee.Engine.Core
                 _transModelViewOk = false;
                 _transModelViewProjectionOk = false;
 
-                SetGlobalEffectParam(ShaderShards.UniformNameDeclarations.Model, _model);
-                SetGlobalEffectParam(ShaderShards.UniformNameDeclarations.ModelView, ModelView);
-                SetGlobalEffectParam(ShaderShards.UniformNameDeclarations.ModelViewProjection, ModelViewProjection);
+                SetGlobalEffectParam(UniformNameDeclarations.Model, _model);
+                SetGlobalEffectParam(UniformNameDeclarations.ModelView, ModelView);
+                SetGlobalEffectParam(UniformNameDeclarations.ModelViewProjection, ModelViewProjection);
 
-                SetGlobalEffectParam(ShaderShards.UniformNameDeclarations.IModel, InvModel);
-                SetGlobalEffectParam(ShaderShards.UniformNameDeclarations.IModelView, InvModelView);
-                SetGlobalEffectParam(ShaderShards.UniformNameDeclarations.IModelViewProjection, InvModelViewProjection);
+                SetGlobalEffectParam(UniformNameDeclarations.IModel, InvModel);
+                SetGlobalEffectParam(UniformNameDeclarations.IModelView, InvModelView);
+                SetGlobalEffectParam(UniformNameDeclarations.IModelViewProjection, InvModelViewProjection);
 
-                SetGlobalEffectParam(ShaderShards.UniformNameDeclarations.ITModel, InvTransModel);
-                SetGlobalEffectParam(ShaderShards.UniformNameDeclarations.ITModelView, InvTransModelView);
-                SetGlobalEffectParam(ShaderShards.UniformNameDeclarations.ITModelViewProjection, InvTransModelViewProjection);
+                SetGlobalEffectParam(UniformNameDeclarations.ITModel, InvTransModel);
+                SetGlobalEffectParam(UniformNameDeclarations.ITModelView, InvTransModelView);
+                SetGlobalEffectParam(UniformNameDeclarations.ITModelViewProjection, InvTransModelViewProjection);
 
-                SetGlobalEffectParam(ShaderShards.UniformNameDeclarations.TModel, TransModel);
-                SetGlobalEffectParam(ShaderShards.UniformNameDeclarations.TModelView, TransModelView);
-                SetGlobalEffectParam(ShaderShards.UniformNameDeclarations.TModelViewProjection, TransModelViewProjection);
+                SetGlobalEffectParam(UniformNameDeclarations.TModel, TransModel);
+                SetGlobalEffectParam(UniformNameDeclarations.TModelView, TransModelView);
+                SetGlobalEffectParam(UniformNameDeclarations.TModelViewProjection, TransModelViewProjection);
             }
         }
 

--- a/src/Engine/Core/RenderContext.cs
+++ b/src/Engine/Core/RenderContext.cs
@@ -1032,7 +1032,6 @@ namespace Fusee.Engine.Core
                     else
                     {
                         renderDependentShards.Add(new KeyValuePair<ShardCategory, string>(ShardCategory.Property, ShaderShards.Fragment.FragProperties.GBufferOut()));
-                        renderDependentShards.Add(new KeyValuePair<ShardCategory, string>(ShardCategory.Method, ShaderShards.Fragment.Lighting.ColorManagementMethods()));
                         renderDependentShards.Add(new KeyValuePair<ShardCategory, string>(ShardCategory.Main, ShaderShards.Fragment.FragMain.RenderToGBuffer(surfEffect.LightingSetup, nameof(surfEffect.SurfaceInput), SurfaceOut.StructName)));
                     }
 

--- a/src/Engine/Core/RenderContext.cs
+++ b/src/Engine/Core/RenderContext.cs
@@ -1032,6 +1032,7 @@ namespace Fusee.Engine.Core
                     else
                     {
                         renderDependentShards.Add(new KeyValuePair<ShardCategory, string>(ShardCategory.Property, ShaderShards.Fragment.FragProperties.GBufferOut()));
+                        renderDependentShards.Add(new KeyValuePair<ShardCategory, string>(ShardCategory.Method, ShaderShards.Fragment.Lighting.ColorManagementMethods()));
                         renderDependentShards.Add(new KeyValuePair<ShardCategory, string>(ShardCategory.Main, ShaderShards.Fragment.FragMain.RenderToGBuffer(surfEffect.LightingSetup, nameof(surfEffect.SurfaceInput), SurfaceOut.StructName)));
                     }
 

--- a/src/Engine/Core/SceneRendererForward.cs
+++ b/src/Engine/Core/SceneRendererForward.cs
@@ -27,7 +27,7 @@ namespace Fusee.Engine.Core
 
         /// <summary>
         /// Enables or disables Frustum Culling.
-        /// If we render with one or more cameras this value will be overwritten by <see cref="CameraComponent.FrustumCullingOn"/>.
+        /// If we render with one or more cameras this value will be overwritten by <see cref="Camera.FrustumCullingOn"/>.
         /// </summary>
         public bool DoFrumstumCulling = true;
 

--- a/src/Engine/Core/SceneRendererForward.cs
+++ b/src/Engine/Core/SceneRendererForward.cs
@@ -109,7 +109,7 @@ namespace Fusee.Engine.Core
                     Active = true,
                     Strength = 1.0f,
                     MaxDistance = 0.0f,
-                    Color = new float4(1.0f, 1.0f, 1.0f, 1f),
+                    Color = new float4(1f, 1f, 1f, 1f),
                     OuterConeAngle = 45f,
                     InnerConeAngle = 35f,
                     Type = LightType.Legacy,

--- a/src/Engine/Core/ShaderShards/Fragment/FragMain.cs
+++ b/src/Engine/Core/ShaderShards/Fragment/FragMain.cs
@@ -32,13 +32,13 @@ namespace Fusee.Engine.Core.ShaderShards.Fragment
                         "result += ApplyLight(allLights[i], surfOut, ambientCo);",
                     "}",
                     //$"oFragmentColor = vec4(GammaCorrection(result.rgb, 1.0/2.0)+ ambient, surfOut.albedo.a);"
-                    $"oFragmentColor = vec4(result.rgb + ambient, surfOut.albedo.a);"
+                    $"oFragmentColor = vec4(EncodeSRGB(result.rgb) + ambient, surfOut.albedo.a);"
                 });
             }
             else
             {
                 //fragMainBody.Add("oFragmentColor = vec4(GammaCorrection(surfOut.albedo.rgb, 1.0/2.0), surfOut.albedo.a);");
-                fragMainBody.Add("oFragmentColor = surfOut.albedo;");
+                fragMainBody.Add("oFragmentColor = vec4(EncodeSRGB(surfOut.albedo.rgb), surfOut.albedo.a);");
             }
 
             return GLSL.MainMethod(fragMainBody);

--- a/src/Engine/Core/ShaderShards/Fragment/FragMain.cs
+++ b/src/Engine/Core/ShaderShards/Fragment/FragMain.cs
@@ -23,7 +23,7 @@ namespace Fusee.Engine.Core.ShaderShards.Fragment
                 fragMainBody.AddRange(
                 new List<string>()
                 {
-                    $"float ambientCo = 0.2;",
+                    $"float ambientCo = 0.1;",
                     $"vec3 ambient = vec3(ambientCo, ambientCo, ambientCo) * surfOut.albedo.rgb;",
                     $"vec3 result = vec3(0.0);",
                     $"for(int i = 0; i < {Lighting.NumberOfLightsForward}; i++)",
@@ -31,11 +31,15 @@ namespace Fusee.Engine.Core.ShaderShards.Fragment
                         "if(allLights[i].isActive == 0) continue;",
                         "result += ApplyLight(allLights[i], surfOut, ambientCo);",
                     "}",
-                    $"oFragmentColor = vec4(result.rgb + ambient, surfOut.albedo.a);"
+                    //$"oFragmentColor = vec4(GammaCorrection(result.rgb, 1.0/2.0)+ ambient, surfOut.albedo.a);"
+                    $"oFragmentColor = vec4(EncodeSRGB(result.rgb) + ambient, surfOut.albedo.a);"
                 });
             }
             else
-                fragMainBody.Add("oFragmentColor = surfOut.albedo;");
+            {
+                //fragMainBody.Add("oFragmentColor = vec4(GammaCorrection(surfOut.albedo.rgb, 1.0/2.0), surfOut.albedo.a);");
+                fragMainBody.Add("oFragmentColor = vec4(EncodeSRGB(surfOut.albedo.rgb), surfOut.albedo.a);");
+            }
 
             return GLSL.MainMethod(fragMainBody);
         }

--- a/src/Engine/Core/ShaderShards/Fragment/FragMain.cs
+++ b/src/Engine/Core/ShaderShards/Fragment/FragMain.cs
@@ -32,13 +32,13 @@ namespace Fusee.Engine.Core.ShaderShards.Fragment
                         "result += ApplyLight(allLights[i], surfOut, ambientCo);",
                     "}",
                     //$"oFragmentColor = vec4(GammaCorrection(result.rgb, 1.0/2.0)+ ambient, surfOut.albedo.a);"
-                    $"oFragmentColor = vec4(EncodeSRGB(result.rgb) + ambient, surfOut.albedo.a);"
+                    $"oFragmentColor = vec4(result.rgb + ambient, surfOut.albedo.a);"
                 });
             }
             else
             {
                 //fragMainBody.Add("oFragmentColor = vec4(GammaCorrection(surfOut.albedo.rgb, 1.0/2.0), surfOut.albedo.a);");
-                fragMainBody.Add("oFragmentColor = vec4(EncodeSRGB(surfOut.albedo.rgb), surfOut.albedo.a);");
+                fragMainBody.Add("oFragmentColor = surfOut.albedo;");
             }
 
             return GLSL.MainMethod(fragMainBody);

--- a/src/Engine/Core/ShaderShards/Fragment/FragShards.cs
+++ b/src/Engine/Core/ShaderShards/Fragment/FragShards.cs
@@ -80,7 +80,7 @@ namespace Fusee.Engine.Core.ShaderShards.Fragment
                 res.Add($"vec4 texCol = texture(IN.AlbedoTex, {VaryingNameDeclarations.TextureCoordinates} * IN.TexTiles);");
                 res.Add($"texCol = vec4(DecodeSRGB(texCol.rgb), texCol.a);");
                 res.Add("float linearLuminance = (0.2126 * texCol.r) + (0.7152 * texCol.g) + (0.0722 * texCol.b);");
-                res.Add($"vec3 mix = mix(IN.Albedo.rgb * linearLuminance, texCol.xyz, IN.AlbedoMix);");                
+                res.Add($"vec3 mix = mix(IN.Albedo.rgb * linearLuminance, texCol.xyz, IN.AlbedoMix);");
                 res.Add($"OUT.albedo = vec4(mix, texCol.a);");
             }
             else

--- a/src/Engine/Core/ShaderShards/Fragment/FragShards.cs
+++ b/src/Engine/Core/ShaderShards/Fragment/FragShards.cs
@@ -78,6 +78,7 @@ namespace Fusee.Engine.Core.ShaderShards.Fragment
             if (lightingSetup.HasFlag(LightingSetupFlags.AlbedoTex))
             {
                 res.Add($"vec4 texCol = texture(IN.AlbedoTex, {VaryingNameDeclarations.TextureCoordinates} * IN.TexTiles);");
+                res.Add($"texCol = vec4(DecodeSRGB(texCol.rgb), texCol.a);");
                 res.Add($"vec3 mix = mix(IN.Albedo.rgb, texCol.xyz, IN.AlbedoMix);");
                 res.Add("float luma = pow((0.2126 * texCol.r) + (0.7152 * texCol.g) + (0.0722 * texCol.b), 1.0/2.2);");
                 res.Add($"OUT.albedo = vec4(mix * luma, texCol.a);");

--- a/src/Engine/Core/ShaderShards/Fragment/FragShards.cs
+++ b/src/Engine/Core/ShaderShards/Fragment/FragShards.cs
@@ -79,9 +79,9 @@ namespace Fusee.Engine.Core.ShaderShards.Fragment
             {
                 res.Add($"vec4 texCol = texture(IN.AlbedoTex, {VaryingNameDeclarations.TextureCoordinates} * IN.TexTiles);");
                 res.Add($"texCol = vec4(DecodeSRGB(texCol.rgb), texCol.a);");
-                res.Add($"vec3 mix = mix(IN.Albedo.rgb, texCol.xyz, IN.AlbedoMix);");
-                res.Add("float luma = pow((0.2126 * texCol.r) + (0.7152 * texCol.g) + (0.0722 * texCol.b), 1.0/2.2);");
-                res.Add($"OUT.albedo = vec4(mix * luma, texCol.a);");
+                res.Add("float linearLuminance = (0.2126 * texCol.r) + (0.7152 * texCol.g) + (0.0722 * texCol.b);");
+                res.Add($"vec3 mix = mix(IN.Albedo.rgb * linearLuminance, texCol.xyz, IN.AlbedoMix);");                
+                res.Add($"OUT.albedo = vec4(mix, texCol.a);");
             }
             else
                 res.Add("OUT.albedo = IN.Albedo;");

--- a/src/Engine/Core/ShaderShards/Fragment/FragShards.cs
+++ b/src/Engine/Core/ShaderShards/Fragment/FragShards.cs
@@ -78,7 +78,6 @@ namespace Fusee.Engine.Core.ShaderShards.Fragment
             if (lightingSetup.HasFlag(LightingSetupFlags.AlbedoTex))
             {
                 res.Add($"vec4 texCol = texture(IN.AlbedoTex, {VaryingNameDeclarations.TextureCoordinates} * IN.TexTiles);");
-                res.Add($"texCol = vec4(DecodeSRGB(texCol.rgb), texCol.a);");
                 res.Add($"vec3 mix = mix(IN.Albedo.rgb, texCol.xyz, IN.AlbedoMix);");
                 res.Add("float luma = pow((0.2126 * texCol.r) + (0.7152 * texCol.g) + (0.0722 * texCol.b), 1.0/2.2);");
                 res.Add($"OUT.albedo = vec4(mix * luma, texCol.a);");

--- a/src/Engine/Core/ShaderShards/Fragment/Lighting.cs
+++ b/src/Engine/Core/ShaderShards/Fragment/Lighting.cs
@@ -663,7 +663,6 @@ namespace Fusee.Engine.Core.ShaderShards.Fragment
         /// </summary>
         public static string DecodeSRGB()
         {
-
             var methodBody = new List<string>
             {
                 "vec3 a = screenRGB / 12.92;",

--- a/src/Engine/Core/ShaderShards/Fragment/Lighting.cs
+++ b/src/Engine/Core/ShaderShards/Fragment/Lighting.cs
@@ -643,7 +643,7 @@ namespace Fusee.Engine.Core.ShaderShards.Fragment
         /// </summary>
         public static string EncodeSRGB()
         {
-            var methodBody = new List<string> 
+            var methodBody = new List<string>
             {
                 "vec3 a = 12.92 * linearRGB;",
                 "vec3 b = 1.055 * pow(linearRGB, vec3(1.0 / 2.4)) - 0.055;",
@@ -690,7 +690,7 @@ namespace Fusee.Engine.Core.ShaderShards.Fragment
                 {
                     GLSL.CreateVar(GLSL.Type.Vec3, "color"),
                     GLSL.CreateVar(GLSL.Type.Float, "g")
-                }, methodBody );
+                }, methodBody);
         }
 
         /// <summary>

--- a/src/Engine/Core/ShaderShards/Fragment/Lighting.cs
+++ b/src/Engine/Core/ShaderShards/Fragment/Lighting.cs
@@ -40,23 +40,7 @@ namespace Fusee.Engine.Core.ShaderShards.Fragment
         /// <summary>
         /// Caches "allLight[i]." names (used as uniform parameters).
         /// </summary>
-        internal static Dictionary<int, LightParamStrings> LightPararamStringsAllLights = new Dictionary<int, LightParamStrings>();
-
-        /// <summary>
-        /// Contains all methods for color management (gamma and from and to sRGB).
-        /// </summary>
-        /// <returns></returns>
-        public static string ColorManagementMethods()
-        {
-            var lighting = new List<string>
-            {
-                GammaCorrection(),
-                EncodeSRGB(),
-                DecodeSRGB()
-            };
-
-            return string.Join("\n", lighting);
-        }
+        internal static Dictionary<int, LightParamStrings> LightPararamStringsAllLights = new Dictionary<int, LightParamStrings>();        
 
         /// <summary>
         /// Collects all lighting methods, dependent on what is defined in the given <see cref="LightingSetupFlags"/> and the LightingCalculationMethod.
@@ -64,10 +48,7 @@ namespace Fusee.Engine.Core.ShaderShards.Fragment
         /// <param name="setup">The <see cref="LightingSetupFlags"/> which is used to decide which lighting methods we need.</param>
         public static string AssembleLightingMethods(LightingSetupFlags setup)
         {
-            var lighting = new List<string>
-            {
-                ColorManagementMethods()
-            };
+            var lighting = new List<string>();
 
             //Adds methods to the PS that calculate the single light components (diffuse, specular)
             if (setup.HasFlag(LightingSetupFlags.BlinnPhong))
@@ -122,6 +103,8 @@ namespace Fusee.Engine.Core.ShaderShards.Fragment
         /// <summary>
         /// Method for calculation the diffuse lighting component.
         /// Replaces the standard diffuse calculation with the one introduced in [Burley 2012, "Physically-Based Shading at Disney"].
+        /// NOTE: In theory the albedo and subsurface colors should be divided by PI or multiplied by 1/PI to maintain energy conservation. If we do this here the colors are too dark.
+        /// This may become an issue with more advanced lighting calculations. See [Akenine-Möller 2018, Real-Time-Rendering 4th Edition, p. 308 - 316].
         /// </summary>
         public static string BRDFDiffuseComponent()
         {
@@ -139,7 +122,7 @@ namespace Fusee.Engine.Core.ShaderShards.Fragment
                 "float Fss90 = LdotH * LdotH * roughness;",
                 "float Fss = mix(1.0, Fss90, FL) * mix(1.0, Fss90, FV);",
                 "float ss = 1.25 * (Fss * (1.0 / max((NdotL + NdotV), 0.001) - 0.5) + 0.5);",
-                "return mix((albedo) * Fd * NdotL, (subsurfaceColor) * ss, subsurface);"
+                "return mix(albedo * Fd * NdotL, subsurfaceColor * ss, subsurface);"
             };
             return GLSL.CreateMethod(GLSL.Type.Vec3, "diffuseLighting",
                 new[]
@@ -633,65 +616,9 @@ namespace Fusee.Engine.Core.ShaderShards.Fragment
             });
 
             //methodBody.Add($"{FragProperties.OutColorName} = vec4(GammaCorrection(lighting.rgb, 1.0/1.9), lighting.a);");
-            methodBody.Add($"{FragProperties.OutColorName} = vec4(EncodeSRGB(lighting.rgb), lighting.a);");
+            methodBody.Add($"{FragProperties.OutColorName} = lighting;");
 
             return GLSL.MainMethod(methodBody);
-        }
-
-        /// <summary>
-        /// Converts a color from linear space to sRGB.
-        /// </summary>
-        public static string EncodeSRGB()
-        {
-            var methodBody = new List<string> 
-            {
-                "vec3 a = 12.92 * linearRGB;",
-                "vec3 b = 1.055 * pow(linearRGB, vec3(1.0 / 2.4)) - 0.055;",
-                "vec3 c = step(vec3(0.0031308), linearRGB);",
-                "return mix(a, b, c);"
-            };
-
-            return GLSL.CreateMethod(GLSL.Type.Vec3, "EncodeSRGB",
-               new[]
-               {
-                    GLSL.CreateVar(GLSL.Type.Vec3, "linearRGB")
-               }, methodBody);
-        }
-
-        /// <summary>
-        /// Converts a color from sRGB to linear space.
-        /// </summary>
-        public static string DecodeSRGB()
-        {
-
-            var methodBody = new List<string>
-            {
-                "vec3 a = screenRGB / 12.92;",
-                "vec3 b = pow((screenRGB + 0.055) / 1.055, vec3(2.4));",
-                "vec3 c = step(vec3(0.04045), screenRGB);",
-                "return mix(a, b, c);"
-            };
-
-            return GLSL.CreateMethod(GLSL.Type.Vec3, "DecodeSRGB",
-              new[]
-              {
-                    GLSL.CreateVar(GLSL.Type.Vec3, "screenRGB")
-              }, methodBody);
-        }
-
-        /// <summary>
-        /// Method for gamma correction.
-        /// </summary>
-        public static string GammaCorrection()
-        {
-            var methodBody = new List<string> { "return pow(color, vec3(g));" };
-
-            return GLSL.CreateMethod(GLSL.Type.Vec3, "GammaCorrection",
-                new[]
-                {
-                    GLSL.CreateVar(GLSL.Type.Vec3, "color"),
-                    GLSL.CreateVar(GLSL.Type.Float, "g")
-                }, methodBody );
         }
 
         /// <summary>

--- a/src/Engine/Core/ShaderShards/Fragment/Lighting.cs
+++ b/src/Engine/Core/ShaderShards/Fragment/Lighting.cs
@@ -43,15 +43,31 @@ namespace Fusee.Engine.Core.ShaderShards.Fragment
         internal static Dictionary<int, LightParamStrings> LightPararamStringsAllLights = new Dictionary<int, LightParamStrings>();
 
         /// <summary>
+        /// Contains all methods for color management (gamma and from and to sRGB).
+        /// </summary>
+        /// <returns></returns>
+        public static string ColorManagementMethods()
+        {
+            var lighting = new List<string>
+            {
+                GammaCorrection(),
+                EncodeSRGB(),
+                DecodeSRGB()
+            };
+
+            return string.Join("\n", lighting);
+        }
+
+        /// <summary>
         /// Collects all lighting methods, dependent on what is defined in the given <see cref="LightingSetupFlags"/> and the LightingCalculationMethod.
         /// </summary>
         /// <param name="setup">The <see cref="LightingSetupFlags"/> which is used to decide which lighting methods we need.</param>
         public static string AssembleLightingMethods(LightingSetupFlags setup)
         {
-            if (setup == LightingSetupFlags.Unlit)
-                return string.Empty;
-
-            var lighting = new List<string>();
+            var lighting = new List<string>
+            {
+                ColorManagementMethods()
+            };
 
             //Adds methods to the PS that calculate the single light components (diffuse, specular)
             if (setup.HasFlag(LightingSetupFlags.BlinnPhong))
@@ -123,8 +139,7 @@ namespace Fusee.Engine.Core.ShaderShards.Fragment
                 "float Fss90 = LdotH * LdotH * roughness;",
                 "float Fss = mix(1.0, Fss90, FL) * mix(1.0, Fss90, FV);",
                 "float ss = 1.25 * (Fss * (1.0 / max((NdotL + NdotV), 0.001) - 0.5) + 0.5);",
-                "return mix((albedo / PI) * (Fd * NdotL), (subsurfaceColor / PI) * ss, subsurface);"
-
+                "return mix((albedo) * Fd * NdotL, (subsurfaceColor) * ss, subsurface);"
             };
             return GLSL.CreateMethod(GLSL.Type.Vec3, "diffuseLighting",
                 new[]
@@ -182,7 +197,7 @@ namespace Fusee.Engine.Core.ShaderShards.Fragment
                 "float denom = (NdotH * NdotH) * (alphaSqr - 1.0) + 1.0f;",
                 "D = alphaSqr / (PI * (denom * denom));",
                 "",
-                "// G (ometry - Schlick�s Approximation of Smith)",
+                "// G (ometry - Schlicks Approximation of Smith)",
                 "float r = roughness + 1.0;",
                 "float k = (r * r) / 8.0;",
                 "",
@@ -462,7 +477,7 @@ namespace Fusee.Engine.Core.ShaderShards.Fragment
             "// then calculate lighting as usual",
             "vec4 lighting = vec4(0);",
             "",
-            "float ambientCo = 0.2;",
+            "float ambientCo = 0.1;",
             "vec4 ambient = vec4(0,0,0,1);",
             "vec4 diffuse = vec4(0,0,0,1);",
             "vec4 specular = vec4(0,0,0,1);",
@@ -617,9 +632,66 @@ namespace Fusee.Engine.Core.ShaderShards.Fragment
                 "}",
             });
 
-            methodBody.Add($"{FragProperties.OutColorName} = lighting;");
+            //methodBody.Add($"{FragProperties.OutColorName} = vec4(GammaCorrection(lighting.rgb, 1.0/1.9), lighting.a);");
+            methodBody.Add($"{FragProperties.OutColorName} = vec4(EncodeSRGB(lighting.rgb), lighting.a);");
 
             return GLSL.MainMethod(methodBody);
+        }
+
+        /// <summary>
+        /// Converts a color from linear space to sRGB.
+        /// </summary>
+        public static string EncodeSRGB()
+        {
+            var methodBody = new List<string> 
+            {
+                "vec3 a = 12.92 * linearRGB;",
+                "vec3 b = 1.055 * pow(linearRGB, vec3(1.0 / 2.4)) - 0.055;",
+                "vec3 c = step(vec3(0.0031308), linearRGB);",
+                "return mix(a, b, c);"
+            };
+
+            return GLSL.CreateMethod(GLSL.Type.Vec3, "EncodeSRGB",
+               new[]
+               {
+                    GLSL.CreateVar(GLSL.Type.Vec3, "linearRGB")
+               }, methodBody);
+        }
+
+        /// <summary>
+        /// Converts a color from sRGB to linear space.
+        /// </summary>
+        public static string DecodeSRGB()
+        {
+
+            var methodBody = new List<string>
+            {
+                "vec3 a = screenRGB / 12.92;",
+                "vec3 b = pow((screenRGB + 0.055) / 1.055, vec3(2.4));",
+                "vec3 c = step(vec3(0.04045), screenRGB);",
+                "return mix(a, b, c);"
+            };
+
+            return GLSL.CreateMethod(GLSL.Type.Vec3, "DecodeSRGB",
+              new[]
+              {
+                    GLSL.CreateVar(GLSL.Type.Vec3, "screenRGB")
+              }, methodBody);
+        }
+
+        /// <summary>
+        /// Method for gamma correction.
+        /// </summary>
+        public static string GammaCorrection()
+        {
+            var methodBody = new List<string> { "return pow(color, vec3(g));" };
+
+            return GLSL.CreateMethod(GLSL.Type.Vec3, "GammaCorrection",
+                new[]
+                {
+                    GLSL.CreateVar(GLSL.Type.Vec3, "color"),
+                    GLSL.CreateVar(GLSL.Type.Float, "g")
+                }, methodBody );
         }
 
         /// <summary>

--- a/src/Engine/Core/ShaderShards/Fragment/Lighting.cs
+++ b/src/Engine/Core/ShaderShards/Fragment/Lighting.cs
@@ -40,7 +40,7 @@ namespace Fusee.Engine.Core.ShaderShards.Fragment
         /// <summary>
         /// Caches "allLight[i]." names (used as uniform parameters).
         /// </summary>
-        internal static Dictionary<int, LightParamStrings> LightPararamStringsAllLights = new Dictionary<int, LightParamStrings>();        
+        internal static Dictionary<int, LightParamStrings> LightPararamStringsAllLights = new Dictionary<int, LightParamStrings>();
 
         /// <summary>
         /// Collects all lighting methods, dependent on what is defined in the given <see cref="LightingSetupFlags"/> and the LightingCalculationMethod.
@@ -104,7 +104,7 @@ namespace Fusee.Engine.Core.ShaderShards.Fragment
         /// Method for calculation the diffuse lighting component.
         /// Replaces the standard diffuse calculation with the one introduced in [Burley 2012, "Physically-Based Shading at Disney"].
         /// NOTE: In theory the albedo and subsurface colors should be divided by PI or multiplied by 1/PI to maintain energy conservation. If we do this here the colors are too dark.
-        /// This may become an issue with more advanced lighting calculations. See [Akenine-Möller 2018, Real-Time-Rendering 4th Edition, p. 308 - 316].
+        /// This may become an issue with more advanced lighting calculations. See [Akenine-Mï¿½ller 2018, Real-Time-Rendering 4th Edition, p. 308 - 316].
         /// </summary>
         public static string BRDFDiffuseComponent()
         {

--- a/src/Engine/GUI/Assets/text.frag
+++ b/src/Engine/GUI/Assets/text.frag
@@ -14,6 +14,14 @@ uniform float AlbedoMix;
 
 out vec4 outColor;
 
+vec3 EncodeSRgb(vec3 linearRGB)
+{
+    vec3 a = 12.92 * linearRGB;
+    vec3 b = 1.055 * pow(linearRGB, vec3(1.0 / 2.4)) - 0.055;
+    vec3 c = step(vec3(0.0031308), linearRGB);
+    return mix(a, b, c);
+}
+
 void main()
 {
 	vec3 N = normalize(vMVNormal);
@@ -26,5 +34,7 @@ void main()
     objCol = vec4(mixCol, texCol.a);
     vec4 Idif = vec4(max(dot(N, L), 0.0) * lightColor, 1.0);
 
-	outColor = Idif * objCol;
+    vec4 linearOutCol = Idif * objCol;
+
+	outColor = vec4(EncodeSRgb(linearOutCol.rgb), linearOutCol.a);
 }

--- a/src/Engine/GUI/Assets/texture.frag
+++ b/src/Engine/GUI/Assets/texture.frag
@@ -14,18 +14,34 @@ uniform float AlbedoMix;
 
 out vec4 outColor;
 
+vec3 EncodeSRgb(vec3 linearRGB)
+{
+    vec3 a = 12.92 * linearRGB;
+    vec3 b = 1.055 * pow(linearRGB, vec3(1.0 / 2.4)) - 0.055;
+    vec3 c = step(vec3(0.0031308), linearRGB);
+    return mix(a, b, c);
+}
+
+vec3 DecodeSRgb(vec3 sRgb)
+{
+    vec3 a = sRgb / 12.92;
+    vec3 b = pow((sRgb + 0.055) / 1.055, vec3(2.4));
+    vec3 c = step(vec3(0.04045), sRgb);
+    return mix(a, b, c);
+}
+
 void main()
 {
 	vec3 N = normalize(vMVNormal);
 	vec3 L = vec3(0.0, 0.0, -1.0);
 
     vec3 lightColor = vec3(1.0, 1.0, 1.0);
-    vec4 objCol = vec4(0.0, 0.0, 0.0, 1.0);
     vec4 texCol = texture(AlbedoTexture, vUV * AlbedoTextureTiles);
-    vec3 mixCol = mix(Albedo.xyz, texCol.xyz, AlbedoMix);
-    float luma = pow((0.2126 * texCol.r) + (0.7152 * texCol.g) + (0.0722 * texCol.b), 1.0/2.2);
-    objCol = vec4(mixCol * luma, texCol.a);
-    vec4 Idif = vec4(max(dot(N, L), 0.0) * lightColor, 1.0);
+    
+    texCol = vec4(DecodeSRgb(texCol.rgb), texCol.a);
+    float linearLuminance = (0.2126 * texCol.r) + (0.7152 * texCol.g) + (0.0722 * texCol.b);
 
-	outColor = Idif * objCol;
+    vec3 Idif = vec3(max(dot(N, L), 0.0) * lightColor);
+    vec3 linearOutCol = Idif * mix(Albedo.rgb * linearLuminance, texCol.rgb, AlbedoMix);
+	outColor = vec4(EncodeSRgb(linearOutCol.rgb), texCol.a);
 }

--- a/src/Engine/Imp/Graphics/Android/RenderContextImp.cs
+++ b/src/Engine/Imp/Graphics/Android/RenderContextImp.cs
@@ -1830,7 +1830,7 @@ namespace Fusee.Engine.Imp.Graphics.Android
                     }
                     break;
                 case RenderState.BlendFactor:
-                    float4 col = ColorUint.FromRgba(value);
+                    float4 col = (float4)ColorUint.FromRgba(value);
                     GL.BlendColor(col.r, col.g, col.b, col.a);
                     break;
 

--- a/src/Engine/Imp/Graphics/Android/RenderContextImp.cs
+++ b/src/Engine/Imp/Graphics/Android/RenderContextImp.cs
@@ -1830,7 +1830,7 @@ namespace Fusee.Engine.Imp.Graphics.Android
                     }
                     break;
                 case RenderState.BlendFactor:
-                    float4 col = ColorUint.FromRgba(value).Tofloat4();
+                    float4 col = ColorUint.FromRgba(value);
                     GL.BlendColor(col.r, col.g, col.b, col.a);
                     break;
 

--- a/src/Engine/Player/Core/Player.cs
+++ b/src/Engine/Player/Core/Player.cs
@@ -305,7 +305,7 @@ namespace Fusee.Engine.Player.Core
                 UIElementPosition.GetAnchors(AnchorPos.StretchHorizontal),
                 UIElementPosition.CalcOffsets(AnchorPos.StretchHorizontal, new float2(_initCanvasWidth / 2 - 4, 0), _initCanvasHeight, _initCanvasWidth, new float2(8, 1)),
                 guiLatoBlack,
-                ColorUint.Greenery,
+                (float4)ColorUint.Greenery,
                 HorizontalTextAlignment.Center,
                 VerticalTextAlignment.Center);
 
@@ -334,7 +334,7 @@ namespace Fusee.Engine.Player.Core
         public void BtnLogoEnter(CodeComponent sender)
         {
             var effect = _gui.Children.FindNodes(node => node.Name == "fuseeLogo").First().GetComponent<Effect>();
-            effect.SetFxParam(UniformNameDeclarations.Albedo, new float4(0.0f, 0.0f, 0.0f, 1f));
+            effect.SetFxParam(UniformNameDeclarations.Albedo, (float4)ColorUint.Black);
             effect.SetFxParam(UniformNameDeclarations.AlbedoMix, 0.8f);
         }
 

--- a/src/Engine/Player/Core/Player.cs
+++ b/src/Engine/Player/Core/Player.cs
@@ -305,7 +305,7 @@ namespace Fusee.Engine.Player.Core
                 UIElementPosition.GetAnchors(AnchorPos.StretchHorizontal),
                 UIElementPosition.CalcOffsets(AnchorPos.StretchHorizontal, new float2(_initCanvasWidth / 2 - 4, 0), _initCanvasHeight, _initCanvasWidth, new float2(8, 1)),
                 guiLatoBlack,
-                ColorUint.Tofloat4(ColorUint.Greenery),
+                ColorUint.Greenery,
                 HorizontalTextAlignment.Center,
                 VerticalTextAlignment.Center);
 

--- a/src/Math/Core/M.cs
+++ b/src/Math/Core/M.cs
@@ -891,5 +891,10 @@ namespace Fusee.Math.Core
         }
 
         #endregion Internal Members
+
+        public static float Step(float edge, float val)
+        {
+            return val < edge ? 0.0f : 1.0f;
+        }
     }
 }

--- a/src/Math/Core/M.cs
+++ b/src/Math/Core/M.cs
@@ -867,6 +867,18 @@ namespace Fusee.Math.Core
 
         #endregion Equals
 
+        /// <summary>
+        /// Generates a step function by comparing "val" to "edge".
+        /// 0.0 is returned if "val" is smaller than "edge" and 1.0 is returned otherwise.
+        /// </summary>
+        /// <param name="edge">Specifies the location of the edge of the step function.</param>
+        /// <param name="val">Specifies the value to be used to generate the step function.</param>
+        /// <returns></returns>
+        public static float Step(float edge, float val)
+        {
+            return val < edge ? 0.0f : 1.0f;
+        }
+
         #endregion Public Members
 
         #region Internal Members
@@ -891,10 +903,5 @@ namespace Fusee.Math.Core
         }
 
         #endregion Internal Members
-
-        public static float Step(float edge, float val)
-        {
-            return val < edge ? 0.0f : 1.0f;
-        }
     }
 }

--- a/src/Math/Core/float2.cs
+++ b/src/Math/Core/float2.cs
@@ -36,6 +36,16 @@ namespace Fusee.Math.Core
         /// <summary>
         /// Constructs a new float2.
         /// </summary>
+        /// <param name="val">This value will be set for the x and y component.</param>
+        public float2(float val)
+        {
+            x = val;
+            y = val;
+        }
+
+        /// <summary>
+        /// Constructs a new float2.
+        /// </summary>
         /// <param name="x">The x coordinate of the net float2.</param>
         /// <param name="y">The y coordinate of the net float2.</param>
         public float2(float x, float y)
@@ -488,6 +498,27 @@ namespace Fusee.Math.Core
 
         #endregion Dot
 
+        /// <summary>
+        /// Performs <see cref="M.Step(float, float)"/> for each component of the input vectors.
+        /// </summary>
+        /// <param name="edge">Specifies the location of the edge of the step function.</param>
+        /// <param name="val">Specifies the value to be used to generate the step function.</param>
+        public static float2 Step(float2 edge, float2 val)
+        {
+            return new float2(M.Step(edge.x, val.x), M.Step(edge.y, val.y));
+        }
+
+        /// <summary>
+        /// Returns a float2 where all components are raised to the specified power.
+        /// </summary>
+        /// <param name="val">The float3 to be raised to a power.</param>
+        /// <param name="exp">A float that specifies a power.</param>
+        /// <returns></returns>
+        public static float2 Pow(float2 val, float exp)
+        {
+            return new float2(MathF.Pow(val.r, exp), MathF.Pow(val.g, exp));
+        }
+
         #region Lerp
 
         /// <summary>
@@ -503,6 +534,20 @@ namespace Fusee.Math.Core
         {
             a.x = blend * (b.x - a.x) + a.x;
             a.y = blend * (b.y - a.y) + a.y;
+            return a;
+        }
+
+        /// <summary>
+        /// Returns a new Vector that is the linear blend of the 2 given Vectors.
+        /// Each component of vector a is blended with its equivalent in vector b.
+        /// </summary>
+        /// <param name="a">First input vector</param>
+        /// <param name="b">Second input vector</param>
+        /// <param name="blend">The blend factor. a when blend=0, b when blend=1.</param>       
+        public static float2 Lerp(float2 a, float2 b, float2 blend)
+        {
+            a.x = blend.x * (b.x - a.x) + a.x;
+            a.y = blend.y * (b.y - a.y) + a.y;
             return a;
         }
 

--- a/src/Math/Core/float3.cs
+++ b/src/Math/Core/float3.cs
@@ -613,6 +613,11 @@ namespace Fusee.Math.Core
 
         #endregion Cross
 
+        public static float3 Step(float3 edge, float3 val)
+        {
+            return new float3(M.Step(edge.x, val.x), M.Step(edge.y, val.y), M.Step(edge.z, val.z));
+        }
+
         #region Lerp
 
         /// <summary>

--- a/src/Math/Core/float3.cs
+++ b/src/Math/Core/float3.cs
@@ -1,6 +1,7 @@
 ﻿using ProtoBuf;
 using System;
 using System.Globalization;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 namespace Fusee.Math.Core
@@ -38,6 +39,17 @@ namespace Fusee.Math.Core
         #endregion Fields
 
         #region Constructors
+
+        /// <summary>
+        /// Constructs a new float3.
+        /// </summary>
+        /// <param name="val">This value will be set for the x, y and z component.</param>
+        public float3(float val)
+        {
+            x = val;
+            y = val;
+            z = val;
+        }
 
         /// <summary>
         /// Constructs a new float3.
@@ -211,6 +223,19 @@ namespace Fusee.Math.Core
         }
 
         #endregion public NormalizeFast()
+
+        #region Color Conversion
+
+        /// <summary>
+        /// Converts this float3 - which is interpreted as a color - from linear color space to sRgb space.
+        /// </summary>
+        /// <returns></returns>
+        public float3 LinearColorFromSRgb()
+        {
+            return LinearColorFromSRgb(this);
+        }
+
+        #endregion
 
         /// <summary>
         /// Returns an array of floats with the three components of the vector.
@@ -623,6 +648,17 @@ namespace Fusee.Math.Core
             return new float3(M.Step(edge.x, val.x), M.Step(edge.y, val.y), M.Step(edge.z, val.z));
         }
 
+        /// <summary>
+        /// Returns a float3 where all components are raised to the specified power.
+        /// </summary>
+        /// <param name="val">The float3 to be raised to a power.</param>
+        /// <param name="exp">A float that specifies a power.</param>
+        /// <returns></returns>
+        public static float3 Pow(float3 val, float exp)
+        {
+            return new float3(MathF.Pow(val.r, exp), MathF.Pow(val.g, exp), MathF.Pow(val.b, exp));
+        }
+
         #region Lerp
 
         /// <summary>
@@ -784,6 +820,59 @@ namespace Fusee.Math.Core
         }
 
         #endregion Rotate
+
+        #region Color Conversion
+
+        /// <summary>
+        /// Converts a color value from linear to sRgb space.
+        /// </summary>
+        /// <param name="sRGBCol">The sRgb color value as <see cref="float3"/>.</param>
+        public static float3 LinearColorFromSRgb(float3 sRGBCol)
+        {
+            return new float3(LinearToSRgb(sRGBCol.x), LinearToSRgb(sRGBCol.y), LinearToSRgb(sRGBCol.z));
+        }
+
+        private static float LinearToSRgb(float input)
+        {
+            return input <= 0.04045f ? input  / 12.92f :MathF.Pow((input + 0.055f) * (1.0f / 1.055f), 2.4f);
+        }
+
+        /// <summary>
+        /// Converts a color value from linear to sRgb space.
+        /// </summary>
+        /// <param name="r">The red color value in range 0 - 255.</param>
+        /// <param name="g">The green color value in range 0 - 255.</param>
+        /// <param name="b">The blue color value in range 0 - 255.</param>
+        public static float3 LinearColorFromSRgb(int r, int g, int b)
+        {
+            var val = new float3(r / 255f, g / 255f, b / 255f);
+            return LinearColorFromSRgb(val);
+        }
+
+        /// <summary>
+        /// Converts a color value from linear to sRgb space.
+        /// </summary>
+        /// <param name="hex">The color value as hex code in form of a "FFFFFF" string.</param>
+        public static float3 LinearColorFromSRgb(string hex)
+        {
+            var rgb = Convert.ToUInt32(hex, 16);
+            return LinearColorFromSRgb(rgb);
+        }
+
+        /// <summary>
+        /// Converts a color value from linear to sRgb space.
+        /// </summary>
+        /// <param name="col">The color value as uint.</param>
+        public static float3 LinearColorFromSRgb(uint col)
+        {
+            var b = (byte)(col & byte.MaxValue);
+            var g = (byte)(col >> 8 & byte.MaxValue);
+            var r = (byte)(col >> 16 & byte.MaxValue);
+
+            return LinearColorFromSRgb(r, g, b);
+        }
+
+        #endregion
 
         #endregion Static
 
@@ -1083,7 +1172,7 @@ namespace Fusee.Math.Core
 
         #endregion Overrides
 
-        #region Color
+        #region Color Swizzle
 
         /// <summary>
         /// The red component (same as x)

--- a/src/Math/Core/float3.cs
+++ b/src/Math/Core/float3.cs
@@ -843,7 +843,7 @@ namespace Fusee.Math.Core
 
         private static float SRgbToLinear(float input)
         {
-            return input > 0.0031308f ? input * 12.92f : MathF.Pow((input - 0.055f) * 1.055f, 1f/2.4f);
+            return input > 0.0031308f ? input * 12.92f : MathF.Pow((input - 0.055f) * 1.055f, 1f / 2.4f);
         }
 
         /// <summary>
@@ -880,7 +880,7 @@ namespace Fusee.Math.Core
 
             return SRgbFromLinearColor(r, g, b);
         }
-        
+
         /// <summary>
         /// Converts a color value from sRgb to linear space.
         /// </summary>

--- a/src/Math/Core/float3.cs
+++ b/src/Math/Core/float3.cs
@@ -613,6 +613,11 @@ namespace Fusee.Math.Core
 
         #endregion Cross
 
+        /// <summary>
+        /// Performs <see cref="M.Step(float, float)"/> for each component of the input vectors.
+        /// </summary>
+        /// <param name="edge">Specifies the location of the edge of the step function.</param>
+        /// <param name="val">Specifies the value to be used to generate the step function.</param>
         public static float3 Step(float3 edge, float3 val)
         {
             return new float3(M.Step(edge.x, val.x), M.Step(edge.y, val.y), M.Step(edge.z, val.z));
@@ -638,14 +643,12 @@ namespace Fusee.Math.Core
         }
 
         /// <summary>
-        /// Returns a new Vector that is the linear blend of the 2 given Vectors
+        /// Returns a new Vector that is the linear blend of the 2 given Vectors.
+        /// Each component of vector a is blended with its equivalent in vector b.
         /// </summary>
         /// <param name="a">First input vector</param>
         /// <param name="b">Second input vector</param>
-        /// <param name="blend">The blend factor. a when blend=0, b when blend=1.</param>
-        /// <returns>
-        /// a when blend=0, b when blend=1, and a linear combination otherwise
-        /// </returns>
+        /// <param name="blend">The blend factor. a when blend=0, b when blend=1.</param>       
         public static float3 Lerp(float3 a, float3 b, float3 blend)
         {
             a.x = blend.x * (b.x - a.x) + a.x;

--- a/src/Math/Core/float3.cs
+++ b/src/Math/Core/float3.cs
@@ -632,6 +632,23 @@ namespace Fusee.Math.Core
             return a;
         }
 
+        /// <summary>
+        /// Returns a new Vector that is the linear blend of the 2 given Vectors
+        /// </summary>
+        /// <param name="a">First input vector</param>
+        /// <param name="b">Second input vector</param>
+        /// <param name="blend">The blend factor. a when blend=0, b when blend=1.</param>
+        /// <returns>
+        /// a when blend=0, b when blend=1, and a linear combination otherwise
+        /// </returns>
+        public static float3 Lerp(float3 a, float3 b, float3 blend)
+        {
+            a.x = blend.x * (b.x - a.x) + a.x;
+            a.y = blend.y * (b.y - a.y) + a.y;
+            a.z = blend.z * (b.z - a.z) + a.z;
+            return a;
+        }
+
         #endregion Lerp
 
         #region Barycentric

--- a/src/Math/Core/float3.cs
+++ b/src/Math/Core/float3.cs
@@ -834,7 +834,7 @@ namespace Fusee.Math.Core
 
         private static float LinearToSRgb(float input)
         {
-            return input <= 0.04045f ? input  / 12.92f :MathF.Pow((input + 0.055f) * (1.0f / 1.055f), 2.4f);
+            return input <= 0.04045f ? input / 12.92f : MathF.Pow((input + 0.055f) * (1.0f / 1.055f), 2.4f);
         }
 
         /// <summary>

--- a/src/Math/Core/float3.cs
+++ b/src/Math/Core/float3.cs
@@ -235,6 +235,15 @@ namespace Fusee.Math.Core
             return LinearColorFromSRgb(this);
         }
 
+        /// <summary>
+        /// Converts this float3 - which is interpreted as a color - from sRgb space to linear color space.
+        /// </summary>
+        /// <returns></returns>
+        public float3 SRgbFromLinearColor()
+        {
+            return SRgbFromLinearColor(this);
+        }
+
         #endregion
 
         /// <summary>
@@ -826,6 +835,55 @@ namespace Fusee.Math.Core
         /// <summary>
         /// Converts a color value from linear to sRgb space.
         /// </summary>
+        /// <param name="linearColor">The linear color value as <see cref="float3"/>.</param>
+        public static float3 SRgbFromLinearColor(float3 linearColor)
+        {
+            return new float3(SRgbToLinear(linearColor.x), SRgbToLinear(linearColor.y), SRgbToLinear(linearColor.z));
+        }
+
+        private static float SRgbToLinear(float input)
+        {
+            return input > 0.0031308f ? input * 12.92f : MathF.Pow((input - 0.055f) * 1.055f, 1f/2.4f);
+        }
+
+        /// <summary>
+        /// Converts a color value from linear to sRgb space.
+        /// </summary>
+        /// <param name="r">The red color value in range 0 - 255.</param>
+        /// <param name="g">The green color value in range 0 - 255.</param>
+        /// <param name="b">The blue color value in range 0 - 255.</param>
+        public static float3 SRgbFromLinearColor(int r, int g, int b)
+        {
+            var val = new float3(r / 255f, g / 255f, b / 255f);
+            return SRgbFromLinearColor(val);
+        }
+
+        /// <summary>
+        ///Converts a color value from linear to sRgb space.
+        /// </summary>
+        /// <param name="hex">The color value as hex code in form of a "FFFFFF" string.</param>
+        public static float3 SRgbFromLinearColor(string hex)
+        {
+            var rgb = Convert.ToUInt32(hex, 16);
+            return SRgbFromLinearColor(rgb);
+        }
+
+        /// <summary>
+        /// Converts a color value from linear to sRgb space.
+        /// </summary>
+        /// <param name="col">The color value as uint.</param>
+        public static float3 SRgbFromLinearColor(uint col)
+        {
+            var b = (byte)(col & byte.MaxValue);
+            var g = (byte)(col >> 8 & byte.MaxValue);
+            var r = (byte)(col >> 16 & byte.MaxValue);
+
+            return SRgbFromLinearColor(r, g, b);
+        }
+        
+        /// <summary>
+        /// Converts a color value from sRgb to linear space.
+        /// </summary>
         /// <param name="sRGBCol">The sRgb color value as <see cref="float3"/>.</param>
         public static float3 LinearColorFromSRgb(float3 sRGBCol)
         {
@@ -838,7 +896,7 @@ namespace Fusee.Math.Core
         }
 
         /// <summary>
-        /// Converts a color value from linear to sRgb space.
+        /// Converts a color value from sRgb to linear space.
         /// </summary>
         /// <param name="r">The red color value in range 0 - 255.</param>
         /// <param name="g">The green color value in range 0 - 255.</param>
@@ -850,7 +908,7 @@ namespace Fusee.Math.Core
         }
 
         /// <summary>
-        /// Converts a color value from linear to sRgb space.
+        /// Converts a color value from sRgb to linear space.
         /// </summary>
         /// <param name="hex">The color value as hex code in form of a "FFFFFF" string.</param>
         public static float3 LinearColorFromSRgb(string hex)
@@ -860,7 +918,7 @@ namespace Fusee.Math.Core
         }
 
         /// <summary>
-        /// Converts a color value from linear to sRgb space.
+        /// Converts a color value from sRgb to linear space.
         /// </summary>
         /// <param name="col">The color value as uint.</param>
         public static float3 LinearColorFromSRgb(uint col)

--- a/src/Math/Core/float4.cs
+++ b/src/Math/Core/float4.cs
@@ -81,6 +81,18 @@ namespace Fusee.Math.Core
         /// <summary>
         /// Constructs a new float4.
         /// </summary>
+        /// <param name="val">This value will be set for the x, y, z and w component.</param>
+        public float4(float val)
+        {
+            x = val;
+            y = val;
+            z = val;
+            w = val;
+        }
+
+        /// <summary>
+        /// Constructs a new float4.
+        /// </summary>
         /// <param name="x">The x component of the float4.</param>
         /// <param name="y">The y component of the float4.</param>
         /// <param name="z">The z component of the float4.</param>
@@ -324,6 +336,15 @@ namespace Fusee.Math.Core
 
         #endregion public Round()
 
+        /// <summary>
+        /// Converts this float4 - which is interpreted as a color - from linear color space to sRgb space.
+        /// </summary>
+        /// <returns></returns>
+        public float4 LinearColorFromSRgb()
+        {
+            return LinearColorFromSRgb(this);
+        }
+
         #endregion Instance
 
         #region Static
@@ -556,6 +577,17 @@ namespace Fusee.Math.Core
             return new float4(M.Step(edge.x, val.x), M.Step(edge.y, val.y), M.Step(edge.z, val.z),M.Step(edge.w, val.w));
         }
 
+        /// <summary>
+        /// Returns a float4 where all components are raised to the specified power.
+        /// </summary>
+        /// <param name="val">The float4 to be raised to a power.</param>
+        /// <param name="exp">A float that specifies a power.</param>
+        /// <returns></returns>
+        public static float4 Pow(float4 val, float exp)
+        {
+            return new float4(MathF.Pow(val.x, exp), MathF.Pow(val.y, exp), MathF.Pow(val.z, exp), MathF.Pow(val.w, exp));
+        }
+
         #region Lerp
 
         /// <summary>
@@ -626,6 +658,54 @@ namespace Fusee.Math.Core
         }
 
         #endregion Round
+
+        #region Color Conversion
+
+        /// <summary>
+        /// Converts a color value from linear to sRgb space.
+        /// </summary>
+        /// <param name="sRGBCol">The sRgb color value as <see cref="float4"/>.</param>
+        public static float4 LinearColorFromSRgb(float4 sRGBCol)
+        {
+            return new float4(float3.LinearColorFromSRgb(sRGBCol.rgb), sRGBCol.a);
+        }
+
+        /// <summary>
+        /// Converts a color value from linear to sRgb space.
+        /// </summary>
+        /// <param name="r">The red color value in range 0 - 255.</param>
+        /// <param name="g">The green color value in range 0 - 255.</param>
+        /// <param name="b">The blue color value in range 0 - 255.</param>
+        /// <param name="a">The alpha value in range 0 - 255.</param>
+        public static float4 LinearColorFromSRgb(int r, int g, int b, int a)
+        {
+            return new float4(float3.LinearColorFromSRgb(r,g,b), a/255f);
+        }
+
+        /// <summary>
+        /// Converts a color value from linear to sRgb space.
+        /// </summary>
+        /// <param name="hex">The color value as hex code in form of a "FFFFFFFF" string.</param>
+        public static float4 LinearColorFromSRgb(string hex)
+        {
+            var rgba = Convert.ToUInt32(hex, 16);
+            return LinearColorFromSRgb(rgba);
+        }
+
+        /// <summary>
+        /// Converts a color value from linear to sRgb space.
+        /// </summary>
+        /// <param name="col">The color value as uint.</param>
+        public static float4 LinearColorFromSRgb(uint col)
+        {
+            var a = (byte)(col & byte.MaxValue);
+            var b = (byte)(col >> 8 & byte.MaxValue);
+            var g = (byte)(col >> 16 & byte.MaxValue);
+            var r = (byte)(col >> 24 & byte.MaxValue);
+            return LinearColorFromSRgb(r, g, b, a);
+        }
+
+        #endregion
 
         #endregion Static
 
@@ -856,7 +936,7 @@ namespace Fusee.Math.Core
 
         #endregion Overrides
 
-        #region Color
+        #region Color Swizzle
 
         /// <summary>
         /// The red component (same as x)

--- a/src/Math/Core/float4.cs
+++ b/src/Math/Core/float4.cs
@@ -337,12 +337,21 @@ namespace Fusee.Math.Core
         #endregion public Round()
 
         /// <summary>
-        /// Converts this float4 - which is interpreted as a color - from linear color space to sRgb space.
+        /// Converts this float4 - which is interpreted as a color - from sRgb space to linear color space.       
         /// </summary>
         /// <returns></returns>
         public float4 LinearColorFromSRgb()
         {
             return LinearColorFromSRgb(this);
+        }
+
+        /// <summary>
+        /// Converts this float4 - which is interpreted as a color - from linear color space to sRgb space.
+        /// </summary>
+        /// <returns></returns>
+        public float4 SRgbFromLinearColor()
+        {
+            return SRgbFromLinearColor(this);
         }
 
         #endregion Instance
@@ -664,6 +673,50 @@ namespace Fusee.Math.Core
         /// <summary>
         /// Converts a color value from linear to sRgb space.
         /// </summary>
+        /// <param name="sRGBCol">The linear color value as <see cref="float4"/>.</param>
+        public static float4 SRgbFromLinearColor(float4 sRGBCol)
+        {
+            return new float4(float3.SRgbFromLinearColor(sRGBCol.rgb), sRGBCol.a);
+        }
+
+        /// <summary>
+        /// Converts a color value from linear to sRgb space.
+        /// </summary>
+        /// <param name="r">The red color value in range 0 - 255.</param>
+        /// <param name="g">The green color value in range 0 - 255.</param>
+        /// <param name="b">The blue color value in range 0 - 255.</param>
+        /// <param name="a">The alpha value in range 0 - 255.</param>
+        public static float4 SRgbFromLinearColor(int r, int g, int b, int a)
+        {
+            return new float4(float3.SRgbFromLinearColor(r, g, b), a / 255f);
+        }
+
+        /// <summary>
+        /// Converts a color value from linear to sRgb space.
+        /// </summary>
+        /// <param name="hex">The color value as hex code in form of a "FFFFFFFF" string.</param>
+        public static float4 SRgbFromLinearColor(string hex)
+        {
+            var rgba = Convert.ToUInt32(hex, 16);
+            return SRgbFromLinearColor(rgba);
+        }
+
+        /// <summary>
+        /// Converts a color value from linear to sRgb space.
+        /// </summary>
+        /// <param name="col">The color value as uint.</param>
+        public static float4 SRgbFromLinearColor(uint col)
+        {
+            var a = (byte)(col & byte.MaxValue);
+            var b = (byte)(col >> 8 & byte.MaxValue);
+            var g = (byte)(col >> 16 & byte.MaxValue);
+            var r = (byte)(col >> 24 & byte.MaxValue);
+            return SRgbFromLinearColor(r, g, b, a);
+        }
+
+        /// <summary>
+        /// Converts a color value from sRgb to linear space.
+        /// </summary>
         /// <param name="sRGBCol">The sRgb color value as <see cref="float4"/>.</param>
         public static float4 LinearColorFromSRgb(float4 sRGBCol)
         {
@@ -671,7 +724,7 @@ namespace Fusee.Math.Core
         }
 
         /// <summary>
-        /// Converts a color value from linear to sRgb space.
+        ///Converts a color value from sRgb to linear space.
         /// </summary>
         /// <param name="r">The red color value in range 0 - 255.</param>
         /// <param name="g">The green color value in range 0 - 255.</param>
@@ -683,7 +736,7 @@ namespace Fusee.Math.Core
         }
 
         /// <summary>
-        /// Converts a color value from linear to sRgb space.
+        /// Converts a color value from sRgb to linear space.
         /// </summary>
         /// <param name="hex">The color value as hex code in form of a "FFFFFFFF" string.</param>
         public static float4 LinearColorFromSRgb(string hex)
@@ -693,7 +746,7 @@ namespace Fusee.Math.Core
         }
 
         /// <summary>
-        /// Converts a color value from linear to sRgb space.
+        /// Converts a color value from sRgb to linear space.
         /// </summary>
         /// <param name="col">The color value as uint.</param>
         public static float4 LinearColorFromSRgb(uint col)

--- a/src/Math/Core/float4.cs
+++ b/src/Math/Core/float4.cs
@@ -574,7 +574,7 @@ namespace Fusee.Math.Core
         /// <param name="val">Specifies the value to be used to generate the step function.</param>
         public static float4 Step(float4 edge, float4 val)
         {
-            return new float4(M.Step(edge.x, val.x), M.Step(edge.y, val.y), M.Step(edge.z, val.z),M.Step(edge.w, val.w));
+            return new float4(M.Step(edge.x, val.x), M.Step(edge.y, val.y), M.Step(edge.z, val.z), M.Step(edge.w, val.w));
         }
 
         /// <summary>
@@ -679,7 +679,7 @@ namespace Fusee.Math.Core
         /// <param name="a">The alpha value in range 0 - 255.</param>
         public static float4 LinearColorFromSRgb(int r, int g, int b, int a)
         {
-            return new float4(float3.LinearColorFromSRgb(r,g,b), a/255f);
+            return new float4(float3.LinearColorFromSRgb(r, g, b), a / 255f);
         }
 
         /// <summary>

--- a/src/Math/Core/float4.cs
+++ b/src/Math/Core/float4.cs
@@ -546,6 +546,16 @@ namespace Fusee.Math.Core
 
         #endregion Dot
 
+        /// <summary>
+        /// Performs <see cref="M.Step(float, float)"/> for each component of the input vectors.
+        /// </summary>
+        /// <param name="edge">Specifies the location of the edge of the step function.</param>
+        /// <param name="val">Specifies the value to be used to generate the step function.</param>
+        public static float4 Step(float4 edge, float4 val)
+        {
+            return new float4(M.Step(edge.x, val.x), M.Step(edge.y, val.y), M.Step(edge.z, val.z),M.Step(edge.w, val.w));
+        }
+
         #region Lerp
 
         /// <summary>
@@ -561,6 +571,22 @@ namespace Fusee.Math.Core
             a.y = blend * (b.y - a.y) + a.y;
             a.z = blend * (b.z - a.z) + a.z;
             a.w = blend * (b.w - a.w) + a.w;
+            return a;
+        }
+
+        /// <summary>
+        /// Returns a new Vector that is the linear blend of the 2 given Vectors.
+        /// Each component of vector a is blended with its equivalent in vector b.
+        /// </summary>
+        /// <param name="a">First input vector</param>
+        /// <param name="b">Second input vector</param>
+        /// <param name="blend">The blend factor. a when blend=0, b when blend=1.</param>       
+        public static float4 Lerp(float4 a, float4 b, float4 blend)
+        {
+            a.x = blend.x * (b.x - a.x) + a.x;
+            a.y = blend.y * (b.y - a.y) + a.y;
+            a.z = blend.z * (b.z - a.z) + a.z;
+            a.w = blend.w * (b.w - a.w) + a.w;
             return a;
         }
 

--- a/src/Tests/Math/Core/Float2Test.cs
+++ b/src/Tests/Math/Core/Float2Test.cs
@@ -318,11 +318,27 @@ namespace Fusee.Test.Math.Core
 
         #endregion
 
+        [Theory]
+        [MemberData(nameof(GetStep))]
+        public void Step(float2 edge, float2 val, float2 expected)
+        {
+            Assert.Equal(expected, float2.Step(edge, val));
+        }
+
         #region Lerp
 
         [Theory]
         [MemberData(nameof(GetLerp))]
         public void Lerp_TestLerp(float2 left, float2 right, float blend, float2 expected)
+        {
+            var actual = float2.Lerp(left, right, blend);
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Theory]
+        [MemberData(nameof(GetLerp2))]
+        public void Lerp_TestLerp2(float2 left, float2 right, float2 blend, float2 expected)
         {
             var actual = float2.Lerp(left, right, blend);
 
@@ -659,6 +675,16 @@ namespace Fusee.Test.Math.Core
             yield return new object[] { zero, one, 1, one };
         }
 
+        public static IEnumerable<object[]> GetLerp2()
+        {
+            var one = new float2(1, 1);
+            var zero = new float2(0, 0);
+
+            yield return new object[] { zero, one, new float2(0.5f, 0.5f), new float2(0.5f, 0.5f) };
+            yield return new object[] { zero, one, float2.Zero, zero };
+            yield return new object[] { zero, one, float2.One, one };
+        }
+
         public static IEnumerable<object[]> GetBarycentric()
         {
             var zero = new float2(0, 0);
@@ -668,6 +694,14 @@ namespace Fusee.Test.Math.Core
             yield return new object[] { zero, x, y, 0, 0, y };
             yield return new object[] { zero, x, y, 1, 0, zero };
             yield return new object[] { zero, x, y, 0, 1, x };
+        }
+
+        public static IEnumerable<object[]> GetStep()
+        {
+            var x = new float2(2.222f, 2.222f);
+            var y = new float2(1.111f, 1.111f);
+            yield return new object[] { x, y, float2.Zero };
+            yield return new object[] { y, x, float2.One };
         }
 
         #endregion

--- a/src/Tests/Math/Core/Float3Test.cs
+++ b/src/Tests/Math/Core/Float3Test.cs
@@ -401,6 +401,15 @@ namespace Fusee.Test.Math.Core
             Assert.Equal(expected, actual);
         }
 
+        [Theory]
+        [MemberData(nameof(GetLerp3))]
+        public void Lerp_TestLerp3(float3 left, float3 right, float3 blend, float3 expected)
+        {
+            var actual = float3.Lerp(left, right, blend);
+
+            Assert.Equal(expected, actual);
+        }
+
         #endregion
 
         #region Barycentric
@@ -465,6 +474,13 @@ namespace Fusee.Test.Math.Core
         }
 
         #endregion
+
+        [Theory]
+        [MemberData(nameof(GetStep))]
+        public void Step(float3 edge, float3 val, float3 expected)
+        {
+            Assert.Equal(expected, float3.Step(edge, val));
+        }
 
         #endregion
 
@@ -825,6 +841,16 @@ namespace Fusee.Test.Math.Core
             yield return new object[] { zero, one, 1, one };
         }
 
+        public static IEnumerable<object[]> GetLerp3()
+        {
+            var one = new float3(1, 1, 1);
+            var zero = new float3(0, 0, 0);
+
+            yield return new object[] { zero, one, new float3(0.5f, 0.5f, 0.5f), new float3(0.5f, 0.5f, 0.5f) };
+            yield return new object[] { zero, one, float3.Zero, zero };
+            yield return new object[] { zero, one, float3.One, one };
+        }
+
         public static IEnumerable<object[]> GetBarycentric()
         {
             var x = new float3(1, 0, 0);
@@ -860,6 +886,14 @@ namespace Fusee.Test.Math.Core
             yield return new object[] { xRot, y, z };
             yield return new object[] { yRot, z, x };
             yield return new object[] { zRot, x, y };
+        }
+
+        public static IEnumerable<object[]> GetStep()
+        {
+            var x = new float3(2.222f, 2.222f, 2.222f);
+            var y = new float3(1.111f, 1.111f, 1.111f);
+            yield return new object[] { x, y, float3.Zero };
+            yield return new object[] { y, x, float3.One };
         }
 
         #endregion

--- a/src/Tests/Math/Core/Float4Test.cs
+++ b/src/Tests/Math/Core/Float4Test.cs
@@ -413,6 +413,15 @@ namespace Fusee.Test.Math.Core
             Assert.Equal(expected, actual);
         }
 
+        [Theory]
+        [MemberData(nameof(GetLerp4))]
+        public void Lerp_TestLerp4(float4 left, float4 right, float4 blend, float4 expected)
+        {
+            var actual = float4.Lerp(left, right, blend);
+
+            Assert.Equal(expected, actual);
+        }
+
         #endregion
 
         #region Barycentric
@@ -627,6 +636,13 @@ namespace Fusee.Test.Math.Core
 
         #endregion
 
+        [Theory]
+        [MemberData(nameof(GetStep))]
+        public void Step(float4 edge, float4 val, float4 expected)
+        {
+            Assert.Equal(expected, float4.Step(edge, val));
+        }
+
         #region IEnumerables
 
         public static IEnumerable<object[]> GetNormalize()
@@ -713,6 +729,16 @@ namespace Fusee.Test.Math.Core
             yield return new object[] { zero, one, 1, one };
         }
 
+        public static IEnumerable<object[]> GetLerp4()
+        {
+            var one = new float4(1, 1, 1, 1);
+            var zero = new float4(0, 0, 0, 0);
+
+            yield return new object[] { zero, one, new float4(0.5f, 0.5f, 0.5f, 0.5f), new float4(0.5f, 0.5f, 0.5f, 0.5f) };
+            yield return new object[] { zero, one, float4.Zero, zero };
+            yield return new object[] { zero, one, float4.One, one };
+        }
+
         public static IEnumerable<object[]> GetBarycentric()
         {
             var x = new float4(1, 0, 0, 0);
@@ -722,6 +748,14 @@ namespace Fusee.Test.Math.Core
             yield return new object[] { x, y, z, 0, 0, z };
             yield return new object[] { x, y, z, 1, 0, x };
             yield return new object[] { x, y, z, 0, 1, y };
+        }
+
+        public static IEnumerable<object[]> GetStep()
+        {
+            var x = new float4(2.222f, 2.222f, 2.222f, 2.222f);
+            var y = new float4(1.111f, 1.111f, 1.111f, 1.111f);
+            yield return new object[] { x, y, float4.Zero };
+            yield return new object[] { y, x, float4.One };
         }
 
         #endregion

--- a/src/Tests/Math/Core/MTest.cs
+++ b/src/Tests/Math/Core/MTest.cs
@@ -513,7 +513,6 @@ namespace Fusee.Test.Math.Core
         }
         #endregion
 
-
         #region BinomialCoefficient
         [Fact]
         public void BinominalCoefficient_IsOne()
@@ -651,6 +650,14 @@ namespace Fusee.Test.Math.Core
         public void Clamp_IsMinIsMax_double(double x, double min, double max)
         {
             Assert.Equal(1, M.Clamp(x, min, max));
+        }
+
+        [Theory]
+        [InlineData(2.222f, 1.111f, 0.0f)]
+        [InlineData(1.111f, 2.222f, 1.0f)]
+        public void Step(float edge, float val, float expected)
+        {
+            Assert.Equal(expected, M.Step(edge, val));
         }
 
         #endregion

--- a/src/Tests/Serialization/Fusee.Serialization.Test/SimpleConvertSceneGraph.cs
+++ b/src/Tests/Serialization/Fusee.Serialization.Test/SimpleConvertSceneGraph.cs
@@ -533,7 +533,7 @@ namespace Fusee.Test.Serialization.V1
                            }
                        },
                        MakeEffect.FromDiffuseSpecular(
-                           albedoColor: ColorUint.Red,
+                           albedoColor: (float4)ColorUint.Red,
                            emissionColor: float4.Zero,
                            shininess: 4.0f,
                            specularStrength: 1.0f),
@@ -567,7 +567,7 @@ namespace Fusee.Test.Serialization.V1
                            WasLoaded = true
                        },
                        new Camera(Engine.Core.Scene.ProjectionMethod.Orthographic, 0, 500, 2000),
-                       MakeEffect.FromBRDF(ColorUint.Green, float4.Zero, 0.2f, 0, 0.5f, 1.46f, 0),
+                       MakeEffect.FromBRDF((float4)ColorUint.Green, float4.Zero, 0.2f, 0, 0.5f, 1.46f, 0),
                        new Cube()
                     },
                     Children = new ChildList
@@ -579,7 +579,7 @@ namespace Fusee.Test.Serialization.V1
                             {
                                 new Transform {Translation=new float3(0, 60, 0),  Scale = new float3(20, 100, 20) },
                                 MakeEffect.FromDiffuseSpecular(
-                                    albedoColor: ColorUint.Green,
+                                    albedoColor: (float4)ColorUint.Green,
                                     emissionColor: float4.Zero,
                                     specularStrength: 1.0f,
                                     shininess: 4.0f),
@@ -607,7 +607,7 @@ namespace Fusee.Test.Serialization.V1
                                             {
                                                 new Transform {Translation=new float3(0, 40, 0),  Scale = new float3(20, 100, 20) },
                                                 MakeEffect.FromDiffuseSpecular(
-                                                    albedoColor: ColorUint.Yellow,
+                                                    albedoColor: (float4)ColorUint.Yellow,
                                                     emissionColor: float4.Zero,
                                                     specularStrength: 1.0f,
                                                     shininess: 4.0f),
@@ -631,7 +631,7 @@ namespace Fusee.Test.Serialization.V1
                                                             {
                                                                 new Transform {Translation=new float3(0, 40, 0),  Scale = new float3(20, 100, 20) },
                                                                 MakeEffect.FromDiffuseSpecular(
-                                                                                    albedoColor: ColorUint.Blue,
+                                                                                    albedoColor: (float4)ColorUint.Blue,
                                                                                     emissionColor: float4.Zero,
                                                                                     specularStrength: 1.0f,
                                                                                     shininess: 4.0f),

--- a/src/Tests/Serialization/Fusee.Serialization.Test/SimpleConvertSceneGraph.cs
+++ b/src/Tests/Serialization/Fusee.Serialization.Test/SimpleConvertSceneGraph.cs
@@ -533,7 +533,7 @@ namespace Fusee.Test.Serialization.V1
                            }
                        },
                        MakeEffect.FromDiffuseSpecular(
-                           albedoColor: ColorUint.Tofloat4(ColorUint.Red),
+                           albedoColor: ColorUint.Red,
                            emissionColor: float4.Zero,
                            shininess: 4.0f,
                            specularStrength: 1.0f),
@@ -567,7 +567,7 @@ namespace Fusee.Test.Serialization.V1
                            WasLoaded = true
                        },
                        new Camera(Engine.Core.Scene.ProjectionMethod.Orthographic, 0, 500, 2000),
-                       MakeEffect.FromBRDF(ColorUint.Tofloat4(ColorUint.Green), float4.Zero, 0.2f, 0, 0.5f, 1.46f, 0),
+                       MakeEffect.FromBRDF(ColorUint.Green, float4.Zero, 0.2f, 0, 0.5f, 1.46f, 0),
                        new Cube()
                     },
                     Children = new ChildList
@@ -579,7 +579,7 @@ namespace Fusee.Test.Serialization.V1
                             {
                                 new Transform {Translation=new float3(0, 60, 0),  Scale = new float3(20, 100, 20) },
                                 MakeEffect.FromDiffuseSpecular(
-                                    albedoColor: ColorUint.Tofloat4(ColorUint.Green),
+                                    albedoColor: ColorUint.Green,
                                     emissionColor: float4.Zero,
                                     specularStrength: 1.0f,
                                     shininess: 4.0f),
@@ -607,7 +607,7 @@ namespace Fusee.Test.Serialization.V1
                                             {
                                                 new Transform {Translation=new float3(0, 40, 0),  Scale = new float3(20, 100, 20) },
                                                 MakeEffect.FromDiffuseSpecular(
-                                                    albedoColor: ColorUint.Tofloat4(ColorUint.Yellow),
+                                                    albedoColor: ColorUint.Yellow,
                                                     emissionColor: float4.Zero,
                                                     specularStrength: 1.0f,
                                                     shininess: 4.0f),
@@ -631,7 +631,7 @@ namespace Fusee.Test.Serialization.V1
                                                             {
                                                                 new Transform {Translation=new float3(0, 40, 0),  Scale = new float3(20, 100, 20) },
                                                                 MakeEffect.FromDiffuseSpecular(
-                                                                                    albedoColor: ColorUint.Tofloat4(ColorUint.Blue),
+                                                                                    albedoColor: ColorUint.Blue,
                                                                                     emissionColor: float4.Zero,
                                                                                     specularStrength: 1.0f,
                                                                                     shininess: 4.0f),


### PR DESCRIPTION
**Summary:**

Color Management:

- All colors written in user code are expected to be in linear color space. The output color is converted to sRgb in the shaders after the lighting calculation.
- Textures are expected in sRgb colors. The color will be handled accordingly in the shaders (except one decides to write their own shader and not to use the provided effects).

ColorUint:

- The exlplicit cast operator to float3/4 automatically converts the ColorUint to linear space.
- The exlplicit cast operator from float3/4 to ColorUint automatically converts the ColorUint to sRgb.
--> a ColoUint is always a sRgb value.

Added Methods:

M:

- Step(float, float) + Test

float2/3/4:
- single value constructor
- static Pow(float2/3/4, float) + Test
- static Lerp(float2/3/4, float2/3/4, float2/3/4) + Test
- static Step(float2/3/4, float2/3/4) + Test

float3/4:

- instance LinearColorFromSRgb()
- static LinearColorFromSRgb(float3/4 sRGBCol)
- static LinearColorFromSRgb(int r, int g, int b)
- static LinearColorFromSRgb(string hex)
- static LinearColorFromSRgb(uint col)
- instance SRgbFromLinearColor()
- static SRgbFromLinearColor(float3/4 sRGBCol)
- static SRgbFromLinearColor(int r, int g, int b)
- static SRgbFromLinearColor(string hex)
- static SRgbFromLinearColor(uint col)

All examples should be adapted to these changes.

Closes #272