### PR TITLE
Feature/524 point cloud with multiple cameras

### DIFF
--- a/Examples/Complete/ImGui/Desktop/Main.cs
+++ b/Examples/Complete/ImGui/Desktop/Main.cs
@@ -1,12 +1,10 @@
 ﻿using Fusee.Base.Common;
 using Fusee.Base.Core;
 using Fusee.Base.Imp.Desktop;
-using Fusee.Engine.Common;
 using Fusee.Engine.Core;
 using Fusee.Engine.Core.Scene;
 using Fusee.Serialization;
 using System.IO;
-using System.Reflection;
 using System.Threading.Tasks;
 
 namespace Fusee.Examples.FuseeImGui.Desktop

--- a/Examples/Complete/PointCloudPotree2/Core/PointCloudPotree2.cs
+++ b/Examples/Complete/PointCloudPotree2/Core/PointCloudPotree2.cs
@@ -143,9 +143,9 @@ namespace Fusee.Examples.PointCloudPotree2.Core
             _sih = new SceneInteractionHandler(_gui);
 
             _sceneRenderer = new SceneRendererForward(_scene);
-            _sceneRenderer.VisitorModules.Add(new PointCloudRenderModule());
+            _sceneRenderer.VisitorModules.Add(new PointCloudRenderModule(_sceneRenderer.GetType() == typeof(SceneRendererForward)));
             _guiRenderer = new SceneRendererForward(_gui);
-
+            _pointCloud.Camera = _cam;
             IsInitialized = true;
         }
 

--- a/Examples/Complete/PointCloudPotree2/ImGui/PointCloudControlCore.cs
+++ b/Examples/Complete/PointCloudPotree2/ImGui/PointCloudControlCore.cs
@@ -120,7 +120,9 @@ namespace Fusee.Examples.PointCloudPotree2.PotreeImGui
                 };
 
                 _sceneRenderer = new SceneRendererForward(_scene);
-                _sceneRenderer.VisitorModules.Add(new PointCloudRenderModule());
+                _sceneRenderer.VisitorModules.Add(new PointCloudRenderModule(_sceneRenderer.GetType() == typeof(SceneRendererForward)));
+
+                _pointCloud.Camera = _cam;
 
                 IsInitialized = true;
             }

--- a/src/Engine/Core/CameraResult.cs
+++ b/src/Engine/Core/CameraResult.cs
@@ -1,5 +1,6 @@
 ﻿using Fusee.Engine.Core.Scene;
 using Fusee.Math.Core;
+using System;
 
 namespace Fusee.Engine.Core
 {

--- a/src/Engine/Core/CameraResult.cs
+++ b/src/Engine/Core/CameraResult.cs
@@ -1,6 +1,5 @@
 ﻿using Fusee.Engine.Core.Scene;
 using Fusee.Math.Core;
-using System;
 
 namespace Fusee.Engine.Core
 {

--- a/src/Engine/Core/IRendererModule.cs
+++ b/src/Engine/Core/IRendererModule.cs
@@ -9,20 +9,27 @@ namespace Fusee.Engine.Core
     public interface IRendererModule : IVisitorModule
     {
         /// <summary>
-        /// The RenderLayer this renderer should render.
+        /// Sets the currently used <see cref="RenderLayer"/>.
         /// </summary>
-        public RenderLayers RenderLayer { get; set; }
+        /// <param name="renderLayer"></param>
+        public void UpdateRenderLayer(RenderLayers renderLayer);
+
+        /// <summary>
+        /// Sets the currently used <see cref="Camera"/>.
+        /// </summary>
+        /// <param name="cam"></param>
+        public void UpdateCamera(Camera cam);
 
         /// <summary>
         /// Sets the render context for the given scene.
         /// </summary>
         /// <param name="rc"></param>
-        public void SetContext(RenderContext rc);
+        public void UpdateContext(RenderContext rc);
 
         /// <summary>
         /// Sets the <see cref="RendererState"/> for this module. Pass the state from the base renderer.
         /// </summary>
         /// <param name="state">The state to set.</param>
-        public void SetState(RendererState state);
+        public void UpdateState(RendererState state);
     }
 }

--- a/src/Engine/Core/RenderCanvas.cs
+++ b/src/Engine/Core/RenderCanvas.cs
@@ -180,6 +180,8 @@ namespace Fusee.Engine.Core
             RC = new RenderContext(ContextImplementor);
             RC.Viewport(0, 0, Width, Height);
             RC.SetRenderStateSet(RenderStateSet.Default);
+            RC.GetWindowHeight = () => CanvasImplementor.Height;
+            RC.GetWindowWidth = () => CanvasImplementor.Width;
 
             VideoManager.Instance.VideoManagerImp = VideoManagerImplementor;
 

--- a/src/Engine/Core/RenderContext.cs
+++ b/src/Engine/Core/RenderContext.cs
@@ -105,6 +105,16 @@ namespace Fusee.Engine.Core
         /// </summary>
         public int ViewportYStart { get; private set; }
 
+        /// <summary>
+        /// Gets the window width.
+        /// </summary>
+        public Func<int> GetWindowWidth { get; internal set; }
+
+        /// <summary>
+        /// Sets the window width.
+        /// </summary>
+        public Func<int> GetWindowHeight { get; internal set; }
+
         #endregion
 
         #region Shader Management fields

--- a/src/Engine/Core/RenderContext.cs
+++ b/src/Engine/Core/RenderContext.cs
@@ -1717,9 +1717,11 @@ namespace Fusee.Engine.Core
         /// <param name="tex">The render texture.</param>
         public void SetRenderTarget(IWritableTexture tex)
         {
-            if (tex is WritableTexture wt)
+            if(tex == null)
+                SetRenderTarget();
+            else if (tex is WritableTexture wt)
                 SetRenderTarget(wt);
-            if (tex is WritableMultisampleTexture wmst)
+            else if (tex is WritableMultisampleTexture wmst)
                 SetRenderTarget(wmst);
         }
 
@@ -1729,7 +1731,7 @@ namespace Fusee.Engine.Core
         /// <param name="tex">The render texture.</param>
         public void SetRenderTarget(WritableTexture tex)
         {
-            var texHandle = _textureManager.GetTextureHandle((WritableTexture)tex);
+            var texHandle = _textureManager.GetTextureHandle(tex);
             _rci.SetRenderTarget(tex, texHandle);
         }
 

--- a/src/Engine/Core/Scene/Camera.cs
+++ b/src/Engine/Core/Scene/Camera.cs
@@ -110,7 +110,7 @@ namespace Fusee.Engine.Core.Scene
         public RenderLayers RenderLayer;
 
         /// <summary>
-        /// Scales the orthograpic viewing frustum. Dosn't have an effect if <see cref="ProjectionMethod.Perspective"/> is used.
+        /// Scales the orthographic viewing frustum. Doesn't have an effect if <see cref="ProjectionMethod.Perspective"/> is used.
         /// </summary>
         public float Scale = 1;
 
@@ -131,6 +131,27 @@ namespace Fusee.Engine.Core.Scene
         }
 
         /// <summary>
+        /// Returns the viewport in px as float4.
+        /// x: start pixel in x direction.
+        /// y: start pixel in y direction.
+        /// z: width of the viewport.
+        /// w: height of the viewport.
+        /// </summary>
+        /// <param name="canvasWidthPx"></param>
+        /// <param name="canvasHeightPx"></param>
+        /// <returns></returns>
+        public float4 GetViewportInPx(int canvasWidthPx, int canvasHeightPx)
+        {
+            var startX = (int)(canvasWidthPx * (Viewport.x / 100));
+            var startY = (int)(canvasHeightPx * (Viewport.y / 100));
+
+            var width = (int)(canvasWidthPx * (Viewport.z / 100));
+            var height = (int)(canvasHeightPx * (Viewport.w / 100));
+
+            return new float4(startX, startY, width, height);
+        }
+
+        /// <summary>
         /// Calculates and returns the projection matrix.
         /// </summary>
         /// <param name="canvasWidthPx">The width of the render canvas.</param>
@@ -145,18 +166,12 @@ namespace Fusee.Engine.Core.Scene
                 return proj;
             }
 
-            var startX = (int)(canvasWidthPx * (Viewport.x / 100));
-            var startY = (int)(canvasHeightPx * (Viewport.y / 100));
-
-            var width = (int)(canvasWidthPx * (Viewport.z / 100));
-            var height = (int)(canvasHeightPx * (Viewport.w / 100));
-
-            viewport = new float4(startX, startY, width, height);
+            viewport = GetViewportInPx(canvasWidthPx, canvasHeightPx);
 
             return ProjectionMethod switch
             {
-                ProjectionMethod.Orthographic => float4x4.CreateOrthographic(width * Scale, height * Scale, ClippingPlanes.x, ClippingPlanes.y),
-                _ => float4x4.CreatePerspectiveFieldOfView(Fov, System.Math.Abs((float)width / height), ClippingPlanes.x, ClippingPlanes.y),
+                ProjectionMethod.Orthographic => float4x4.CreateOrthographic(viewport.z * Scale, viewport.w * Scale, ClippingPlanes.x, ClippingPlanes.y),
+                _ => float4x4.CreatePerspectiveFieldOfView(Fov, System.Math.Abs((float)viewport.z / viewport.w), ClippingPlanes.x, ClippingPlanes.y),
             };
         }
 

--- a/src/Engine/Core/SceneRendererDeferred.cs
+++ b/src/Engine/Core/SceneRendererDeferred.cs
@@ -587,13 +587,8 @@ namespace Fusee.Engine.Core
         /// </summary>
         private void RenderLightPasses(IWritableTexture renderTex = null)
         {
-            if (renderTex != null)
-                _rc.SetRenderTarget(renderTex);
-            else
-            {
-                _rc.SetRenderTarget();
-                _rc.Clear(ClearFlags.Color | ClearFlags.Depth);
-            }
+            _rc.SetRenderTarget(renderTex);
+            _rc.Clear(ClearFlags.Color | ClearFlags.Depth);
 
             var lightPassCnt = 0;
 
@@ -758,7 +753,7 @@ namespace Fusee.Engine.Core
                             _rc.SetEffect(_shadowCubeMapEffect, true);
 
                             _rc.SetRenderTarget((IWritableCubeMap)shadowParams.ShadowMap);
-
+                            _rc.Clear(ClearFlags.Color | ClearFlags.Depth);
                             //No culling here because much of the work is done in the geometry shader.
 
                             Traverse(_sc.Children);
@@ -772,6 +767,7 @@ namespace Fusee.Engine.Core
                                 _shadowEffect.SetFxParam(UniformNameDeclarations.LightSpaceMatrixHash, shadowParams.LightSpaceMatrices[0]);
                                 _rc.SetEffect(_shadowEffect, true);
                                 _rc.SetRenderTarget(shadowParams.ShadowMap);
+                                _rc.Clear(ClearFlags.Color | ClearFlags.Depth);
 
                                 _lightFrustum = shadowParams.Frustums[0];
 
@@ -784,6 +780,7 @@ namespace Fusee.Engine.Core
                                     _shadowEffect.SetFxParam(UniformNameDeclarations.LightSpaceMatrixHash, shadowParams.LightSpaceMatrices[i]);
                                     _rc.SetEffect(_shadowEffect, true);
                                     _rc.SetRenderTarget((IWritableArrayTexture)shadowParams.ShadowMap, i);
+                                    _rc.Clear(ClearFlags.Color | ClearFlags.Depth);
 
                                     _lightFrustum = shadowParams.Frustums[i];
 
@@ -802,6 +799,7 @@ namespace Fusee.Engine.Core
                             _shadowEffect.SetFxParam(UniformNameDeclarations.LightSpaceMatrixHash, shadowParams.LightSpaceMatrices[0]);
                             _rc.SetEffect(_shadowEffect, false);
                             _rc.SetRenderTarget(shadowParams.ShadowMap);
+                            _rc.Clear(ClearFlags.Color | ClearFlags.Depth);
 
                             _lightFrustum = shadowParams.Frustums[0];
                             Traverse(_sc.Children);
@@ -820,6 +818,7 @@ namespace Fusee.Engine.Core
         {
             _currentPass = RenderPasses.Geometry;
             _rc.SetRenderTarget(_gBufferRenderTarget);
+            _rc.Clear(ClearFlags.Color | ClearFlags.Depth);
             Traverse(_sc.Children);
         }
 
@@ -834,6 +833,7 @@ namespace Fusee.Engine.Core
             }
             _rc.SetEffect(_ssaoTexEffect);
             _rc.SetRenderTarget(_ssaoRenderTexture);
+            _rc.Clear(ClearFlags.Color | ClearFlags.Depth);
             _rc.Render(_quad);
 
             //Pass 3: Blur SSAO Texture
@@ -845,6 +845,7 @@ namespace Fusee.Engine.Core
             }
             _rc.SetEffect(_blurEffect);
             _rc.SetRenderTarget(_blurRenderTex);
+            _rc.Clear(ClearFlags.Color | ClearFlags.Depth);
             _rc.Render(_quad);
 
             //Set blurred SSAO Texture as SSAO Texture in gBuffer
@@ -865,7 +866,7 @@ namespace Fusee.Engine.Core
                 _rc.SetRenderTarget();
             else
                 _rc.SetRenderTarget(renderTex);
-
+            _rc.Clear(ClearFlags.Color | ClearFlags.Depth);
             _rc.Render(_quad);
         }
 

--- a/src/Engine/Core/SceneRendererForward.cs
+++ b/src/Engine/Core/SceneRendererForward.cs
@@ -42,7 +42,7 @@ namespace Fusee.Engine.Core
                 _renderLayer = value;
                 foreach (var module in VisitorModules)
                 {
-                    ((IRendererModule)module).RenderLayer = _renderLayer;
+                    ((IRendererModule)module).UpdateRenderLayer(_renderLayer);
                 }
             }
         }
@@ -279,18 +279,25 @@ namespace Fusee.Engine.Core
                 _rc = rc;
                 foreach (var module in VisitorModules)
                 {
-                    ((IRendererModule)module).SetContext(_rc);
+                    ((IRendererModule)module).UpdateContext(_rc);
                 }
                 InitState();
             }
         }
 
-        private void SetStateAndRenderLayerInModules()
+        protected void NotifyStateChanges()
         {
             foreach (var module in VisitorModules)
             {
-                ((IRendererModule)module).RenderLayer = _renderLayer;
-                ((IRendererModule)module).SetState(_state);
+                ((IRendererModule)module).UpdateState(_state);
+            }
+        }
+
+        protected void NotifyCameraChanges(Camera cam)
+        {
+            foreach (var module in VisitorModules)
+            {
+                ((IRendererModule)module).UpdateCamera(cam);
             }
         }
 
@@ -301,10 +308,10 @@ namespace Fusee.Engine.Core
         /// Renders the scene.
         /// </summary>
         /// <param name="rc"></param>
-        public void Render(RenderContext rc)
+        public virtual void Render(RenderContext rc)
         {
             SetContext(rc);
-            SetStateAndRenderLayerInModules();
+            NotifyStateChanges();
 
             PrePassVisitor.PrePassTraverse(_sc);
 
@@ -313,18 +320,29 @@ namespace Fusee.Engine.Core
             if (PrePassVisitor.CameraPrepassResults.Count != 0)
             {
                 var cams = PrePassVisitor.CameraPrepassResults.OrderBy(cam => cam.Item2.Camera.Layer);
+
+                //Clear for all cameras
+                foreach (var cam in cams)
+                {
+                    if (cam.Item2.Camera.Active)
+                        PerCamClear(cam.Item2);
+                }
+
+                //Render for all cameras
                 foreach (var cam in cams)
                 {
                     if (cam.Item2.Camera.Active)
                     {
+                        NotifyCameraChanges(cam.Item2.Camera);
                         DoFrumstumCulling = cam.Item2.Camera.FrustumCullingOn;
-                        PerCamRender(cam);
-                        //Reset Viewport and frustum culling bool in case we have another scene, rendered without a camera
-                        _rc.Viewport(0, 0, rc.DefaultState.CanvasWidth, rc.DefaultState.CanvasHeight);
-                        //Standard value: frustum culling is on.
-                        DoFrumstumCulling = true;
+                        PerCamRender(cam.Item2);
                     }
                 }
+
+                //Reset Viewport and frustum culling bool in case we have another scene, rendered without a camera
+                _rc.Viewport(0, 0, rc.DefaultState.CanvasWidth, rc.DefaultState.CanvasHeight);
+                //Standard value: frustum culling is on.
+                DoFrumstumCulling = true;
             }
             else
             {
@@ -335,38 +353,50 @@ namespace Fusee.Engine.Core
             _rc.ClearGlobalEffectParamsDirtyFlag();
         }
 
-        private void PerCamRender(Tuple<SceneNode, CameraResult> cam)
+        internal void PerCamClear(CameraResult cam)
         {
-            var tex = cam.Item2.Camera.RenderTexture;
+            var tex = cam.Camera.RenderTexture;
+            RenderLayer = cam.Camera.RenderLayer;
 
-            RenderLayer = cam.Item2.Camera.RenderLayer;
+            float4 viewport = tex != null
+                ? cam.Camera.GetViewportInPx(tex.Width, tex.Height)
+                : cam.Camera.GetViewportInPx(_rc.GetWindowWidth(), _rc.GetWindowHeight());
 
+            _rc.Viewport((int)viewport.x, (int)viewport.y, (int)viewport.z, (int)viewport.w);
+
+            _rc.ClearColor = cam.Camera.BackgroundColor;
+            if (cam.Camera.ClearColor)
+                _rc.Clear(ClearFlags.Color);
+
+            if (cam.Camera.ClearDepth)
+                _rc.Clear(ClearFlags.Depth);
+        }
+
+        private void PerCamRender(CameraResult cam)
+        {
+            RenderLayer = cam.Camera.RenderLayer;
+            _rc.View = cam.View;
+
+            float4 viewport;
+            var tex = cam.Camera.RenderTexture;
             if (tex != null)
             {
-                _rc.SetRenderTarget(cam.Item2.Camera.RenderTexture);
-                _rc.Projection = cam.Item2.Camera.GetProjectionMat(cam.Item2.Camera.RenderTexture.Width, cam.Item2.Camera.RenderTexture.Height, out var viewport);
+                _rc.SetRenderTarget(cam.Camera.RenderTexture);
+                _rc.Projection = cam.Camera.GetProjectionMat(cam.Camera.RenderTexture.Width, cam.Camera.RenderTexture.Height, out viewport);
                 _rc.Viewport((int)viewport.x, (int)viewport.y, (int)viewport.z, (int)viewport.w);
             }
             else
             {
                 _rc.SetRenderTarget();
-                _rc.Projection = cam.Item2.Camera.GetProjectionMat(_rc.ViewportWidth, _rc.ViewportHeight, out var viewport);
-                _rc.Viewport((int)viewport.x, (int)viewport.y, (int)viewport.z, (int)viewport.w);
+                _rc.Projection = cam.Camera.GetProjectionMat(_rc.GetWindowWidth(), _rc.GetWindowHeight(), out viewport);
             }
 
-            _rc.ClearColor = cam.Item2.Camera.BackgroundColor;
-
-            if (cam.Item2.Camera.ClearColor)
-                _rc.Clear(ClearFlags.Color);
-
-            if (cam.Item2.Camera.ClearDepth)
-                _rc.Clear(ClearFlags.Depth);
-
-            _rc.View = cam.Item2.View;
+            _rc.ClearColor = cam.Camera.BackgroundColor;
 
             UpdateShaderParamsForAllLights();
 
             Traverse(_sc.Children);
+
         }
 
         /// <summary>

--- a/src/Engine/Core/SceneRendererForward.cs
+++ b/src/Engine/Core/SceneRendererForward.cs
@@ -363,6 +363,7 @@ namespace Fusee.Engine.Core
                 : cam.Camera.GetViewportInPx(_rc.GetWindowWidth(), _rc.GetWindowHeight());
 
             _rc.Viewport((int)viewport.x, (int)viewport.y, (int)viewport.z, (int)viewport.w);
+            _rc.SetRenderTarget(tex);
 
             _rc.ClearColor = cam.Camera.BackgroundColor;
             if (cam.Camera.ClearColor)
@@ -377,21 +378,15 @@ namespace Fusee.Engine.Core
             RenderLayer = cam.Camera.RenderLayer;
             _rc.View = cam.View;
 
-            float4 viewport;
             var tex = cam.Camera.RenderTexture;
-            if (tex != null)
-            {
-                _rc.SetRenderTarget(cam.Camera.RenderTexture);
-                _rc.Projection = cam.Camera.GetProjectionMat(cam.Camera.RenderTexture.Width, cam.Camera.RenderTexture.Height, out viewport);
-                _rc.Viewport((int)viewport.x, (int)viewport.y, (int)viewport.z, (int)viewport.w);
-            }
-            else
-            {
-                _rc.SetRenderTarget();
-                _rc.Projection = cam.Camera.GetProjectionMat(_rc.GetWindowWidth(), _rc.GetWindowHeight(), out viewport);
-            }
 
-            _rc.ClearColor = cam.Camera.BackgroundColor;
+            _rc.SetRenderTarget(tex);
+
+            _rc.Projection = tex != null
+                ? cam.Camera.GetProjectionMat(cam.Camera.RenderTexture.Width, cam.Camera.RenderTexture.Height, out float4 viewport)
+                : cam.Camera.GetProjectionMat(_rc.GetWindowWidth(), _rc.GetWindowHeight(), out viewport);
+
+            _rc.Viewport((int)viewport.x, (int)viewport.y, (int)viewport.z, (int)viewport.w);
 
             UpdateShaderParamsForAllLights();
 

--- a/src/Engine/Core/ShaderShards/Fragment/FragShards.cs
+++ b/src/Engine/Core/ShaderShards/Fragment/FragShards.cs
@@ -89,7 +89,7 @@ namespace Fusee.Engine.Core.ShaderShards.Fragment
             if (surfInput.ShadingModel != ShadingModel.BRDF) return res;
 
             if (surfInput.TextureSetup.HasFlag(TextureSetup.ThicknessMap))
-                res.Add($"OUT.{SurfaceOut.Thickness.Item2} = texture(IN.ThicknessMap, { VaryingNameDeclarations.TextureCoordinates}).r;");
+                res.Add($"OUT.{SurfaceOut.Thickness.Item2} = texture(IN.ThicknessMap, {VaryingNameDeclarations.TextureCoordinates}).r;");
             else
                 res.Add($"OUT.{SurfaceOut.Thickness.Item2} = 1.0;");
             return res;
@@ -178,7 +178,7 @@ namespace Fusee.Engine.Core.ShaderShards.Fragment
             if (shadingModel != ShadingModel.BRDF) return res;
 
             if (texSetup.HasFlag(TextureSetup.ThicknessMap))
-                res.Add($"OUT.{SurfaceOut.Thickness.Item2} = texture(IN.ThicknessMap, { VaryingNameDeclarations.TextureCoordinates}).r;");
+                res.Add($"OUT.{SurfaceOut.Thickness.Item2} = texture(IN.ThicknessMap, {VaryingNameDeclarations.TextureCoordinates}).r;");
             else
                 res.Add($"OUT.{SurfaceOut.Thickness.Item2} = 1.0;");
             return res;

--- a/src/Engine/Core/ShaderShards/Vertex/VertMain.cs
+++ b/src/Engine/Core/ShaderShards/Vertex/VertMain.cs
@@ -62,15 +62,15 @@ namespace Fusee.Engine.Core.ShaderShards.Vertex
 
             if (shadingModel != (ShadingModel.Unlit) && shadingModel != (ShadingModel.Edl))
             {
-                vertMainBody.Add($"{SurfaceOut.SurfOutVaryingName}.{SurfaceOut.Normal.Item2} = normalize(vec3({ UniformNameDeclarations.ITModelView}* vec4({SurfaceOut.SurfOutVaryingName}.normal, 0.0)));");
+                vertMainBody.Add($"{SurfaceOut.SurfOutVaryingName}.{SurfaceOut.Normal.Item2} = normalize(vec3({UniformNameDeclarations.ITModelView}* vec4({SurfaceOut.SurfOutVaryingName}.normal, 0.0)));");
             }
 
             vertMainBody.Add($"{VaryingNameDeclarations.TextureCoordinates} = {UniformNameDeclarations.TextureCoordinates};");
 
             if (texSetup.HasFlag(TextureSetup.NormalMap))
             {
-                vertMainBody.Add($"vec3 T = normalize(vec3({ UniformNameDeclarations.ITModelView} * vec4({ UniformNameDeclarations.Tangent}.xyz, 0.0)));");
-                vertMainBody.Add($"vec3 B = normalize(vec3({ UniformNameDeclarations.ITModelView} * vec4({ UniformNameDeclarations.Bitangent}.xyz, 0.0)));");
+                vertMainBody.Add($"vec3 T = normalize(vec3({UniformNameDeclarations.ITModelView} * vec4({UniformNameDeclarations.Tangent}.xyz, 0.0)));");
+                vertMainBody.Add($"vec3 B = normalize(vec3({UniformNameDeclarations.ITModelView} * vec4({UniformNameDeclarations.Bitangent}.xyz, 0.0)));");
 
                 vertMainBody.Add($"TBN = mat3(T,B,{SurfaceOut.SurfOutVaryingName}.{SurfaceOut.Normal.Item2});");
             }

--- a/src/Engine/Imp/Graphics/Android/RenderContextImp.cs
+++ b/src/Engine/Imp/Graphics/Android/RenderContextImp.cs
@@ -2229,8 +2229,6 @@ namespace Fusee.Engine.Imp.Graphics.Android
 
             if (GL.CheckFramebufferStatus(FramebufferTarget.Framebuffer) != FramebufferErrorCode.FramebufferComplete)
                 throw new Exception($"Error creating RenderTarget: {GL.GetErrorCode()}, {GL.CheckFramebufferStatus(FramebufferTarget.Framebuffer)}");
-
-            GL.Clear(ClearBufferMask.DepthBufferBit | ClearBufferMask.ColorBufferBit);
         }
 
         /// <summary>
@@ -2257,8 +2255,6 @@ namespace Fusee.Engine.Imp.Graphics.Android
 
             if (GL.CheckFramebufferStatus(FramebufferTarget.Framebuffer) != FramebufferErrorCode.FramebufferComplete)
                 throw new Exception($"Error creating RenderTarget: {GL.GetErrorCode()}, {GL.CheckFramebufferStatus(FramebufferTarget.Framebuffer)}");
-
-            GL.Clear(ClearBufferMask.DepthBufferBit | ClearBufferMask.ColorBufferBit);
         }
 
         /// <summary>
@@ -2299,8 +2295,6 @@ namespace Fusee.Engine.Imp.Graphics.Android
 
             if (GL.CheckFramebufferStatus(FramebufferTarget.Framebuffer) != FramebufferErrorCode.FramebufferComplete)
                 throw new Exception($"Error creating RenderTarget: {GL.GetErrorCode()}, {GL.CheckFramebufferStatus(FramebufferTarget.Framebuffer)}");
-
-            GL.Clear(ClearBufferMask.DepthBufferBit | ClearBufferMask.ColorBufferBit);
         }
 
         /// <summary>
@@ -2346,8 +2340,6 @@ namespace Fusee.Engine.Imp.Graphics.Android
 
             if (GL.CheckFramebufferStatus(FramebufferTarget.Framebuffer) != FramebufferErrorCode.FramebufferComplete)
                 throw new Exception($"Error creating RenderTarget: {GL.GetErrorCode()}, {GL.CheckFramebufferStatus(FramebufferTarget.Framebuffer)}");
-
-            GL.Clear(ClearBufferMask.DepthBufferBit | ClearBufferMask.ColorBufferBit);
         }
 
         private int CreateDepthRenderBuffer(int width, int height)

--- a/src/Engine/Imp/Graphics/Desktop/RenderContextImp.cs
+++ b/src/Engine/Imp/Graphics/Desktop/RenderContextImp.cs
@@ -2605,7 +2605,7 @@ namespace Fusee.Engine.Imp.Graphics.Desktop
         public void Scissor(int x, int y, int width, int height)
         {
             //Should be enabled per default - but WPF seems to disable it...
-            if(!GL.IsEnabled(EnableCap.ScissorTest))
+            if (!GL.IsEnabled(EnableCap.ScissorTest))
                 GL.Enable(EnableCap.ScissorTest);
             GL.Scissor(x, y, width, height);
         }

--- a/src/Engine/Imp/Graphics/Desktop/RenderContextImp.cs
+++ b/src/Engine/Imp/Graphics/Desktop/RenderContextImp.cs
@@ -2294,8 +2294,6 @@ namespace Fusee.Engine.Imp.Graphics.Desktop
 
             if (GL.CheckFramebufferStatus(FramebufferTarget.Framebuffer) != FramebufferErrorCode.FramebufferComplete)
                 throw new Exception($"Error creating RenderTarget: {GL.GetError()}, {GL.CheckFramebufferStatus(FramebufferTarget.Framebuffer)}");
-
-            GL.Clear(ClearBufferMask.DepthBufferBit | ClearBufferMask.ColorBufferBit);
         }
 
 
@@ -2336,8 +2334,6 @@ namespace Fusee.Engine.Imp.Graphics.Desktop
 
             if (GL.CheckFramebufferStatus(FramebufferTarget.Framebuffer) != FramebufferErrorCode.FramebufferComplete)
                 throw new Exception($"Error creating RenderTarget: {GL.GetError()}, {GL.CheckFramebufferStatus(FramebufferTarget.Framebuffer)}");
-
-            GL.Clear(ClearBufferMask.DepthBufferBit | ClearBufferMask.ColorBufferBit);
         }
 
 
@@ -2374,9 +2370,6 @@ namespace Fusee.Engine.Imp.Graphics.Desktop
 
             if (GL.CheckFramebufferStatus(FramebufferTarget.Framebuffer) != FramebufferErrorCode.FramebufferComplete)
                 throw new Exception($"Error creating RenderTarget: {GL.GetError()}, {GL.CheckFramebufferStatus(FramebufferTarget.Framebuffer)}");
-
-
-            GL.Clear(ClearBufferMask.DepthBufferBit | ClearBufferMask.ColorBufferBit);
         }
 
         /// <summary>
@@ -2417,8 +2410,6 @@ namespace Fusee.Engine.Imp.Graphics.Desktop
 
             if (GL.CheckFramebufferStatus(FramebufferTarget.Framebuffer) != FramebufferErrorCode.FramebufferComplete)
                 throw new Exception($"Error creating RenderTarget: {GL.GetError()}, {GL.CheckFramebufferStatus(FramebufferTarget.Framebuffer)}");
-
-            GL.Clear(ClearBufferMask.DepthBufferBit | ClearBufferMask.ColorBufferBit);
         }
 
         /// <summary>
@@ -2469,8 +2460,6 @@ namespace Fusee.Engine.Imp.Graphics.Desktop
             {
                 throw new Exception($"Error creating RenderTarget: {GL.GetError()}, {GL.CheckFramebufferStatus(FramebufferTarget.Framebuffer)}");
             }
-
-            GL.Clear(ClearBufferMask.DepthBufferBit | ClearBufferMask.ColorBufferBit);
         }
 
         private int CreateDepthRenderBuffer(int width, int height)

--- a/src/Engine/Imp/Graphics/Desktop/RenderContextImp.cs
+++ b/src/Engine/Imp/Graphics/Desktop/RenderContextImp.cs
@@ -2604,6 +2604,9 @@ namespace Fusee.Engine.Imp.Graphics.Desktop
         /// <param name="height">Height of the scissor box.</param>
         public void Scissor(int x, int y, int width, int height)
         {
+            //Should be enabled per default - but WPF seems to disable it...
+            if(!GL.IsEnabled(EnableCap.ScissorTest))
+                GL.Enable(EnableCap.ScissorTest);
             GL.Scissor(x, y, width, height);
         }
 

--- a/src/ImGui/Desktop/Fusee.ImGui.Desktop/FuseeMath2VectorExtensions.cs
+++ b/src/ImGui/Desktop/Fusee.ImGui.Desktop/FuseeMath2VectorExtensions.cs
@@ -1,10 +1,5 @@
 ﻿using Fusee.Math.Core;
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Numerics;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Fusee.ImGuiDesktop
 {

--- a/src/ImGui/Desktop/Fusee.ImGui.Desktop/ImGuiController.cs
+++ b/src/ImGui/Desktop/Fusee.ImGui.Desktop/ImGuiController.cs
@@ -1,5 +1,4 @@
 ﻿using Fusee.Base.Core;
-using Fusee.Engine.Core;
 using Fusee.Math.Core;
 using ImGuiNET;
 using OpenTK.Graphics.OpenGL;

--- a/src/ImGui/Desktop/Fusee.ImGui.Desktop/ImGuiInputImp.cs
+++ b/src/ImGui/Desktop/Fusee.ImGui.Desktop/ImGuiInputImp.cs
@@ -3,10 +3,8 @@ using Fusee.Engine.Core;
 using Fusee.Engine.Imp.Graphics.Desktop;
 using ImGuiNET;
 using OpenTK.Windowing.Desktop;
-using OpenTK.Windowing.GraphicsLibraryFramework;
 using System;
 using System.Collections.Generic;
-using System.Numerics;
 
 namespace Fusee.ImGuiDesktop
 {

--- a/src/ImGui/Desktop/Fusee.ImGui.Desktop/ImGuiRenderCanvasImp.cs
+++ b/src/ImGui/Desktop/Fusee.ImGui.Desktop/ImGuiRenderCanvasImp.cs
@@ -1,23 +1,9 @@
 ﻿using Fusee.Base.Core;
 using Fusee.Engine.Common;
 using Fusee.Engine.Core;
-using Fusee.Engine.Imp.Graphics.Desktop;
-using Fusee.Math.Core;
-using ImGuiNET;
 using OpenTK.Graphics.OpenGL;
-using OpenTK.Windowing.Common.Input;
 using OpenTK.Windowing.Desktop;
-using SixLabors.ImageSharp.PixelFormats;
-using SixLabors.ImageSharp.Processing;
 using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Linq;
-using System.Numerics;
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Fusee.ImGuiDesktop
 {

--- a/src/ImGui/Desktop/Fusee.ImGui.Desktop/ImGuiRenderContextImp.cs
+++ b/src/ImGui/Desktop/Fusee.ImGui.Desktop/ImGuiRenderContextImp.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace Fusee.ImGuiDesktop
+﻿namespace Fusee.ImGuiDesktop
 {
     internal class ImGuiRenderContextImp
     {

--- a/src/ImGui/Desktop/Fusee.ImGui.Desktop/Templates/FuseeControlToTexture.cs
+++ b/src/ImGui/Desktop/Fusee.ImGui.Desktop/Templates/FuseeControlToTexture.cs
@@ -2,7 +2,6 @@
 using Fusee.Engine.Core;
 using OpenTK.Graphics.OpenGL;
 using System;
-using TextureWrapMode = OpenTK.Graphics.OpenGL.TextureWrapMode;
 
 namespace Fusee.ImGuiDesktop.Templates
 {

--- a/src/PointCloud/Core/Scene/PointCloudComponent.cs
+++ b/src/PointCloud/Core/Scene/PointCloudComponent.cs
@@ -27,6 +27,16 @@ namespace Fusee.PointCloud.Core.Scene
         /// <summary>
         /// Instantiates the <see cref="IPointCloudImp"/>.
         /// </summary>
+        public readonly bool DoRenderInstanced;
+
+        /// <summary>
+        /// Reference to the Camera whose properties are used to control the visibility of point cloud chunks (octants).
+        /// </summary>
+        public Camera Camera;
+
+        /// <summary>
+        /// Instantiates the <see cref="IPointCloudImp"/>.
+        /// </summary>
         public PointCloudComponent(IPointCloudImp imp)
         {
             PointCloudImp = imp;

--- a/src/PointCloud/Core/Scene/PointCloudRenderModule.cs
+++ b/src/PointCloud/Core/Scene/PointCloudRenderModule.cs
@@ -1,8 +1,6 @@
 using Fusee.Base.Core;
 using Fusee.Engine.Core;
-using Fusee.Engine.Core.Primitives;
 using Fusee.Engine.Core.Scene;
-using Fusee.PointCloud.Common;
 using Fusee.Xene;
 using System;
 
@@ -102,12 +100,12 @@ namespace Fusee.PointCloud.Core.Scene
                 var fov = (float)_rc.ViewportWidth / _rc.ViewportHeight;
                 pointCloud.PointCloudImp.Update(fov, _rc.ViewportHeight, _rc.RenderFrustum, _rc.InvView.Column4.xyz);
             }
-            
+
             foreach (var mesh in (pointCloud.PointCloudImp).MeshesToRender)
             {
                 _rc.Render(mesh, _isForwardModule);
             }
-            
+
         }
     }
 }

--- a/src/PointCloud/Core/Scene/PointCloudRenderModule.cs
+++ b/src/PointCloud/Core/Scene/PointCloudRenderModule.cs
@@ -1,5 +1,8 @@
-﻿using Fusee.Engine.Core;
+using Fusee.Base.Core;
+using Fusee.Engine.Core;
+using Fusee.Engine.Core.Primitives;
 using Fusee.Engine.Core.Scene;
+using Fusee.PointCloud.Common;
 using Fusee.Xene;
 using System;
 
@@ -20,13 +23,20 @@ namespace Fusee.PointCloud.Core.Scene
         /// <summary>
         /// The RenderLayer this renderer should render.
         /// </summary>
-        public RenderLayers RenderLayer { get; set; }
+        private RenderLayers _renderLayer;
+
+        /// <summary>
+        /// The RenderLayer this renderer should render.
+        /// </summary>
+        private Camera _camera;
+
+        private readonly bool _isForwardModule;
 
         /// <summary>
         /// Sets the render context for the given scene.
         /// </summary>
         /// <param name="rc"></param>
-        public void SetContext(RenderContext rc)
+        public void UpdateContext(RenderContext rc)
         {
             if (rc == null)
                 throw new ArgumentNullException(nameof(rc));
@@ -41,7 +51,7 @@ namespace Fusee.PointCloud.Core.Scene
         /// Sets the render context for the given scene.
         /// </summary>
         /// <param name="state"></param>
-        public void SetState(RendererState state)
+        public void UpdateState(RendererState state)
         {
             if (state == null)
                 throw new ArgumentNullException(nameof(state));
@@ -52,6 +62,25 @@ namespace Fusee.PointCloud.Core.Scene
             }
         }
 
+        public void UpdateRenderLayer(RenderLayers renderLayer)
+        {
+            _renderLayer = renderLayer;
+        }
+
+        public void UpdateCamera(Camera cam)
+        {
+            _camera = cam;
+        }
+
+        /// <summary>
+        /// Creates a new instance of type <see cref="PointCloudRenderModule"/>.
+        /// </summary>
+        /// <param name="doRenderForward">Propagated the render type (forward or deferred) to the <see cref="RenderContext"/>.</param>
+        public PointCloudRenderModule(bool doRenderForward)
+        {
+            _isForwardModule = doRenderForward;
+        }
+
         /// <summary>
         /// Determines visible points of a point cloud (using the components <see cref="VisibilityTester"/>) and renders them.
         /// </summary>
@@ -60,19 +89,25 @@ namespace Fusee.PointCloud.Core.Scene
         public void RenderPointCloud(PointCloudComponent pointCloud)
         {
             if (!pointCloud.Active) return;
-            if (!RenderLayer.HasFlag(_state.RenderLayer.Layer) && !_state.RenderLayer.Layer.HasFlag(RenderLayer) || _state.RenderLayer.Layer.HasFlag(RenderLayers.None))
+            if (!_renderLayer.HasFlag(_state.RenderLayer.Layer) && !_state.RenderLayer.Layer.HasFlag(_renderLayer) || _state.RenderLayer.Layer.HasFlag(RenderLayers.None))
                 return;
-            //if (_rc.InvView == float4x4.Identity) return;
 
-            var fov = (float)_rc.ViewportWidth / _rc.ViewportHeight;
-            pointCloud.PointCloudImp.Update(fov, _rc.ViewportHeight, _rc.RenderFrustum, _rc.InvView.Column4.xyz);
-
-            foreach (var mesh in pointCloud.PointCloudImp.MeshesToRender)
+            if (pointCloud.Camera == null)
             {
-                var renderStatesBefore = _rc.CurrentRenderState.Copy();
-                _rc.Render(mesh, true);
-                _state.RenderUndoStates = renderStatesBefore.Merge(_rc.CurrentRenderState);
+                Diagnostics.Warn("Point Cloud Render Camera is null!");
+                return;
             }
+            else if (pointCloud.Camera == _camera)
+            {
+                var fov = (float)_rc.ViewportWidth / _rc.ViewportHeight;
+                pointCloud.PointCloudImp.Update(fov, _rc.ViewportHeight, _rc.RenderFrustum, _rc.InvView.Column4.xyz);
+            }
+            
+            foreach (var mesh in (pointCloud.PointCloudImp).MeshesToRender)
+            {
+                _rc.Render(mesh, _isForwardModule);
+            }
+            
         }
     }
 }


### PR DESCRIPTION
Closes #524 

## Summary

- added "Camera" property to `PointCloudComponent` (see #524)
- added "Clear Pass": the `SceneRenderers` clear for all active cameras and render for all active cameras seperatily
- removed `GL.Clear` calls from RCI `SetRenderTarget` methods for clarity

Render using multiple viewports / cameras, with or without render texture should now function correctly.