### PR TITLE
Disabled getWeights() 

### DIFF
--- a/src/Engine/Core/SceneRendererDeferred.cs
+++ b/src/Engine/Core/SceneRendererDeferred.cs
@@ -44,14 +44,14 @@ namespace Fusee.Engine.Core
         public int CascadeFarPlane = 500;
 
         /// <summary>
-        /// Controls whether the render output is anti aliased using FXAA. 
+        /// Controls whether the render output is anti aliased using FXAA.
         /// This is done in an additional pass that is turned off if this is set to false.
         /// </summary>
         public bool FxaaOn { get; set; } = true;
 
         /// <summary>
         /// Determines if the scene gets rendered with Screen Space Ambient Occlusion.
-        /// This is done in an additional pass that is turned of if this is set to false. 
+        /// This is done in an additional pass that is turned of if this is set to false.
         /// In this case the ambient component of the lighting is a static value.
         /// If possible set this in the "Init" method to avoid the creation of an SSAO texture if you don't need one.
         /// </summary>
@@ -98,7 +98,7 @@ namespace Fusee.Engine.Core
         //The following ShaderEffects cache all possible ShaderEffects, needed to render the lighting passes.
         private ShaderEffect _lightingPassEffectPoint; //needed when a point light is rendered;
         private ShaderEffect _lightingPassEffectOther; //needed when a light of another type is rendered;
-        private ShaderEffect _lightingPassEffectNoShadow; //needed when a light of another type is rendered without shadows;         
+        private ShaderEffect _lightingPassEffectNoShadow; //needed when a light of another type is rendered without shadows;
         private ShaderEffect _lightingPassEffectCascaded; //needed when a parallel light is rendered with cascaded shadow mapping;
         private ShaderEffect _lightingPassEffectNoCascades; //needed when a parallel light is rendered without cascaded shadow mapping;
 
@@ -184,9 +184,9 @@ namespace Fusee.Engine.Core
                 }
             }
 
-            var wc = CurrentNode.GetWeights();
-            if (wc != null)
-                AddWeightToMesh(mesh, wc);
+            //var wc = CurrentNode.GetWeights();
+            //if (wc != null)
+            //    AddWeightToMesh(mesh, wc);
 
             var renderStatesBefore = _rc.CurrentRenderState.Copy();
             if (_currentPass == RenderPasses.Shadow && _currentLightType == LightType.Point)

--- a/src/Engine/Core/SceneRendererForward.cs
+++ b/src/Engine/Core/SceneRendererForward.cs
@@ -96,7 +96,7 @@ namespace Fusee.Engine.Core
 
         #endregion
 
-        #region Initialization Construction Startup      
+        #region Initialization Construction Startup
 
 
         private Light _legacyLight;
@@ -611,7 +611,7 @@ namespace Fusee.Engine.Core
         /// <summary>
         /// If a Transform is visited the model matrix of the <see cref="RenderContext"/> and <see cref="RendererState"/> is updated.
         /// It additionally updates the view matrix of the RenderContext.
-        /// </summary> 
+        /// </summary>
         /// <param name="transform">The Transform.</param>
         [VisitMethod]
         public void RenderTransform(Transform transform)
@@ -647,8 +647,8 @@ namespace Fusee.Engine.Core
         }
 
         /// <summary>
-        /// If a Mesh is visited and it has a <see cref="Weight"/> the BoneIndices and  BoneWeights get set, 
-        /// the shader parameters for all lights in the scene are updated and the geometry is passed to be pushed through the rendering pipeline.        
+        /// If a Mesh is visited and it has a <see cref="Weight"/> the BoneIndices and  BoneWeights get set,
+        /// the shader parameters for all lights in the scene are updated and the geometry is passed to be pushed through the rendering pipeline.
         /// </summary>
         /// <param name="mesh">The Mesh.</param>
         [VisitMethod]
@@ -669,9 +669,9 @@ namespace Fusee.Engine.Core
                 }
             }
 
-            var wc = CurrentNode.GetWeights();
-            if (wc != null)
-                AddWeightToMesh(mesh, wc);
+            //var wc = CurrentNode.GetWeights();
+            //if (wc != null)
+            //    AddWeightToMesh(mesh, wc);
 
             var renderStatesBefore = _rc.CurrentRenderState.Copy();
             _rc.Render(mesh, true);


### PR DESCRIPTION
This disables the `getWeights()` function for each render pass. Should yield a performance boost up to 20 fps.