### PR TITLE
Patch/bunch of tiny fixes

### DIFF
--- a/BuildNuget.cmd
+++ b/BuildNuget.cmd
@@ -29,7 +29,7 @@ msbuild dis\NuGet\Android\Android.csproj -t:restore,pack -p:Configuration=Releas
 
 dotnet pack dis\DnTemplate\DnTemplate.csproj -c Release -o bin\Release\nuget
 
-msbuild dis\VSTemplate\VSTemplate.sln -t:restore,pack -p:Configuration=Release
+msbuild dis\VSTemplate\VSTemplate.sln -t:restore,build -p:Configuration=Release
 copy /Y dis\VSTemplate\VSTemplate\bin\Release\ProjectTemplates\CSharp\1033\Fusee.Template.VS.zip bin\Release\nuget\
 copy /Y dis\VSTemplate\VSIX\bin\Release\Fusee.Template.VS.vsix bin\Release\nuget\
 

--- a/BuildNuget.cmd
+++ b/BuildNuget.cmd
@@ -30,9 +30,9 @@ msbuild dis\NuGet\Android\Android.csproj -t:restore,pack -p:Configuration=Releas
 dotnet pack dis\DnTemplate\DnTemplate.csproj -c Release -o bin\Release\nuget
 
 msbuild dis\VSTemplate\VSTemplate.sln -t:restore,build -p:Configuration=Release
-copy /Y dis\VSTemplate\VSTemplate\bin\Release\ProjectTemplates\CSharp\1033\Fusee.Template.VS.zip bin\Release\nuget\
-copy /Y dis\VSTemplate\VSIX\bin\Release\Fusee.Template.VS.vsix bin\Release\nuget\
-
+copy /Y dis\VSTemplate\VSTemplate\bin\Release\ProjectTemplates\CSharp\1033\Fusee.Template.VS.zip bin\Release\nuget\ >nul
+copy /Y dis\VSTemplate\VSIX\bin\Release\Fusee.Template.VS.vsix bin\Release\nuget\ >nul
+tar -c -a -f bin\Release\nuget\io_export_fus.zip -C bin\Release\Tools\CmdLine\BlenderScripts\addons *
 goto END
 
 :ERRORDOTNET

--- a/dis/DnTemplate/template/Fusee_App.csproj
+++ b/dis/DnTemplate/template/Fusee_App.csproj
@@ -11,4 +11,8 @@
   <ItemGroup>
     <PackageReference Include="Fusee.Desktop" Version="0.9.0" />
   </ItemGroup>
+  <PropertyGroup>
+    <!-- Suppress warning NU1701: Package restore of OpenTK 3.1 with net462 - remove after update to OpenTK 4 -->
+    <NoWarn>NU1701</NoWarn>
+  </PropertyGroup>
 </Project>

--- a/dis/VSTemplate/VSTemplate/Core/Core.csproj
+++ b/dis/VSTemplate/VSTemplate/Core/Core.csproj
@@ -15,4 +15,9 @@
   <ItemGroup>
     <PackageReference Include="Fusee.Core" Version="0.9.0" />
   </ItemGroup>
+
+  <PropertyGroup>
+    <!-- Suppress warning NU1701: Package restore of OpenTK 3.1 with net462 - remove after update to OpenTK 4 -->
+    <NoWarn>NU1701</NoWarn>
+  </PropertyGroup>
 </Project>

--- a/dis/VSTemplate/VSTemplate/Desktop/Desktop.csproj
+++ b/dis/VSTemplate/VSTemplate/Desktop/Desktop.csproj
@@ -23,4 +23,9 @@
       <Name>Core</Name>
     </ProjectReference>
   </ItemGroup>
+
+  <PropertyGroup>
+    <!-- Suppress warning NU1701: Package restore of OpenTK 3.1 with net462 - remove after update to OpenTK 4 -->
+    <NoWarn>NU1701</NoWarn>
+  </PropertyGroup>
 </Project>

--- a/src/Base/Core/Diagnostics.cs
+++ b/src/Base/Core/Diagnostics.cs
@@ -92,6 +92,7 @@ namespace Fusee.Base.Core
         public enum SeverityLevel
         {
 #pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+            Verbose = -1,
             Debug = 0,
             Info,
             Warn,
@@ -104,6 +105,8 @@ namespace Fusee.Base.Core
         {
             switch (lvl)
             {
+                case SeverityLevel.Verbose:
+                    return "Verbose";
                 case SeverityLevel.Debug:
                     return "Debug";
                 case SeverityLevel.Info:
@@ -123,6 +126,9 @@ namespace Fusee.Base.Core
         {
             switch (lvl)
             {
+                case SeverityLevel.Verbose:
+                    Console.ForegroundColor = ConsoleColor.DarkGray;
+                    break;
                 case SeverityLevel.Debug:
                     Console.ForegroundColor = ConsoleColor.Green;
                     break;
@@ -231,6 +237,22 @@ namespace Fusee.Base.Core
             Writer(o, logLevel, null, null, callerName, sourceLineNumber, sourceFilePath);
         }
 
+        /// <summary>
+        ///     Log a debug event.
+        ///     Per default visible within the Visual Studio debug console and the console window in debug builds.
+        /// </summary>
+        /// <param name="o">The object to write</param>
+        /// <param name="ex">A possible exception, optional</param>
+        /// <param name="args">Possible arguments, optional</param>
+        /// <param name="callerName">The calling method</param>
+        /// <param name="sourceLineNumber">The line number, optional.</param>
+        /// <param name="sourceFilePath">The file path, optional.</param>
+        [Conditional("DEBUG")]
+        public static void Verbose(object o, Exception ex = null, object[] args = null, [CallerMemberName] string callerName = "", [CallerLineNumber] int sourceLineNumber = 0, [CallerFilePath] string sourceFilePath = "")
+        {
+            Writer(o, SeverityLevel.Verbose, ex, args, callerName, sourceLineNumber, sourceFilePath);
+        }
+        
         /// <summary>
         ///     Log a debug event.
         ///     Per default visible within the Visual Studio debug console and the console window in debug builds.

--- a/src/Base/Core/Diagnostics.cs
+++ b/src/Base/Core/Diagnostics.cs
@@ -252,7 +252,7 @@ namespace Fusee.Base.Core
         {
             Writer(o, SeverityLevel.Verbose, ex, args, callerName, sourceLineNumber, sourceFilePath);
         }
-        
+
         /// <summary>
         ///     Log a debug event.
         ///     Per default visible within the Visual Studio debug console and the console window in debug builds.

--- a/src/Engine/Core/Audio.cs
+++ b/src/Engine/Core/Audio.cs
@@ -34,7 +34,7 @@ namespace Fusee.Engine.Core
             {
                 if (value == null)
                 {
-                    Diagnostics.Warn("WARNING: No Audio implementation set. To enable Audio functionality inject an appropriate implementation of IAudioImp in your platform specific application main module.");
+                    Diagnostics.Verbose("WARNING: No Audio implementation set. To enable Audio functionality inject an appropriate implementation of IAudioImp in your platform specific application main module.");
                     _audioImp = new DummyAudioImp();
                 }
                 else

--- a/src/Engine/Core/Network.cs
+++ b/src/Engine/Core/Network.cs
@@ -23,7 +23,7 @@ namespace Fusee.Engine.Core
             {
                 if (value == null)
                 {
-                    Diagnostics.Warn("No Network implementation set. To enable Network functionality inject an appropriate implementation of INetworkImp in your platform specific application main module.");
+                    Diagnostics.Verbose("No Network implementation set. To enable Network functionality inject an appropriate implementation of INetworkImp in your platform specific application main module.");
                     _networkImp = new DummyNetworkImp();
                 }
                 else

--- a/src/Engine/Core/Time.cs
+++ b/src/Engine/Core/Time.cs
@@ -90,22 +90,22 @@
         public static long Frames => Instance.TimeFrames;
 
         /// <summary>
-        /// Provides the DeltaTime since the last frame in milliseconds that is effected by the TimeScale (read only).
+        /// Provides the DeltaTime since the last frame in seconds that is effected by the TimeScale (read only).
         /// </summary>
         public float TimeDeltaTime => _deltaTime;
         /// <summary>
-        /// Provides the DeltaTime since the last frame in milliseconds that is effected by the TimeScale (read only).
+        /// Provides the DeltaTime since the last frame in seconds that is effected by the TimeScale (read only).
         /// </summary>
         public static float DeltaTime => Instance.TimeDeltaTime;
 
         /// <summary>
-        /// Provides the DeltaTime since the last frame in milliseconds that is unaffected by the TimeScale (read only).
+        /// Provides the DeltaTime since the last frame in seconds that is unaffected by the TimeScale (read only).
         /// </summary>
-        public float TimeRealDeltaTimeMs => _realDeltaTime;
+        public float TimeRealDeltaTime => _realDeltaTime;
         /// <summary>
-        /// Provides the DeltaTime since the last frame in milliseconds that is unaffected by the TimeScale (read only).
+        /// Provides the DeltaTime since the last frame in seconds that is unaffected by the TimeScale (read only).
         /// </summary>
-        public static float RealDeltaTimeMs => Instance.TimeRealDeltaTimeMs;
+        public static float RealDeltaTime => Instance.TimeRealDeltaTime;
 
         /// <summary>
         /// Provides the passed time since start of the application effected by TimeScale (read only).

--- a/src/Engine/Imp/Graphics/Desktop/RenderContextImp.cs
+++ b/src/Engine/Imp/Graphics/Desktop/RenderContextImp.cs
@@ -62,7 +62,8 @@ namespace Fusee.Engine.Imp.Graphics.Desktop
             _blendEquationAlpha = (BlendEquationMode)blendEqA;
             _blendEquationRgb = (BlendEquationMode)blendEqRgb;
 
-            Diagnostics.Debug(GetHardwareDescription());
+            Diagnostics.Debug(GL.GetString(StringName.Vendor) + " - " + GL.GetString(StringName.Renderer) + " - " + GL.GetString(StringName.Version));
+            Diagnostics.Verbose(GL.GetString(StringName.Extensions));
         }
 
         #region Image data related Members

--- a/src/Engine/Imp/Graphics/Desktop/WindowsSpaceMouseDeviceImp.cs
+++ b/src/Engine/Imp/Graphics/Desktop/WindowsSpaceMouseDeviceImp.cs
@@ -259,7 +259,7 @@ namespace Fusee.Engine.Imp.Graphics.Desktop
             }
             catch (Exception ex)
             {
-                Diagnostics.Warn("Trouble initializing the SpaceMouse. Probably due to missing driver.\n" + ex);
+                Diagnostics.Verbose("Trouble initializing the SpaceMouse. Probably due to missing driver.\n" + ex);
                 _current3DConnexionDevice = null;
             }
 

--- a/src/Tools/CmdLine/Verbs/Player.cs
+++ b/src/Tools/CmdLine/Verbs/Player.cs
@@ -1,4 +1,4 @@
-﻿using CommandLine;
+using CommandLine;
 using Fusee.Base.Common;
 using Fusee.Base.Core;
 using Fusee.Base.Imp.Desktop;
@@ -138,7 +138,7 @@ namespace Fusee.Tools.CmdLine.Verbs
 
                                 if (serversion != ourversion)
                                 {
-                                    Console.WriteLine("Warning: Fusee player and the assembly are on different versions. This can result in unexpected behaviour.\nPlayer version: " + ourversion + "\nAssembly version: " + serversion);
+                                    Console.WriteLine("Warning: Fusee player and the assembly are on different versions. If you experience unexpected behavior, try installing the corresponding player version. See https://fusee3d.org/wiki/Using-FUSEE-in-Visual-Studio-Code.html for help.\nPlayer version: " + ourversion + "\nAssembly version: " + serversion);
                                 }
 
                                 tApp = asm.GetTypes().FirstOrDefault(t => typeof(RenderCanvas).IsAssignableFrom(t));


### PR DESCRIPTION
- Introduces new log level Verbose.
- Implementation warnings changed to log level Verbose
- Fixed and updated NuGet build script. It now packs the blender plugin directly to zip.
- Fixed DeltaTime documentation.
- Suppress OpenTK restore warning in DnTemplate & VSTemplate

Fixes #241 
Fixes #248 
Fixes #249