### PR TITLE
Remove shader src parameters from GUINode

### DIFF
--- a/Examples/Complete/AdvancedUI/Core/AdvancedUI.cs
+++ b/Examples/Complete/AdvancedUI/Core/AdvancedUI.cs
@@ -365,8 +365,6 @@ namespace Fusee.Examples.AdvancedUI.Core
             Texture guiFuseeLogo = new(AssetStorage.Get<ImageData>("FuseeText.png"));
             TextureNode fuseeLogo = new(
                 "fuseeLogo",
-                UIHelper.VsTex,
-                UIHelper.PsTex,
                 guiFuseeLogo,
                 UIElementPosition.GetAnchors(AnchorPos.TopTopLeft),
                 UIElementPosition.CalcOffsets(AnchorPos.TopTopLeft, new float2(0, _canvasHeight - 0.5f), _canvasHeight, _canvasWidth, new float2(1.75f, 0.5f)), float2.One);

--- a/Examples/Complete/AdvancedUI/Core/UIHelper.cs
+++ b/Examples/Complete/AdvancedUI/Core/UIHelper.cs
@@ -33,12 +33,6 @@ namespace Fusee.Examples.AdvancedUI.Core
         internal static float2 AnnotationDim = new(3f, 0.5f);
         internal static float4 AnnotationBorderThickness = new(6, 0.5f, 0.5f, 0.5f);
 
-        internal static string VsTex = AssetStorage.Get<string>("texture.vert");
-        internal static string PsTex = AssetStorage.Get<string>("texture.frag");
-        internal static string PsText = AssetStorage.Get<string>("text.frag");
-        internal static string VsNineSlice = AssetStorage.Get<string>("nineSlice.vert");
-        internal static string PsNineSlice = AssetStorage.Get<string>("nineSliceTile.frag");
-
         internal static Font FontRaleway = AssetStorage.Get<Font>("Raleway-Regular.ttf");
         internal static FontMap RalewayFontMap = new(FontRaleway, 24);
 
@@ -127,8 +121,6 @@ namespace Fusee.Examples.AdvancedUI.Core
         {
             TextureNode icon = new(
                 "icon",
-                VsTex,
-                PsTex,
                 iconTex,
                 new MinMaxRect
                 {
@@ -142,8 +134,6 @@ namespace Fusee.Examples.AdvancedUI.Core
             TextNode annotationText = new(
                 text,
                 "annotation text",
-                VsTex,
-                PsText,
                 new MinMaxRect
                 {
                     Min = new float2(0, 0),
@@ -157,8 +147,6 @@ namespace Fusee.Examples.AdvancedUI.Core
 
             TextureNode annotation = new(
                 "Annotation",
-                VsNineSlice,
-                PsNineSlice,
                 frameTex,
                 new MinMaxRect
                 {

--- a/Examples/Complete/BoneAnimation/Core/Bone.cs
+++ b/Examples/Complete/BoneAnimation/Core/Bone.cs
@@ -337,8 +337,6 @@ namespace Fusee.Examples.BoneAnimation.Core
             var guiFuseeLogo = new Texture(AssetStorage.Get<ImageData>("FuseeText.png"));
             var fuseeLogo = new TextureNode(
                 "fuseeLogo",
-                vsTex,
-                psTex,
                 //Set the albedo texture you want to use.
                 guiFuseeLogo,
                 //Define anchor points. They are given in percent, seen from the lower left corner, respectively to the width/height of the parent.
@@ -356,8 +354,6 @@ namespace Fusee.Examples.BoneAnimation.Core
             var text = new TextNode(
                 "FUSEE Picking Example",
                 "ButtonText",
-                vsTex,
-                psText,
                 UIElementPosition.GetAnchors(AnchorPos.StretchHorizontal),
                 UIElementPosition.CalcOffsets(AnchorPos.StretchHorizontal, new float2(canvasWidth / 2 - 4, 0), canvasHeight, canvasWidth, new float2(8, 1)),
                 guiLatoBlack,

--- a/Examples/Complete/BoneAnimation/Core/Bone.cs
+++ b/Examples/Complete/BoneAnimation/Core/Bone.cs
@@ -319,10 +319,6 @@ namespace Fusee.Examples.BoneAnimation.Core
 
         private SceneContainer CreateGui()
         {
-            var vsTex = AssetStorage.Get<string>("texture.vert");
-            var psTex = AssetStorage.Get<string>("texture.frag");
-            var psText = AssetStorage.Get<string>("text.frag");
-
             var canvasWidth = Width / 100f;
             var canvasHeight = Height / 100f;
 

--- a/Examples/Complete/Camera/Core/Camera.cs
+++ b/Examples/Complete/Camera/Core/Camera.cs
@@ -255,8 +255,6 @@ namespace Fusee.Examples.Camera.Core
             Texture guiFuseeLogo = new(AssetStorage.Get<ImageData>("FuseeText.png"));
             TextureNode fuseeLogo = new(
                 "fuseeLogo",
-                vsTex,
-                psTex,
                 //Set the diffuse texture you want to use.
                 guiFuseeLogo,
                 //Define anchor points. They are given in percent, seen from the lower left corner, respectively to the width/height of the parent.
@@ -274,8 +272,6 @@ namespace Fusee.Examples.Camera.Core
             TextNode text = new(
                 "FUSEE Camera Example",
                 "ButtonText",
-                vsTex,
-                psText,
                 UIElementPosition.GetAnchors(AnchorPos.StretchHorizontal),
                 UIElementPosition.CalcOffsets(AnchorPos.StretchHorizontal, new float2(canvasWidth / 2 - 4, 0), canvasHeight, canvasWidth, new float2(8, 1)),
                 guiLatoBlack,

--- a/Examples/Complete/Camera/Core/Camera.cs
+++ b/Examples/Complete/Camera/Core/Camera.cs
@@ -237,10 +237,6 @@ namespace Fusee.Examples.Camera.Core
 
         private SceneContainer CreateGui()
         {
-            string vsTex = AssetStorage.Get<string>("texture.vert");
-            string psTex = AssetStorage.Get<string>("texture.frag");
-            string psText = AssetStorage.Get<string>("text.frag");
-
             float canvasWidth = Width / 100f;
             float canvasHeight = Height / 100f;
 

--- a/Examples/Complete/ComputeFractal/Core/ComputeFractal.cs
+++ b/Examples/Complete/ComputeFractal/Core/ComputeFractal.cs
@@ -172,20 +172,6 @@ namespace Fusee.Examples.ComputeFractal.Core
 
         private SceneContainer CreateGui()
         {
-
-/* Unmerged change from project 'Fusee.Examples.ComputeFractal.Core(net5.0)'
-Before:
-            var vsTex = AssetStorage.Get<string>("texture.vert");
-            var psText = AssetStorage.Get<string>("text.frag");
-After:
-            _ = AssetStorage.Get<string>("texture.vert");
-            string psText;
-            _ = AssetStorage.Get<string>("text.frag");
-*/
-            _ = AssetStorage.Get<string>("texture.vert");
-            string psText;
-            _ = AssetStorage.Get<string>("text.frag");
-
             var canvasWidth = Width / 100f;
             var canvasHeight = Height / 100f;
 

--- a/Examples/Complete/ComputeFractal/Core/ComputeFractal.cs
+++ b/Examples/Complete/ComputeFractal/Core/ComputeFractal.cs
@@ -172,8 +172,19 @@ namespace Fusee.Examples.ComputeFractal.Core
 
         private SceneContainer CreateGui()
         {
+
+/* Unmerged change from project 'Fusee.Examples.ComputeFractal.Core(net5.0)'
+Before:
             var vsTex = AssetStorage.Get<string>("texture.vert");
             var psText = AssetStorage.Get<string>("text.frag");
+After:
+            _ = AssetStorage.Get<string>("texture.vert");
+            string psText;
+            _ = AssetStorage.Get<string>("text.frag");
+*/
+            _ = AssetStorage.Get<string>("texture.vert");
+            string psText;
+            _ = AssetStorage.Get<string>("text.frag");
 
             var canvasWidth = Width / 100f;
             var canvasHeight = Height / 100f;

--- a/Examples/Complete/ComputeFractal/Core/ComputeFractal.cs
+++ b/Examples/Complete/ComputeFractal/Core/ComputeFractal.cs
@@ -184,8 +184,6 @@ namespace Fusee.Examples.ComputeFractal.Core
             var textNode = new TextNode(
                 "Fractal Magnification Factor: " + _depthFactor,
                 "FractalDepth",
-                vsTex,
-                psText,
                 UIElementPosition.GetAnchors(AnchorPos.StretchHorizontal),
                 UIElementPosition.CalcOffsets(AnchorPos.StretchHorizontal, new float2(canvasWidth / 2 - 4, 0), canvasHeight, canvasWidth, new float2(8, 1)),
                 guiLatoBlack,

--- a/Examples/Complete/Integrations/Core/Main.cs
+++ b/Examples/Complete/Integrations/Core/Main.cs
@@ -175,8 +175,6 @@ namespace Fusee.Examples.Integrations.Core
             var guiFuseeLogo = new Texture(AssetStorage.Get<ImageData>("FuseeText.png"));
             var fuseeLogo = new TextureNode(
                 "fuseeLogo",
-                vsTex,
-                psTex,
                 //Set the albedo texture you want to use.
                 guiFuseeLogo,
                 //Define anchor points. They are given in percent, seen from the lower left corner, respectively to the width/height of the parent.
@@ -194,8 +192,6 @@ namespace Fusee.Examples.Integrations.Core
             var text = new TextNode(
                 "FUSEE Simple Example",
                 "ButtonText",
-                vsTex,
-                psText,
                 UIElementPosition.GetAnchors(AnchorPos.StretchHorizontal),
                 UIElementPosition.CalcOffsets(AnchorPos.StretchHorizontal, new float2(canvasWidth / 2 - 4, 0), canvasHeight, canvasWidth, new float2(8, 1)),
                 guiLatoBlack,

--- a/Examples/Complete/Integrations/Core/Main.cs
+++ b/Examples/Complete/Integrations/Core/Main.cs
@@ -157,10 +157,6 @@ namespace Fusee.Examples.Integrations.Core
 
         private SceneContainer CreateGui()
         {
-            var vsTex = AssetStorage.Get<string>("texture.vert");
-            var psTex = AssetStorage.Get<string>("texture.frag");
-            var psText = AssetStorage.Get<string>("text.frag");
-
             var canvasWidth = Width / 100f;
             var canvasHeight = Height / 100f;
 

--- a/Examples/Complete/Labyrinth/Core/Labyrinth.cs
+++ b/Examples/Complete/Labyrinth/Core/Labyrinth.cs
@@ -359,10 +359,6 @@ namespace Fusee.Examples.Labyrinth.Core
 
         private SceneContainer CreateGui()
         {
-            var vsTex = AssetStorage.Get<string>("texture.vert");
-            var psTex = AssetStorage.Get<string>("texture.frag");
-            var psText = AssetStorage.Get<string>("text.frag");
-
             var canvasWidth = Width / 100f;
             var canvasHeight = Height / 100f;
 
@@ -734,10 +730,6 @@ namespace Fusee.Examples.Labyrinth.Core
         // Creates winning display
         public SceneContainer WinningDisplay()
         {
-            var vsTex = AssetStorage.Get<string>("texture.vert");
-            var psTex = AssetStorage.Get<string>("texture.frag");
-            var psText = AssetStorage.Get<string>("text.frag");
-
             var canvasWidth = Width / 100f;
             var canvasHeight = Height / 100f;
 

--- a/Examples/Complete/Labyrinth/Core/Labyrinth.cs
+++ b/Examples/Complete/Labyrinth/Core/Labyrinth.cs
@@ -377,8 +377,6 @@ namespace Fusee.Examples.Labyrinth.Core
             var guiFuseeLogo = new Texture(AssetStorage.Get<ImageData>("FuseeText.png"));
             var fuseeLogo = new TextureNode(
                 "fuseeLogo",
-                vsTex,
-                psTex,
                 //Set the albedo texture you want to use.
                 guiFuseeLogo,
                 //Define anchor points. They are given in percent, seen from the lower left corner, respectively to the width/height of the parent.
@@ -396,8 +394,6 @@ namespace Fusee.Examples.Labyrinth.Core
             var text = new TextNode(
                 "FUSEE Simple Example",
                 "ButtonText",
-                vsTex,
-                psText,
                 UIElementPosition.GetAnchors(AnchorPos.StretchHorizontal),
                 UIElementPosition.CalcOffsets(AnchorPos.StretchHorizontal, new float2(canvasWidth / 2 - 4, 0), canvasHeight, canvasWidth, new float2(8, 1)),
                 guiLatoBlack,
@@ -409,8 +405,6 @@ namespace Fusee.Examples.Labyrinth.Core
             var timer = new TextNode(
                 "00:00.00",
                 "Timer",
-                vsTex,
-                psText,
                 UIElementPosition.GetAnchors(AnchorPos.TopTopRight),
                 new MinMaxRect
                 {
@@ -758,8 +752,6 @@ namespace Fusee.Examples.Labyrinth.Core
             var guiFuseeLogo = new Texture(AssetStorage.Get<ImageData>("FuseeText.png"));
             var fuseeLogo = new TextureNode(
                 "fuseeLogo",
-                vsTex,
-                psText,
                 //Set the albedo texture you want to use.
                 guiFuseeLogo,
                 //Define anchor points. They are given in percent, seen from the lower left corner, respectively to the width/height of the parent.
@@ -777,8 +769,6 @@ namespace Fusee.Examples.Labyrinth.Core
             var text = new TextNode(
                 "FUSEE Simple Example",
                 "ButtonText",
-                vsTex,
-                psText,
                 UIElementPosition.GetAnchors(AnchorPos.StretchHorizontal),
                 UIElementPosition.CalcOffsets(AnchorPos.StretchHorizontal, new float2(canvasWidth / 2 - 4, 0), canvasHeight, canvasWidth, new float2(8, 1)),
                 guiLatoBlack,
@@ -790,8 +780,6 @@ namespace Fusee.Examples.Labyrinth.Core
                 "SOLVED\n" +
                 _timertext.Text,
                 "Timer",
-                vsTex,
-                psText,
                 UIElementPosition.GetAnchors(AnchorPos.Middle),
                 new MinMaxRect
                 {

--- a/Examples/Complete/Materials/Core/Materials.cs
+++ b/Examples/Complete/Materials/Core/Materials.cs
@@ -30,10 +30,7 @@ namespace Fusee.Examples.Materials.Core
         public override void Init()
         {
             Font fontLato = AssetStorage.Get<Font>("Lato-Black.ttf");
-            FontMap fontLatoMap = new(fontLato, 32);
-
-            string vsTex = AssetStorage.Get<string>("texture.vert");
-            string psTex = AssetStorage.Get<string>("texture.frag");
+            FontMap fontLatoMap = new(fontLato, 32);            
 
             Icosphere icosphereWithTangents = new(5);
             icosphereWithTangents.Tangents = icosphereWithTangents.CalculateTangents();
@@ -62,8 +59,6 @@ namespace Fusee.Examples.Materials.Core
                             new TextNode(
                             "How-To:\n############################\n- Move with WASD\n- Left mouse button rotates spheres\n- Mouse wheel zooms",
                             "howTo",
-                            vsTex,
-                            psTex,
                             UIElementPosition.GetAnchors(AnchorPos.DownDownLeft),
                             UIElementPosition.CalcOffsets(AnchorPos.DownDownLeft, new float2(-11, -5), canvasHeight, canvasWidth, new float2(12, 1)),
                             fontLatoMap,
@@ -87,8 +82,6 @@ namespace Fusee.Examples.Materials.Core
                                 new TextNode(
                                 "Complete",
                                 "desc",
-                                vsTex,
-                                psTex,
                                 MinMaxRect.FromCenterSize(float2.Zero, float2.One),
                                 new MinMaxRect(),
                                 fontLatoMap,
@@ -97,8 +90,6 @@ namespace Fusee.Examples.Materials.Core
                                 VerticalTextAlignment.Center),new TextNode(
                                 "NOT YET IMPLEMENTED",
                                 "desc",
-                                vsTex,
-                                psTex,
                                 MinMaxRect.FromCenterSize(float2.Zero, float2.One),
                                 new MinMaxRect
                                 {
@@ -126,8 +117,6 @@ namespace Fusee.Examples.Materials.Core
                                 new TextNode(
                                 "Albedo and Specular",
                                 "desc",
-                                vsTex,
-                                psTex,
                                 MinMaxRect.FromCenterSize(float2.Zero, float2.One),
                                 new MinMaxRect(),
                                 fontLatoMap,
@@ -151,8 +140,6 @@ namespace Fusee.Examples.Materials.Core
                                 new TextNode(
                                 "Albedo, specular and\nalbedo texture",
                                 "desc",
-                                vsTex,
-                                psTex,
                                 MinMaxRect.FromCenterSize(float2.Zero, float2.One),
                                 new MinMaxRect(),
                                 fontLatoMap,
@@ -176,8 +163,6 @@ namespace Fusee.Examples.Materials.Core
                                 new TextNode(
                                 "Specular texture",
                                 "desc",
-                                vsTex,
-                                psTex,
                                 MinMaxRect.FromCenterSize(float2.Zero, float2.One),
                                 new MinMaxRect(),
                                 fontLatoMap,
@@ -187,8 +172,6 @@ namespace Fusee.Examples.Materials.Core
                                 new TextNode(
                                 "NOT YET IMPLEMENTED",
                                 "desc",
-                                vsTex,
-                                psTex,
                                 MinMaxRect.FromCenterSize(float2.Zero, float2.One),
                                 new MinMaxRect
                                 {
@@ -216,8 +199,6 @@ namespace Fusee.Examples.Materials.Core
                                 new TextNode(
                                 "Normal map",
                                 "desc",
-                                vsTex,
-                                psTex,
                                 MinMaxRect.FromCenterSize(float2.Zero, float2.One),
                                 new MinMaxRect(),
                                 fontLatoMap,
@@ -241,8 +222,6 @@ namespace Fusee.Examples.Materials.Core
                                      new TextNode(
                                         "Albedo and emissive",
                                         "desc",
-                                        vsTex,
-                                        psTex,
                                         MinMaxRect.FromCenterSize(float2.Zero, float2.One),
                                         new MinMaxRect(),
                                         fontLatoMap,
@@ -252,8 +231,6 @@ namespace Fusee.Examples.Materials.Core
                                       new TextNode(
                                         "NOT YET IMPLEMENTED",
                                         "desc",
-                                        vsTex,
-                                        psTex,
                                         MinMaxRect.FromCenterSize(float2.Zero, float2.One),
                                         new MinMaxRect
                                         {
@@ -281,8 +258,6 @@ namespace Fusee.Examples.Materials.Core
                                      new TextNode(
                                         "Albedo, emissive and\nemissive texture",
                                         "desc",
-                                        vsTex,
-                                        psTex,
                                         MinMaxRect.FromCenterSize(float2.Zero, float2.One),
                                         new MinMaxRect(),
                                         fontLatoMap,
@@ -292,8 +267,6 @@ namespace Fusee.Examples.Materials.Core
                                      new TextNode(
                                         "NOT YET IMPLEMENTED",
                                         "desc",
-                                        vsTex,
-                                        psTex,
                                         MinMaxRect.FromCenterSize(float2.Zero, float2.One),
                                         new MinMaxRect
                                         {

--- a/Examples/Complete/Materials/Core/Materials.cs
+++ b/Examples/Complete/Materials/Core/Materials.cs
@@ -30,7 +30,7 @@ namespace Fusee.Examples.Materials.Core
         public override void Init()
         {
             Font fontLato = AssetStorage.Get<Font>("Lato-Black.ttf");
-            FontMap fontLatoMap = new(fontLato, 32);            
+            FontMap fontLatoMap = new(fontLato, 32);
 
             Icosphere icosphereWithTangents = new(5);
             icosphereWithTangents.Tangents = icosphereWithTangents.CalculateTangents();

--- a/Examples/Complete/Picking/Core/Picking.cs
+++ b/Examples/Complete/Picking/Core/Picking.cs
@@ -171,10 +171,6 @@ namespace Fusee.Examples.Picking.Core
 
         private SceneContainer CreateGui()
         {
-            var vsTex = AssetStorage.Get<string>("texture.vert");
-            var psTex = AssetStorage.Get<string>("texture.frag");
-            var psText = AssetStorage.Get<string>("text.frag");
-
             var canvasWidth = Width / 100f;
             var canvasHeight = Height / 100f;
 

--- a/Examples/Complete/Picking/Core/Picking.cs
+++ b/Examples/Complete/Picking/Core/Picking.cs
@@ -189,8 +189,6 @@ namespace Fusee.Examples.Picking.Core
             var guiFuseeLogo = new Texture(AssetStorage.Get<ImageData>("FuseeText.png"));
             var fuseeLogo = new TextureNode(
                 "fuseeLogo",
-                vsTex,
-                psTex,
                 //Set the albedo texture you want to use.
                 guiFuseeLogo,
                 //Define anchor points. They are given in percent, seen from the lower left corner, respectively to the width/height of the parent.
@@ -208,8 +206,6 @@ namespace Fusee.Examples.Picking.Core
             var text = new TextNode(
                 "FUSEE Picking Example",
                 "ButtonText",
-                vsTex,
-                psText,
                 UIElementPosition.GetAnchors(AnchorPos.StretchHorizontal),
                 UIElementPosition.CalcOffsets(AnchorPos.StretchHorizontal, new float2(canvasWidth / 2 - 4, 0), canvasHeight, canvasWidth, new float2(8, 1)),
                 guiLatoBlack,

--- a/Examples/Complete/Simple/Core/Simple.cs
+++ b/Examples/Complete/Simple/Core/Simple.cs
@@ -133,10 +133,6 @@ namespace Fusee.Examples.Simple.Core
 
         private SceneContainer CreateGui()
         {
-            var vsTex = AssetStorage.Get<string>("texture.vert");
-            var psTex = AssetStorage.Get<string>("texture.frag");
-            var psText = AssetStorage.Get<string>("text.frag");
-
             var canvasWidth = Width / 100f;
             var canvasHeight = Height / 100f;
 

--- a/Examples/Complete/Simple/Core/Simple.cs
+++ b/Examples/Complete/Simple/Core/Simple.cs
@@ -151,8 +151,6 @@ namespace Fusee.Examples.Simple.Core
             var guiFuseeLogo = new Texture(AssetStorage.Get<ImageData>("FuseeText.png"));
             var fuseeLogo = new TextureNode(
                 "fuseeLogo",
-                vsTex,
-                psTex,
                 //Set the albedo texture you want to use.
                 guiFuseeLogo,
                 //Define anchor points. They are given in percent, seen from the lower left corner, respectively to the width/height of the parent.
@@ -170,8 +168,6 @@ namespace Fusee.Examples.Simple.Core
             var text = new TextNode(
                 "FUSEE Simple Example",
                 "ButtonText",
-                vsTex,
-                psText,
                 UIElementPosition.GetAnchors(AnchorPos.StretchHorizontal),
                 UIElementPosition.CalcOffsets(AnchorPos.StretchHorizontal, new float2(canvasWidth / 2 - 4, 0), canvasHeight, canvasWidth, new float2(8, 1)),
                 guiLatoBlack,

--- a/Examples/Complete/SimpleDeferred/Core/SimpleDeferred.cs
+++ b/Examples/Complete/SimpleDeferred/Core/SimpleDeferred.cs
@@ -288,8 +288,6 @@ namespace Fusee.Examples.SimpleDeferred.Core
             var guiFuseeLogo = new Texture(AssetStorage.Get<ImageData>("FuseeText.png"));
             var fuseeLogo = new TextureNode(
                 "fuseeLogo",
-                vsTex,
-                psTex,
                 //Set the diffuse texture you want to use.
                 guiFuseeLogo,
                 //Define anchor points. They are given in percent, seen from the lower left corner, respectively to the width/height of the parent.
@@ -309,8 +307,6 @@ namespace Fusee.Examples.SimpleDeferred.Core
             var text = new TextNode(
                 "FUSEE Deferred Example",
                 "ButtonText",
-                vsTex,
-                psText,
                 UIElementPosition.GetAnchors(AnchorPos.StretchHorizontal),
                 UIElementPosition.CalcOffsets(AnchorPos.StretchHorizontal, new float2(canvasWidth / 2 - 4, 0), canvasHeight, canvasWidth, new float2(8, 1)),
                 guiLatoBlack,

--- a/Examples/Complete/SimpleDeferred/Core/SimpleDeferred.cs
+++ b/Examples/Complete/SimpleDeferred/Core/SimpleDeferred.cs
@@ -270,10 +270,6 @@ namespace Fusee.Examples.SimpleDeferred.Core
 
         private SceneContainer CreateGui()
         {
-            var vsTex = AssetStorage.Get<string>("texture.vert");
-            var psTex = AssetStorage.Get<string>("texture.frag");
-            var psText = AssetStorage.Get<string>("text.frag");
-
             var canvasWidth = Width / 100f;
             var canvasHeight = Height / 100f;
 

--- a/Examples/Complete/Starkiller/Core/Starkiller.cs
+++ b/Examples/Complete/Starkiller/Core/Starkiller.cs
@@ -262,10 +262,6 @@ namespace Fusee.Examples.Starkiller.Core
         }
         private SceneContainer CreateGui()
         {
-            var vsTex = AssetStorage.Get<string>("texture.vert");
-            var psTex = AssetStorage.Get<string>("texture.frag");
-            var psText = AssetStorage.Get<string>("text.frag");
-
             var canvasWidth = Width / 100f;
             var canvasHeight = Height / 100f;
 

--- a/Examples/Complete/Starkiller/Core/Starkiller.cs
+++ b/Examples/Complete/Starkiller/Core/Starkiller.cs
@@ -280,8 +280,6 @@ namespace Fusee.Examples.Starkiller.Core
             var guiFuseeLogo = new Texture(AssetStorage.Get<ImageData>("FuseeText.png"));
             var fuseeLogo = new TextureNode(
                 "fuseeLogo",
-                vsTex,
-                psTex,
                 //Set the albedo texture you want to use.
                 guiFuseeLogo,
                 //Define anchor points. They are given in percent, seen from the lower left corner, respectively to the width/height of the parent.
@@ -311,8 +309,6 @@ namespace Fusee.Examples.Starkiller.Core
             var text = new TextNode(
                 textToDisplay,
                 "SceneDescriptionText",
-                vsTex,
-                psText,
                 UIElementPosition.GetAnchors(AnchorPos.StretchHorizontal),
                 UIElementPosition.CalcOffsets(AnchorPos.StretchHorizontal, new float2(_initCanvasWidth / 2 - 4, 0), _initCanvasHeight, _initCanvasWidth, new float2(8, 1)),
                 guiLatoBlack,

--- a/Examples/Complete/SurfaceEffects/Core/SurfaceEffects.cs
+++ b/Examples/Complete/SurfaceEffects/Core/SurfaceEffects.cs
@@ -213,10 +213,6 @@ namespace Fusee.Examples.SurfaceEffects.Core
 
         private SceneContainer CreateGui()
         {
-            var vsTex = AssetStorage.Get<string>("texture.vert");
-            var psTex = AssetStorage.Get<string>("texture.frag");
-            var psText = AssetStorage.Get<string>("text.frag");
-
             var canvasWidth = Width / 100f;
             var canvasHeight = Height / 100f;
 

--- a/Examples/Complete/SurfaceEffects/Core/SurfaceEffects.cs
+++ b/Examples/Complete/SurfaceEffects/Core/SurfaceEffects.cs
@@ -231,8 +231,6 @@ namespace Fusee.Examples.SurfaceEffects.Core
             var guiFuseeLogo = new Texture(AssetStorage.Get<ImageData>("FuseeText.png"));
             var fuseeLogo = new TextureNode(
                 "fuseeLogo",
-                vsTex,
-                psTex,
                 //Set the albedo texture you want to use.
                 guiFuseeLogo,
                 //Define anchor points. They are given in percent, seen from the lower left corner, respectively to the width/height of the parent.
@@ -250,8 +248,6 @@ namespace Fusee.Examples.SurfaceEffects.Core
             var text = new TextNode(
                 "FUSEE Simple Example",
                 "ButtonText",
-                vsTex,
-                psText,
                 UIElementPosition.GetAnchors(AnchorPos.StretchHorizontal),
                 UIElementPosition.CalcOffsets(AnchorPos.StretchHorizontal, new float2(canvasWidth / 2 - 4, 0), canvasHeight, canvasWidth, new float2(8, 1)),
                 guiLatoBlack,

--- a/Examples/Complete/UI/Core/UI.cs
+++ b/Examples/Complete/UI/Core/UI.cs
@@ -55,12 +55,6 @@ namespace Fusee.Examples.UI.Core
         //Build a scene graph consisting out of a canvas and other UI elements.
         private SceneContainer CreateNineSliceScene()
         {
-            var vsTex = AssetStorage.Get<string>("texture.vert");
-            var psTex = AssetStorage.Get<string>("texture.frag");
-            var psText = AssetStorage.Get<string>("text.frag");
-            var vsNineSlice = AssetStorage.Get<string>("nineSlice.vert");
-            var psNineSlice = AssetStorage.Get<string>("nineSliceTile.frag");
-
             var canvasScaleFactor = _initWindowWidth / _canvasWidth;
 
             float borderScaleFactor = 1;
@@ -72,8 +66,6 @@ namespace Fusee.Examples.UI.Core
             var fps = new TextNode(
                 "FPS: 0.00",
                 "FPSText",
-                vsTex,
-                psText,
                 UIElementPosition.GetAnchors(AnchorPos.DownDownRight),
                 new MinMaxRect
                 {
@@ -94,8 +86,6 @@ namespace Fusee.Examples.UI.Core
                 "jump\n" +
                 "quickly.",
                 "ButtonText",
-                vsTex,
-                psText,
                 UIElementPosition.GetAnchors(AnchorPos.StretchAll),
                 new MinMaxRect
                 {
@@ -108,9 +98,7 @@ namespace Fusee.Examples.UI.Core
                 VerticalTextAlignment.Center);
 
             var catTextureNode = new TextureNode(
-                "Cat",
-                AssetStorage.Get<string>("nineSlice.vert"),
-                AssetStorage.Get<string>("nineSliceTile.frag"),
+                "Cat",                
                 //Set the albedo texture you want to use.
                 new Texture(AssetStorage.Get<ImageData>("Kitti.jpg"), false, TextureFilterMode.Linear),
 
@@ -135,8 +123,6 @@ namespace Fusee.Examples.UI.Core
 
             var bltTextureNode = new TextureNode(
                 "Blt",
-                vsTex,
-                psTex,
                 //Set the albedo texture you want to use.
                 _bltDestinationTex,
                 //_fontMap.Image,
@@ -152,8 +138,6 @@ namespace Fusee.Examples.UI.Core
 
             var quagganTextureNode1 = new TextureNode(
                 "Quaggan1",
-                vsNineSlice,
-                psNineSlice,
                 new Texture(AssetStorage.Get<ImageData>("testTex.jpg"), false, TextureFilterMode.Linear),
                 //In this setup the element will stay in the upper left corner of the parent and will not be stretched at all.
                 UIElementPosition.GetAnchors(AnchorPos.TopTopLeft), //Anchor is in the lower right corner.Anchor is in the lower left corner.
@@ -167,8 +151,6 @@ namespace Fusee.Examples.UI.Core
 
             var nineSliceTextureNode = new TextureNode(
                 "testImage",
-                vsNineSlice,
-                psNineSlice,
                 new Texture(AssetStorage.Get<ImageData>("9SliceSprites-4.png")),
                 //In this setup the element will stay in the upper right corner of the parent and will not be stretched at all.
                 UIElementPosition.GetAnchors(AnchorPos.TopTopRight),//Anchor is in the upper right corner.//Anchor is in the upper right corner.
@@ -184,8 +166,6 @@ namespace Fusee.Examples.UI.Core
 
             var quagganTextureNode = new TextureNode(
                 "Quaggan",
-                vsNineSlice,
-                psNineSlice,
                 new Texture(AssetStorage.Get<ImageData>("testTex.jpg"), false, TextureFilterMode.Linear),
                 //In this setup the element will stay in the upper left corner of the parent and will not be stretched at all.
                 UIElementPosition.GetAnchors(AnchorPos.TopTopLeft), //Anchor is in the lower right corner.Anchor is in the lower left corner.
@@ -198,8 +178,6 @@ namespace Fusee.Examples.UI.Core
 
             var quagganTextureNode2 = new TextureNode(
                 "Quaggan",
-                vsNineSlice,
-                psNineSlice,
                 new Texture(AssetStorage.Get<ImageData>("testTex.jpg"), false, TextureFilterMode.Linear),
                 //In this setup the element will stay in the upper left corner of the parent and will not be stretched at all.
                 UIElementPosition.GetAnchors(AnchorPos.TopTopLeft), //Anchor is in the lower right corner.Anchor is in the lower left corner.
@@ -212,8 +190,6 @@ namespace Fusee.Examples.UI.Core
 
             var quagganTextureNode3 = new TextureNode(
                 "Quaggan",
-                vsNineSlice,
-                psNineSlice,
                 new Texture(AssetStorage.Get<ImageData>("testTex.jpg"), false, TextureFilterMode.Linear),
                 //In this setup the element will stay in the upper left corner of the parent and will not be stretched at all.
                 UIElementPosition.GetAnchors(AnchorPos.StretchVertical), //Anchor is in the lower right corner. Anchor is in the lower left corner.

--- a/Examples/Complete/UI/Core/UI.cs
+++ b/Examples/Complete/UI/Core/UI.cs
@@ -98,7 +98,7 @@ namespace Fusee.Examples.UI.Core
                 VerticalTextAlignment.Center);
 
             var catTextureNode = new TextureNode(
-                "Cat",                
+                "Cat",
                 //Set the albedo texture you want to use.
                 new Texture(AssetStorage.Get<ImageData>("Kitti.jpg"), false, TextureFilterMode.Linear),
 

--- a/src/Engine/Core/FontMap.cs
+++ b/src/Engine/Core/FontMap.cs
@@ -145,7 +145,7 @@ namespace Fusee.Engine.Core
                 // Copy each character in the alphabet to the font atlas
                 foreach (char c in _alphabet)
                 {
-                    IImageData glyphImg = _font.RenderGlyph((uint)c, out int bitmapLeft, out int bitmapTop);
+                    IImageData glyphImg = _font.RenderGlyph(c, out int bitmapLeft, out int bitmapTop);
                     if (offX + glyphImg.Width + 1 >= width)
                     {
                         offY += rowH;

--- a/src/Engine/GUI/GUINode.cs
+++ b/src/Engine/GUI/GUINode.cs
@@ -1,4 +1,5 @@
-﻿using Fusee.Engine.Common;
+﻿using Fusee.Base.Core;
+using Fusee.Engine.Common;
 using Fusee.Engine.Core;
 using Fusee.Engine.Core.Effects;
 using Fusee.Engine.Core.Primitives;
@@ -221,8 +222,6 @@ namespace Fusee.Engine.GUI
         /// By default the border thickness is calculated relative to a unit plane. For a thicker border set the border thickness to the desired value, 2 means a twice as thick border.
         /// </summary>
         /// <param name="name">Name of the SceneNodeContainer.</param>
-        /// <param name="vs">The vertex shader you want to use.</param>
-        /// <param name="ps">The pixel shader you want to use.</param>
         /// /<param name="tex">Diffuse texture.</param>
         /// <param name="anchors">Anchors for the mesh. Influences the scaling of the object if the enclosing canvas is resized.</param>
         /// <param name="offsets">Offsets for the mesh. Defines the position of the object relative to its enclosing UI element.</param>
@@ -234,11 +233,13 @@ namespace Fusee.Engine.GUI
         /// <param name="borderThicknessRight">Border thickness for the right border.</param>
         /// <param name="borderThicknessTop">Border thickness for the top border.</param>
         /// <returns></returns>
-        public TextureNode(string name, string vs, string ps, Texture tex, MinMaxRect anchors,
+        public TextureNode(string name, Texture tex, MinMaxRect anchors,
             MinMaxRect offsets, float2 tiles, float4 borders, float borderThicknessLeft = 1, float borderThicknessRight = 1, float borderThicknessTop = 1, float borderThicknessBottom = 1, float borderScaleFactor = 1)
         {
             var borderThickness = new float4(borderThicknessLeft, borderThicknessRight, borderThicknessTop,
                 borderThicknessBottom);
+            var vs = AssetStorage.Get<string>("nineSlice.vert");
+            var ps = AssetStorage.Get<string>("nineSliceTile.frag");
             Name = name;
             Components = new List<SceneComponent>
             {
@@ -295,16 +296,16 @@ namespace Fusee.Engine.GUI
         /// Creates a SceneNodeContainer with the proper components and children for rendering a nine sliced texture.
         /// </summary>
         /// <param name="name">Name of the SceneNodeContainer.</param>
-        /// <param name="vs">The vertex shader you want to use.</param>
-        /// <param name="ps">The pixel shader you want to use.</param>
         /// /<param name="tex">Diffuse texture.</param>
         /// <param name="anchors">Anchors for the mesh. Influences the scaling of the object if the enclosing canvas is resized.</param>
         /// <param name="offsets">Offsets for the mesh. Defines the position of the object relative to its enclosing UI element.</param>
         /// <param name="diffuseTexTiles">The tiling of the diffuse texture.</param>
         /// <returns></returns>
-        public TextureNode(string name, string vs, string ps, Texture tex, MinMaxRect anchors,
+        public TextureNode(string name, Texture tex, MinMaxRect anchors,
             MinMaxRect offsets, float2 diffuseTexTiles)
         {
+            var vs = AssetStorage.Get<string>("texture.vert");
+            var ps = AssetStorage.Get<string>("texture.frag");
             Name = name;
             Components = new List<SceneComponent>
             {
@@ -360,17 +361,18 @@ namespace Fusee.Engine.GUI
         /// </summary>
         /// <param name="text">The text you want to display.</param>
         /// <param name="name">The name of the SceneNodeContainer.</param>
-        /// <param name="vs">The vertex shader you want to use..</param>
-        /// <param name="ps">The pixel shader you want to use.</param>
         /// <param name="anchors">Anchors for the mesh. Influences the scaling of the object if the enclosing canvas is resized.</param>
         /// <param name="offsets">The offsets.</param>
         /// <param name="fontMap">Offsets for the mesh. Defines the position of the object relative to its enclosing UI element.</param>
         /// <param name="color">The color.</param>
         /// <param name="horizontalAlignment">The <see cref="HorizontalTextAlignment"/> defines the text's placement along the enclosing <see cref="MinMaxRect"/>'s x-axis.</param>
         /// <param name="verticalTextAlignment">The <see cref="HorizontalTextAlignment"/> defines the text's placement along the enclosing <see cref="MinMaxRect"/>'s y-axis.</param>
-        public TextNode(string text, string name, string vs, string ps, MinMaxRect anchors, MinMaxRect offsets,
+        public TextNode(string text, string name, MinMaxRect anchors, MinMaxRect offsets,
             FontMap fontMap, float4 color, HorizontalTextAlignment horizontalAlignment = HorizontalTextAlignment.Left, VerticalTextAlignment verticalTextAlignment = VerticalTextAlignment.Top)
         {
+
+            string vs = AssetStorage.Get<string>("texture.vert");
+            string ps = AssetStorage.Get<string>("text.frag");
             var textMesh = new GUIText(fontMap, text, horizontalAlignment)
             {
                 Name = name + "textMesh"

--- a/src/Engine/Player/Core/Player.cs
+++ b/src/Engine/Player/Core/Player.cs
@@ -264,8 +264,6 @@ namespace Fusee.Engine.Player.Core
             var guiFuseeLogo = new Texture(AssetStorage.Get<ImageData>("FuseeText.png"));
             var fuseeLogo = new TextureNode(
                 "fuseeLogo",
-                vsTex,
-                psTex,
                 //Set the albedo texture you want to use.
                 guiFuseeLogo,
                 //Define anchor points. They are given in percent, seen from the lower left corner, respectively to the width/height of the parent.
@@ -283,8 +281,6 @@ namespace Fusee.Engine.Player.Core
             var text = new TextNode(
                 "FUSEE Simple Example",
                 "ButtonText",
-                vsTex,
-                psText,
                 UIElementPosition.GetAnchors(AnchorPos.StretchHorizontal),
                 UIElementPosition.CalcOffsets(AnchorPos.StretchHorizontal, new float2(canvasWidth / 2 - 4, 0), canvasHeight, canvasWidth, new float2(8, 1)),
                 guiLatoBlack,

--- a/src/Engine/Player/Core/Player.cs
+++ b/src/Engine/Player/Core/Player.cs
@@ -246,10 +246,6 @@ namespace Fusee.Engine.Player.Core
 
         private SceneContainer CreateGui()
         {
-            var vsTex = AssetStorage.Get<string>("texture.vert");
-            var psTex = AssetStorage.Get<string>("texture.frag");
-            var psText = AssetStorage.Get<string>("text.frag");
-
             var canvasWidth = Width / 100f;
             var canvasHeight = Height / 100f;
 


### PR DESCRIPTION
Removed _vs_ and _ps_ parameters from the TextureNode and TextNode constructors.
There is only one correct set of shaders per constructor. Furthermore this prevents spelling mistakes like "tex" where "text" is needed. 