### PR TITLE
Fix mesh attributes and overhaul Mesh implementation

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -69,6 +69,7 @@
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
+		<PackageReference Include="Microsoft.Toolkit.Diagnostics" Version="7.1.2" />
 	</ItemGroup>
 
 

--- a/Examples/Complete/AdvancedUI/Core/AdvancedUI.cs
+++ b/Examples/Complete/AdvancedUI/Core/AdvancedUI.cs
@@ -539,10 +539,10 @@ namespace Fusee.Examples.AdvancedUI.Core
                 if (mesh != null)
                 {
                     Line newLine = new(linePoints, 0.0025f / _resizeScaleFactor.y, _canvasWidth, _canvasHeight);
-                    mesh.Vertices = newLine.Vertices;
-                    mesh.Normals = newLine.Normals;
-                    mesh.Triangles = newLine.Triangles;
-                    mesh.UVs = newLine.UVs;
+                    mesh.SetVertices(newLine.Vertices.ToArray());
+                    mesh.SetNormals(newLine.Normals.ToArray());
+                    mesh.SetTriangles(newLine.Triangles.ToArray());
+                    mesh.SetUVs(newLine.UVs.ToArray());
                 }
                 else
                 {

--- a/Examples/Complete/Camera/Core/Camera.cs
+++ b/Examples/Complete/Camera/Core/Camera.cs
@@ -179,7 +179,7 @@ namespace Fusee.Examples.Camera.Core
         public override void RenderAFrame()
         {
             float4x4 viewProjection = _mainCam.GetProjectionMat(Width, Height, out _) * float4x4.Invert(_mainCamTransform.Matrix);
-            _frustum.Vertices = FrustumF.CalculateFrustumCorners(viewProjection).ToArray();
+            _frustum.SetVertices(FrustumF.CalculateFrustumCorners(viewProjection).ToArray());
 
             FrustumF frustum = new();
             frustum.CalculateFrustumPlanes(viewProjection);

--- a/Examples/Complete/GeometryEditing/Core/GeometryEditing.cs
+++ b/Examples/Complete/GeometryEditing/Core/GeometryEditing.cs
@@ -279,12 +279,11 @@ namespace Fusee.Examples.GeometryEditing.Core
                 currentSelectedGeometry.Triangulate();
 
                 JometriMesh geometryMesh = new(currentSelectedGeometry);
-                Mesh meshComponent = new()
-                {
-                    Vertices = geometryMesh.Vertices,
-                    Triangles = geometryMesh.Triangles,
-                    Normals = geometryMesh.Normals,
-                };
+                Mesh meshComponent = new();
+                meshComponent.SetVertices(geometryMesh.Vertices.ToArray());
+                meshComponent.SetTriangles(geometryMesh.Triangles.ToArray());
+                meshComponent.SetNormals(geometryMesh.Normals.ToArray());
+
                 currentSelection.Components[2] = meshComponent;
             }
 
@@ -302,12 +301,11 @@ namespace Fusee.Examples.GeometryEditing.Core
                 currentSelectedGeometry.Triangulate();
 
                 JometriMesh geometryMesh = new(currentSelectedGeometry);
-                Mesh meshComponent = new()
-                {
-                    Vertices = geometryMesh.Vertices,
-                    Triangles = geometryMesh.Triangles,
-                    Normals = geometryMesh.Normals,
-                };
+                Mesh meshComponent = new();
+                meshComponent.SetVertices(geometryMesh.Vertices.ToArray());
+                meshComponent.SetTriangles(geometryMesh.Triangles.ToArray());
+                meshComponent.SetNormals(geometryMesh.Normals.ToArray());
+
                 currentSelection.Components[2] = meshComponent;
             }
 
@@ -325,12 +323,11 @@ namespace Fusee.Examples.GeometryEditing.Core
                 currentSelectedGeometry.Triangulate();
 
                 JometriMesh geometryMesh = new(currentSelectedGeometry);
-                Mesh meshComponent = new()
-                {
-                    Vertices = geometryMesh.Vertices,
-                    Triangles = geometryMesh.Triangles,
-                    Normals = geometryMesh.Normals,
-                };
+                Mesh meshComponent = new();
+                meshComponent.SetVertices(geometryMesh.Vertices.ToArray());
+                meshComponent.SetTriangles(geometryMesh.Triangles.ToArray());
+                meshComponent.SetNormals(geometryMesh.Normals.ToArray());
+
                 currentSelection.Components[2] = meshComponent;
             }
         }
@@ -411,12 +408,11 @@ namespace Fusee.Examples.GeometryEditing.Core
 
             SceneNode sceneNodeContainer = new() { Components = new List<SceneComponent>() };
 
-            Mesh meshComponent = new()
-            {
-                Vertices = geometryMesh.Vertices,
-                Triangles = geometryMesh.Triangles,
-                Normals = geometryMesh.Normals,
-            };
+            Mesh meshComponent = new();
+            meshComponent.SetVertices(geometryMesh.Vertices.ToArray());
+            meshComponent.SetTriangles(geometryMesh.Triangles.ToArray());
+            meshComponent.SetNormals(geometryMesh.Normals.ToArray());
+
             Transform translationComponent = new()
             {
                 Rotation = float3.Zero,

--- a/Examples/Complete/MeshingAround/Core/MeshingAround.cs
+++ b/Examples/Complete/MeshingAround/Core/MeshingAround.cs
@@ -103,6 +103,11 @@ namespace Fusee.Examples.MeshingAround.Core
                 Children = new ChildList()
             };
 
+            var sceneNodeOneMesh = new Mesh();
+            sceneNodeOneMesh.SetVertices(meshOne.Vertices.ToArray());
+            sceneNodeOneMesh.SetTriangles(meshOne.Triangles.ToArray());
+            sceneNodeOneMesh.SetNormals(meshOne.Normals.ToArray());
+
             SceneNode sceneNodeOne = new()
             {
                 Components = new List<SceneComponent>()
@@ -113,15 +118,15 @@ namespace Fusee.Examples.MeshingAround.Core
                         Scale = float3.One,
                         Translation = new float3(0, 0, 0)
                     },
-                    new Mesh()
-                    {
-                        Vertices = meshOne.Vertices,
-                        Triangles = meshOne.Triangles,
-                        Normals = meshOne.Normals,
-                    }
+                    sceneNodeOneMesh
                 }
             };
             ///////////////////////////////////////////////////////////
+            var sncMesh = new Mesh();
+            sncMesh.SetVertices(cube.Vertices.ToArray());
+            sncMesh.SetTriangles(cube.Triangles.ToArray());
+            sncMesh.SetNormals(cube.Normals.ToArray());
+
             SceneNode sceneNodeCube = new()
             {
                 Components = new List<SceneComponent>()
@@ -132,16 +137,14 @@ namespace Fusee.Examples.MeshingAround.Core
                         Scale = float3.One,
                         Translation = new float3(-2, -1, 0)
                     },
-                     new Mesh()
-                    {
-                        Vertices = cube.Vertices,
-                        Triangles = cube.Triangles,
-                        Normals = cube.Normals,
-                    }
-
+                    sncMesh
                 }
             };
             //////////////////////////////////////////////////////////////////
+            var sceneNodeCTriMesh = new Mesh();
+            sceneNodeCTriMesh.SetVertices(triangle.Vertices.ToArray());
+            sceneNodeCTriMesh.SetTriangles(triangle.Triangles.ToArray());
+            sceneNodeCTriMesh.SetNormals(triangle.Normals.ToArray());
             SceneNode sceneNodeCTri = new()
             {
                 Components = new List<SceneComponent>()
@@ -152,12 +155,7 @@ namespace Fusee.Examples.MeshingAround.Core
                         Scale = float3.One,
                         Translation = new float3(1.5f, -1, 0)
                     },
-                    new Mesh()
-                    {
-                        Vertices = triangle.Vertices,
-                        Triangles = triangle.Triangles,
-                        Normals = triangle.Normals,
-                    }
+                    sceneNodeCTriMesh
                 }
             };
             //////////////////////////////////////////////////////////////////

--- a/Examples/Complete/Picking/Core/Picking.cs
+++ b/Examples/Complete/Picking/Core/Picking.cs
@@ -276,9 +276,8 @@ namespace Fusee.Examples.Picking.Core
 
         public static Mesh CreateCuboid(float3 size)
         {
-            return new Mesh
-            {
-                Vertices = new[]
+            var m = new Mesh();
+            m.SetVertices(new[]
                 {
                     new float3 {x = +0.5f * size.x, y = -0.5f * size.y, z = +0.5f * size.z},
                     new float3 {x = +0.5f * size.x, y = +0.5f * size.y, z = +0.5f * size.z},
@@ -304,10 +303,10 @@ namespace Fusee.Examples.Picking.Core
                     new float3 {x = +0.5f * size.x, y = -0.5f * size.y, z = +0.5f * size.z},
                     new float3 {x = -0.5f * size.x, y = -0.5f * size.y, z = +0.5f * size.z},
                     new float3 {x = -0.5f * size.x, y = -0.5f * size.y, z = -0.5f * size.z}
-                },
+                });
 
-                Triangles = new ushort[]
-                {
+            m.SetTriangles(new ushort[]
+                 {
                     // front face
                     0, 2, 1, 0, 3, 2,
 
@@ -325,10 +324,10 @@ namespace Fusee.Examples.Picking.Core
 
                     // bottom face
                     20, 22, 21, 20, 23, 22
-                },
+                 });
 
-                Normals = new[]
-                {
+            m.SetNormals(new[]
+            {
                     new float3(0, 0, 1),
                     new float3(0, 0, 1),
                     new float3(0, 0, 1),
@@ -353,10 +352,10 @@ namespace Fusee.Examples.Picking.Core
                     new float3(0, -1, 0),
                     new float3(0, -1, 0),
                     new float3(0, -1, 0)
-                },
+                });
 
-                UVs = new[]
-                {
+            m.SetUVs(new[]
+            {
                     new float2(1, 0),
                     new float2(1, 1),
                     new float2(0, 1),
@@ -381,9 +380,9 @@ namespace Fusee.Examples.Picking.Core
                     new float2(1, 1),
                     new float2(0, 1),
                     new float2(0, 0)
-                },
-                BoundingBox = new AABBf(-0.5f * size, 0.5f * size)
-            };
+                });
+            m.BoundingBox = new AABBf(-0.5f * size, 0.5f * size);
+            return m;
         }
     }
 }

--- a/Examples/Complete/PickingRayCast/Core/PickingRayCast.cs
+++ b/Examples/Complete/PickingRayCast/Core/PickingRayCast.cs
@@ -191,7 +191,7 @@ namespace Fusee.Examples.PickingRayCast.Core
                 var z = rand.Next(-10, 10);
 
                 var mesh = new Engine.Core.Primitives.Cube();
-                mesh.BoundingBox = new AABBf(mesh.Vertices);
+                mesh.BoundingBox = new AABBf(mesh.Vertices.ToArray());
 
                 var cube = new SceneNode()
                 {

--- a/Examples/Complete/ThreeDFont/Core/ThreeDFont.cs
+++ b/Examples/Complete/ThreeDFont/Core/ThreeDFont.cs
@@ -95,6 +95,10 @@ namespace Fusee.Examples.ThreeDFont.Core
             };
 
             //Vladimir
+            var vladMesh = new Mesh();
+            vladMesh.SetVertices(_textMeshVlad.Vertices.ToArray());
+            vladMesh.SetTriangles(_textMeshVlad.Triangles.ToArray());
+            vladMesh.SetNormals(_textMeshVlad.Normals.ToArray());
             var sceneNodeCVlad = new SceneNode
             {
                 Components = new List<SceneComponent>()
@@ -106,16 +110,15 @@ namespace Fusee.Examples.ThreeDFont.Core
                         Translation = new float3(0, 2000, 0)
                     },
                     MakeEffect.FromDiffuseSpecular(new float4(26/255f,232/255f,148/255f,1)),
-                    new Mesh
-                    {
-                        Vertices = _textMeshVlad.Vertices,
-                        Triangles = _textMeshVlad.Triangles,
-                        Normals = _textMeshVlad.Normals,
-                    }
+                   vladMesh
                 }
             };
 
             //Lato
+            var latoMesh = new Mesh();
+            latoMesh.SetVertices(_textMeshLato.Vertices.ToArray());
+            latoMesh.SetTriangles(_textMeshLato.Triangles.ToArray());
+            latoMesh.SetNormals(_textMeshLato.Normals.ToArray());
             var sceneNodeCLato = new SceneNode
             {
                 Components = new List<SceneComponent>()
@@ -127,16 +130,15 @@ namespace Fusee.Examples.ThreeDFont.Core
                         Translation = new float3(0, 0, 0)
                     },
                     MakeEffect.FromDiffuseSpecular(new float4(27/255f,242/255f,216/255f,1)),
-                    new Mesh
-                    {
-                        Vertices = _textMeshLato.Vertices,
-                        Triangles = _textMeshLato.Triangles,
-                        Normals = _textMeshLato.Normals,
-                    }
+                   latoMesh
                 }
             };
 
             //GNU
+            var gnuMesh = new Mesh();
+            gnuMesh.SetVertices(_textMeshGnu.Vertices.ToArray());
+            gnuMesh.SetTriangles(_textMeshGnu.Triangles.ToArray());
+            gnuMesh.SetNormals(_textMeshGnu.Normals.ToArray());
             var sceneNodeCGnu = new SceneNode
             {
                 Components = new List<SceneComponent>()
@@ -148,12 +150,7 @@ namespace Fusee.Examples.ThreeDFont.Core
                         Translation = new float3(0, -2000, 0)
                     },
                     MakeEffect.FromDiffuseSpecular(new float4(34/255f,190/255f,219/255f,1)),
-                    new Mesh
-                    {
-                        Vertices = _textMeshGnu.Vertices,
-                        Triangles = _textMeshGnu.Triangles,
-                        Normals = _textMeshGnu.Normals,
-                    }
+                    gnuMesh
                 }
             };
 

--- a/src/Engine/Common/IRenderContextImp.cs
+++ b/src/Engine/Common/IRenderContextImp.cs
@@ -526,6 +526,94 @@ namespace Fusee.Engine.Common
         void SetBoneWeights(IMeshImp mr, ReadOnlySpan<float4> boneWeights);
 
         /// <summary>
+        /// Binds the vertices onto the GL render context and assigns one vertex to the passed <see cref="IMeshImp" /> instance.
+        /// </summary>
+        /// <param name="mesh">The <see cref="IMeshImp" /> instance.</param>
+        /// <param name="idx">The index position</param>
+        /// <param name="vertex">The vertex.</param>
+        void SetVertex(IMeshImp mesh, int idx, float3 vertex);
+
+        /// <summary>
+        /// Binds the tangents onto the GL render context and assigns one tangent index to the passed <see cref="IMeshImp" /> instance.
+        /// </summary>
+        /// <param name="mr">The <see cref="IMeshImp" /> instance.</param>
+        /// <param name="idx">The index position</param>
+        /// <param name="tangents">The tangents.</param>
+        void SetTangent(IMeshImp mr, int idx, float4 tangents);
+
+        /// <summary>
+        /// Binds the bitangents onto the GL render context and assigns one BiTangent index to the passed <see cref="IMeshImp" /> instance.
+        /// </summary>
+        /// <param name="mr">The <see cref="IMeshImp" /> instance.</param>
+        /// <param name="idx">The index position</param>
+        /// <param name = "bitangent">The bitangent.</param>
+        void SetBiTangent(IMeshImp mr, int idx, float3 bitangent);
+
+        /// <summary>
+        /// Binds the normals onto the GL render context and assigns one NormalBuffer index to the passed <see cref="IMeshImp" /> instance.
+        /// </summary>
+        /// <param name="mr">The <see cref="IMeshImp" /> instance.</param>
+        /// <param name="idx">The index position</param>
+        /// <param name="normal">The normal.</param>
+        void SetNormal(IMeshImp mr, int idx, float3 normal);
+
+        /// <summary>
+        /// Binds the UV coordinates onto the GL render context and assigns one UVBuffer index to the passed <see cref="IMeshImp" /> instance.
+        /// </summary>
+        /// <param name="mr">The <see cref="IMeshImp" /> instance.</param>
+        /// <param name="idx">The index position</param>
+        /// <param name="uv">The UV.</param>
+        void SetUV(IMeshImp mr, int idx, float2 uv);
+
+        /// <summary>
+        /// Binds the colors onto the GL render context and assigns one ColorBuffer index to the passed <see cref="IMeshImp" /> instance.
+        /// </summary>
+        /// <param name="mr">The <see cref="IMeshImp" /> instance.</param>
+        /// <param name="idx">The index position</param>
+        /// <param name="color">The colors.</param>
+        void SetColor(IMeshImp mr, int idx, uint color);
+
+        /// <summary>
+        /// Binds the colors onto the GL render context and assigns one ColorBuffer index to the passed <see cref="IMeshImp" /> instance.
+        /// </summary>
+        /// <param name="mr">The <see cref="IMeshImp" /> instance.</param>
+        /// <param name="idx">The index position</param>
+        /// <param name="color">The color.</param>
+        void SetColor1(IMeshImp mr, int idx, uint color);
+
+        /// <summary>
+        /// Binds the colors onto the GL render context and assigns one ColorBuffer index to the passed <see cref="IMeshImp" /> instance.
+        /// </summary>
+        /// <param name="mr">The <see cref="IMeshImp" /> instance.</param>
+        /// <param name="idx">The index position</param>
+        /// <param name="color">The color.</param>
+        void SetColor2(IMeshImp mr, int idx, uint color);
+
+        /// <summary>
+        /// Binds the triangles onto the GL render context and assigns one ElementBuffer index to the passed <see cref="IMeshImp" /> instance.
+        /// </summary>
+        /// <param name="mr">The <see cref="IMeshImp" /> instance.</param>
+        /// <param name="idx">The index position</param>
+        /// <param name="triangleIndex">The triangle index.</param>
+        void SetTriangle(IMeshImp mr, int idx, ushort triangleIndex);
+
+        /// <summary>
+        /// Binds the bone indices onto the GL render context and assigns one BoneBuffer index to the passed <see cref="IMeshImp" /> instance.
+        /// </summary>
+        /// <param name="mr">The <see cref="IMeshImp" /> instance.</param>
+        /// <param name="idx">The index position</param>
+        /// <param name="boneIndex">The bone index.</param>
+        void SetBoneIndex(IMeshImp mr, int idx, float4 boneIndex);
+
+        /// <summary>
+        /// Binds the bone weights onto the GL render context and assigns one BoneWeight index to the passed <see cref="IMeshImp" /> instance.
+        /// </summary>
+        /// <param name="mr">The <see cref="IMeshImp" /> instance.</param>
+        /// <param name="idx">The index position</param>
+        /// <param name="boneWeight">The bone weight.</param>
+        void SetBoneWeight(IMeshImp mr, int idx, float4 boneWeight);
+
+        /// <summary>
         /// Activates the passed shader program as the current shader for geometry rendering.
         /// </summary>
         /// <param name="shaderProgramImp">The shader to apply to mesh geometry subsequently passed to the RenderContext</param>

--- a/src/Engine/Common/IRenderContextImp.cs
+++ b/src/Engine/Common/IRenderContextImp.cs
@@ -1,5 +1,6 @@
 ﻿using Fusee.Base.Common;
 using Fusee.Math.Core;
+using System;
 using System.Collections.Generic;
 
 namespace Fusee.Engine.Common
@@ -41,7 +42,7 @@ namespace Fusee.Engine.Common
         float ClearDepth { set; get; }
 
         /// <summary>
-        /// The clipping behavior against the Z position of a vertex can be turned off by activating depth clamping. 
+        /// The clipping behavior against the Z position of a vertex can be turned off by activating depth clamping.
         /// This is done with glEnable(GL_DEPTH_CLAMP). This will cause the clip-space Z to remain unclipped by the front and rear viewing volume.
         /// See: https://www.khronos.org/opengl/wiki/Vertex_Post-Processing#Depth_clamping
         /// </summary>
@@ -102,7 +103,7 @@ namespace Fusee.Engine.Common
         /// </summary>
         /// <param name="renderTarget">The render target.</param>
         /// <param name="attachment">Number of the fbo attachment. For example: attachment = 1 will detach the texture currently associated with the ColorAttachment1.</param>
-        /// <param name="isDepthTex">Determines if the texture is a depth texture. In this case the texture currently associated with the DepthAttachment will be detached.</param>       
+        /// <param name="isDepthTex">Determines if the texture is a depth texture. In this case the texture currently associated with the DepthAttachment will be detached.</param>
         void DetachTextureFromFbo(IRenderTarget renderTarget, bool isDepthTex, int attachment = 0);
 
 
@@ -111,7 +112,7 @@ namespace Fusee.Engine.Common
         /// </summary>
         /// <param name="renderTarget">The render target.</param>
         /// <param name="attachment">Number of the fbo attachment. For example: attachment = 1 will attach the texture to the ColorAttachment1.</param>
-        /// <param name="isDepthTex">Determines if the texture is a depth texture. In this case the texture is attached to the DepthAttachment.</param>        
+        /// <param name="isDepthTex">Determines if the texture is a depth texture. In this case the texture is attached to the DepthAttachment.</param>
         /// <param name="texHandle">The gpu handle of the texture.</param>
         void AttacheTextureToFbo(IRenderTarget renderTarget, bool isDepthTex, ITextureHandle texHandle, int attachment = 0);
 
@@ -379,25 +380,25 @@ namespace Fusee.Engine.Common
         /// Method should be called after LoadImage method to process
         /// the BitmapData an make them available for the shader.
         /// </remarks>
-        /// <param name="img">An <see cref="ITexture"/>, containing necessary information for the upload to the graphics card.</param>       
+        /// <param name="img">An <see cref="ITexture"/>, containing necessary information for the upload to the graphics card.</param>
         ITextureHandle CreateTexture(ITexture img);
 
         /// <summary>
         /// Creates a new cube map and binds it to the shader.
-        /// </summary>        
-        /// <param name="img">An <see cref="IWritableArrayTexture"/>, containing necessary information for the upload to the graphics card.</param>       
+        /// </summary>
+        /// <param name="img">An <see cref="IWritableArrayTexture"/>, containing necessary information for the upload to the graphics card.</param>
         ITextureHandle CreateTexture(IWritableArrayTexture img);
 
         /// <summary>
         /// Creates a new cube map and binds it to the shader.
-        /// </summary>        
-        /// <param name="img">An <see cref="IWritableCubeMap"/>, containing necessary information for the upload to the graphics card.</param>       
+        /// </summary>
+        /// <param name="img">An <see cref="IWritableCubeMap"/>, containing necessary information for the upload to the graphics card.</param>
         ITextureHandle CreateTexture(IWritableCubeMap img);
 
         /// <summary>
         /// Creates a new texture and binds it to the shader.
-        /// </summary>      
-        /// <param name="img">An <see cref="IWritableTexture"/>, containing necessary information for the upload to the graphics card.</param>       
+        /// </summary>
+        /// <param name="img">An <see cref="IWritableTexture"/>, containing necessary information for the upload to the graphics card.</param>
         ITextureHandle CreateTexture(IWritableTexture img);
 
         /// <summary>
@@ -440,7 +441,7 @@ namespace Fusee.Engine.Common
         /// <param name="mesh">The <see cref="IMeshImp" /> instance.</param>
         /// <param name="vertices">The vertices.</param>
         /// <exception cref="System.ArgumentException">Vertices must not be null or empty</exception>
-        void SetVertices(IMeshImp mesh, float3[] vertices);
+        void SetVertices(IMeshImp mesh, ReadOnlySpan<float3> vertices);
 
         /// <summary>
         /// Binds the tangents onto the GL render context and assigns an TangentBuffer index to the passed <see cref="IMeshImp" /> instance.
@@ -449,7 +450,7 @@ namespace Fusee.Engine.Common
         /// <param name="tangents">The tangents.</param>
         /// <exception cref="System.ArgumentException">Tangents must not be null or empty</exception>
         /// <exception cref="System.ApplicationException"></exception>
-        void SetTangents(IMeshImp mr, float4[] tangents);
+        void SetTangents(IMeshImp mr, ReadOnlySpan<float4> tangents);
 
         /// <summary>
         /// Binds the bitangents onto the GL render context and assigns an BiTangentBuffer index to the passed <see cref="IMeshImp" /> instance.
@@ -458,7 +459,7 @@ namespace Fusee.Engine.Common
         /// <param name = "bitangents">The bitangents.</param>
         /// <exception cref="System.ArgumentException">BiTangents must not be null or empty</exception>
         /// <exception cref="System.ApplicationException"></exception>
-        void SetBiTangents(IMeshImp mr, float3[] bitangents);
+        void SetBiTangents(IMeshImp mr, ReadOnlySpan<float3> bitangents);
 
         /// <summary>
         /// Binds the normals onto the GL render context and assigns an NormalBuffer index to the passed <see cref="IMeshImp" /> instance.
@@ -466,7 +467,7 @@ namespace Fusee.Engine.Common
         /// <param name="mr">The <see cref="IMeshImp" /> instance.</param>
         /// <param name="normals">The normals.</param>
         /// <exception cref="System.ArgumentException">Normals must not be null or empty</exception>
-        void SetNormals(IMeshImp mr, float3[] normals);
+        void SetNormals(IMeshImp mr, ReadOnlySpan<float3> normals);
 
         /// <summary>
         /// Binds the UV coordinates onto the GL render context and assigns an UVBuffer index to the passed <see cref="IMeshImp" /> instance.
@@ -474,7 +475,7 @@ namespace Fusee.Engine.Common
         /// <param name="mr">The <see cref="IMeshImp" /> instance.</param>
         /// <param name="uvs">The UV's.</param>
         /// <exception cref="System.ArgumentException">UVs must not be null or empty</exception>
-        void SetUVs(IMeshImp mr, float2[] uvs);
+        void SetUVs(IMeshImp mr, ReadOnlySpan<float2> uvs);
 
         /// <summary>
         /// Binds the colors onto the GL render context and assigns an ColorBuffer index to the passed <see cref="IMeshImp" /> instance.
@@ -482,7 +483,7 @@ namespace Fusee.Engine.Common
         /// <param name="mr">The <see cref="IMeshImp" /> instance.</param>
         /// <param name="colors">The colors.</param>
         /// <exception cref="System.ArgumentException">colors must not be null or empty</exception>
-        void SetColors(IMeshImp mr, uint[] colors);
+        void SetColors(IMeshImp mr, ReadOnlySpan<uint> colors);
 
         /// <summary>
         /// Binds the colors onto the GL render context and assigns an ColorBuffer index to the passed <see cref="IMeshImp" /> instance.
@@ -490,7 +491,7 @@ namespace Fusee.Engine.Common
         /// <param name="mr">The <see cref="IMeshImp" /> instance.</param>
         /// <param name="colors">The colors.</param>
         /// <exception cref="System.ArgumentException">colors must not be null or empty</exception>
-        void SetColors1(IMeshImp mr, uint[] colors);
+        void SetColors1(IMeshImp mr, ReadOnlySpan<uint> colors);
 
         /// <summary>
         /// Binds the colors onto the GL render context and assigns an ColorBuffer index to the passed <see cref="IMeshImp" /> instance.
@@ -498,7 +499,7 @@ namespace Fusee.Engine.Common
         /// <param name="mr">The <see cref="IMeshImp" /> instance.</param>
         /// <param name="colors">The colors.</param>
         /// <exception cref="System.ArgumentException">colors must not be null or empty</exception>
-        void SetColors2(IMeshImp mr, uint[] colors);
+        void SetColors2(IMeshImp mr, ReadOnlySpan<uint> colors);
 
         /// <summary>
         /// Binds the triangles onto the GL render context and assigns an ElementBuffer index to the passed <see cref="IMeshImp" /> instance.
@@ -506,7 +507,7 @@ namespace Fusee.Engine.Common
         /// <param name="mr">The <see cref="IMeshImp" /> instance.</param>
         /// <param name="triangleIndices">The triangle indices.</param>
         /// <exception cref="System.ArgumentException">triangleIndices must not be null or empty</exception>
-        void SetTriangles(IMeshImp mr, ushort[] triangleIndices);
+        void SetTriangles(IMeshImp mr, ReadOnlySpan<ushort> triangleIndices);
 
         /// <summary>
         /// Binds the bone indices onto the GL render context and assigns an ElementBuffer index to the passed <see cref="IMeshImp" /> instance.
@@ -514,7 +515,7 @@ namespace Fusee.Engine.Common
         /// <param name="mr">The <see cref="IMeshImp" /> instance.</param>
         /// <param name="boneIndices">The bone indices.</param>
         /// <exception cref="System.ArgumentException">boneIndices must not be null or empty</exception>
-        void SetBoneIndices(IMeshImp mr, float4[] boneIndices);
+        void SetBoneIndices(IMeshImp mr, ReadOnlySpan<float4> boneIndices);
 
         /// <summary>
         /// Binds the bone weights onto the GL render context and assigns an ElementBuffer index to the passed <see cref="IMeshImp" /> instance.
@@ -522,7 +523,7 @@ namespace Fusee.Engine.Common
         /// <param name="mr">The <see cref="IMeshImp" /> instance.</param>
         /// <param name="boneWeights">The bone weights.</param>
         /// <exception cref="System.ArgumentException">boneWeights must not be null or empty</exception>
-        void SetBoneWeights(IMeshImp mr, float4[] boneWeights);
+        void SetBoneWeights(IMeshImp mr, ReadOnlySpan<float4> boneWeights);
 
         /// <summary>
         /// Activates the passed shader program as the current shader for geometry rendering.
@@ -633,7 +634,7 @@ namespace Fusee.Engine.Common
         /// <summary>
         /// Renders the specified mesh.
         /// </summary>
-        /// <param name="mr">The mesh that should be rendered.</param>        
+        /// <param name="mr">The mesh that should be rendered.</param>
         /// <remarks>
         /// Passes geometry to be pushed through the rendering pipeline. <see cref="IMeshImp"/> for a description how geometry is made up.
         /// The geometry is transformed and rendered by the currently active shader program.
@@ -747,17 +748,17 @@ namespace Fusee.Engine.Common
         /// <returns>The Z value at (x, y).</returns>
         float GetPixelDepth(int x, int y);
 
-        /// <summary> 
-        /// Returns the capabilities of the underlying graphics hardware 
-        /// </summary> 
-        /// <param name="capability">The capability to check against</param> 
-        /// <returns>uint</returns> 
+        /// <summary>
+        /// Returns the capabilities of the underlying graphics hardware
+        /// </summary>
+        /// <param name="capability">The capability to check against</param>
+        /// <returns>uint</returns>
         uint GetHardwareCapabilities(HardwareCapability capability);
 
-        /// <summary> 
-        /// Returns a human readable description of the underlying graphics hardware 
-        /// </summary> 
-        /// <returns>Description</returns> 
+        /// <summary>
+        /// Returns a human readable description of the underlying graphics hardware
+        /// </summary>
+        /// <returns>Description</returns>
         string GetHardwareDescription();
     }
 
@@ -778,7 +779,7 @@ namespace Fusee.Engine.Common
         CanUseGeometryShaders,
 
         /// <summary>
-        /// Returns the max value for GL_MAX_SAMPLES usable in multi-sample <see cref="IWritableTexture"/> textures 
+        /// Returns the max value for GL_MAX_SAMPLES usable in multi-sample <see cref="IWritableTexture"/> textures
         /// </summary>
         MaxSamples
     }

--- a/src/Engine/Common/MeshChangedEnum.cs
+++ b/src/Engine/Common/MeshChangedEnum.cs
@@ -1,7 +1,7 @@
 ﻿namespace Fusee.Engine.Common
 {
     /// <summary>
-    /// Propagates Mesh properties changed status to the MeshManager 
+    /// Propagates Mesh properties changed status to the MeshManager
     /// </summary>
     public enum MeshChangedEnum
     {
@@ -16,9 +16,19 @@
         Vertices,
 
         /// <summary>
+        /// One Vertex has changed.
+        /// </summary>
+        Vertex,
+
+        /// <summary>
         /// The Triangles have changed.
         /// </summary>
         Triangles,
+
+        /// <summary>
+        /// One Triangle has changed.
+        /// </summary>
+        Triangle,
 
         /// <summary>
         /// The field Mesh changed.
@@ -26,9 +36,19 @@
         Colors,
 
         /// <summary>
+        /// One color has changed.
+        /// </summary>
+        Color,
+
+        /// <summary>
         /// The field Colors1 changed.
         /// </summary>
         Colors1,
+
+        /// <summary>
+        /// One Color1 has changed.
+        /// </summary>
+        Color1,
 
         /// <summary>
         /// The field Colors2 changed.
@@ -36,9 +56,19 @@
         Colors2,
 
         /// <summary>
+        /// One Color2 has changed.
+        /// </summary>
+        Color2,
+
+        /// <summary>
         /// The field Normals changed.
         /// </summary>
         Normals,
+
+        /// <summary>
+        /// One Normals has changed.
+        /// </summary>
+        Normal,
 
         /// <summary>
         /// The field UVs changed.
@@ -46,9 +76,19 @@
         Uvs,
 
         /// <summary>
+        /// One UV has changed.
+        /// </summary>
+        Uv,
+
+        /// <summary>
         /// The field BoneWeights changed.
         /// </summary>
         BoneWeights,
+
+        /// <summary>
+        /// One BoneWeight has changed.
+        /// </summary>
+        BoneWeight,
 
         /// <summary>
         /// The field BoneIndices changed.
@@ -56,14 +96,28 @@
         BoneIndices,
 
         /// <summary>
+        /// One Bone Index has changed.
+        /// </summary>
+        BondeIndex,
+
+        /// <summary>
         /// The field Tangents changed.
         /// </summary>
         Tangents,
 
         /// <summary>
+        /// One Tangent has changed.
+        /// </summary>
+        Tangent,
+
+        /// <summary>
         /// The field BiTangents changed.
         /// </summary>
-        BiTangents
+        BiTangents,
 
+        /// <summary>
+        /// One BiTangent has changed.
+        /// </summary>
+        BiTangent
     }
 }

--- a/src/Engine/Common/MeshChangedEventArgs.cs
+++ b/src/Engine/Common/MeshChangedEventArgs.cs
@@ -3,6 +3,15 @@
 namespace Fusee.Engine.Common
 {
     /// <summary>
+    /// Data for a mesh changed event
+    /// </summary>
+    public class MeshChangedEventAdditionalData
+    {
+        public int Index;
+        public object Value;
+    }
+
+    /// <summary>
     /// EventArgs to propagate changes of a <see cref="Mesh"/> object's life cycle and property changes.
     /// </summary>
     public class MeshChangedEventArgs : EventArgs
@@ -18,14 +27,21 @@ namespace Fusee.Engine.Common
         public MeshChangedEnum ChangedEnum { get; protected set; }
 
         /// <summary>
+        /// Additional data for change event
+        /// </summary>
+        public MeshChangedEventAdditionalData Data { get; }
+
+        /// <summary>
         /// Constructor takes a Mesh and a description which property of the mesh changed.
         /// </summary>
         /// <param name="mesh">The Mesh which property of life cycle has changed.</param>
         /// <param name="meshChangedEnum">The <see cref="MeshChangedEnum"/> describing which property of the Mesh changed.</param>
-        public MeshChangedEventArgs(IManagedMesh mesh, MeshChangedEnum meshChangedEnum)
+        /// <param name="data">Additional data, needed for a single value change</param>
+        public MeshChangedEventArgs(IManagedMesh mesh, MeshChangedEnum meshChangedEnum, MeshChangedEventAdditionalData data = null)
         {
             Mesh = mesh;
             ChangedEnum = meshChangedEnum;
+            Data = data;
         }
     }
 }

--- a/src/Engine/Core/FusSceneConverter.cs
+++ b/src/Engine/Core/FusSceneConverter.cs
@@ -555,18 +555,27 @@ namespace Fusee.Engine.Core
             {
                 MeshType = (PrimitiveType)m.MeshType,
                 Active = true,
-                BiTangents = m.BiTangents,
-                BoneIndices = m.BoneIndices,
-                BoundingBox = m.BoundingBox,
-                BoneWeights = m.BoneWeights,
-                Colors = m.Colors,
-                Name = m.Name,
-                Normals = m.Normals,
-                Tangents = m.Tangents,
-                Triangles = m.Triangles,
-                UVs = m.UVs,
-                Vertices = m.Vertices
+                Name = m.Name
             };
+
+            if(m.BiTangents != null)
+            mesh.SetBiTangents(m.BiTangents);
+            if (m.BoneIndices != null)
+                mesh.SetBoneIndices(m.BoneIndices);
+            if (m.BoneWeights != null)
+                mesh.SetBoneWeights(m.BoneWeights);
+            if (m.Colors != null)
+                mesh.SetColors(m.Colors);
+            if (m.Normals != null)
+                mesh.SetNormals(m.Normals);
+            if (m.Tangents != null)
+                mesh.SetTangents(m.Tangents);
+            if (m.Triangles != null)
+                mesh.SetTriangles(m.Triangles);
+            if (m.UVs != null)
+                mesh.SetUVs(m.UVs);
+            if (m.Vertices != null)
+                mesh.SetVertices(m.Vertices);
 
             if (_currentNode.Components == null)
             {
@@ -1257,17 +1266,17 @@ namespace Fusee.Engine.Core
             var mesh = new FusMesh
             {
                 MeshType = (int)m.MeshType,
-                BiTangents = m.BiTangents,
-                BoneIndices = m.BoneIndices,
-                BoundingBox = m.BoundingBox,
-                BoneWeights = m.BoneWeights,
-                Colors = m.Colors,
                 Name = m.Name,
-                Normals = m.Normals,
-                Tangents = m.Tangents,
-                Triangles = m.Triangles,
-                UVs = m.UVs,
-                Vertices = m.Vertices
+                BoundingBox = m.BoundingBox,
+                BiTangents = m.BiTangents.ToArray(),
+                BoneIndices = m.BoneIndices.ToArray(),
+                BoneWeights = m.BoneWeights.ToArray(),
+                Colors = m.Colors.ToArray(),
+                Normals = m.Normals.ToArray(),
+                Tangents = m.Tangents.ToArray(),
+                Triangles = m.Triangles.ToArray(),
+                UVs = m.UVs.ToArray(),
+                Vertices = m.Vertices.ToArray()
             };
 
             _currentNode.AddComponent(mesh);

--- a/src/Engine/Core/FusSceneConverter.cs
+++ b/src/Engine/Core/FusSceneConverter.cs
@@ -555,11 +555,12 @@ namespace Fusee.Engine.Core
             {
                 MeshType = (PrimitiveType)m.MeshType,
                 Active = true,
-                Name = m.Name
+                Name = m.Name,
+                BoundingBox = m.BoundingBox
             };
 
             if(m.BiTangents != null)
-            mesh.SetBiTangents(m.BiTangents);
+                mesh.SetBiTangents(m.BiTangents);
             if (m.BoneIndices != null)
                 mesh.SetBoneIndices(m.BoneIndices);
             if (m.BoneWeights != null)

--- a/src/Engine/Core/FusSceneConverter.cs
+++ b/src/Engine/Core/FusSceneConverter.cs
@@ -559,7 +559,7 @@ namespace Fusee.Engine.Core
                 BoundingBox = m.BoundingBox
             };
 
-            if(m.BiTangents != null)
+            if (m.BiTangents != null)
                 mesh.SetBiTangents(m.BiTangents);
             if (m.BoneIndices != null)
                 mesh.SetBoneIndices(m.BoneIndices);

--- a/src/Engine/Core/Geometry.cs
+++ b/src/Engine/Core/Geometry.cs
@@ -309,7 +309,7 @@ namespace Fusee.Engine.Core
                     normals.Add(CalcFaceNormal(_faces[i]));
                 }
                 // Quick and dirty solution: if the smoothing angle holds for all combinations we create a shared normal,
-                // otherwise we create individual normals for each face. 
+                // otherwise we create individual normals for each face.
                 // TODO: Build groups of shared normals where faces are connected by edges (need edges to do this)
                 bool smoothit = true;
                 for (int i = 0; i < normals.Count; i++)
@@ -372,7 +372,7 @@ namespace Fusee.Engine.Core
             /// Returns a hash code for this instance.
             /// </summary>
             /// <returns>
-            /// A hash code for this instance, suitable for use in hashing algorithms and data structures like a hash table. 
+            /// A hash code for this instance, suitable for use in hashing algorithms and data structures like a hash table.
             /// </returns>
             public override int GetHashCode()
             {
@@ -434,16 +434,14 @@ namespace Fusee.Engine.Core
                 mTris.AddRange(Triangulate(f, mFace));
             }
 
-            Mesh m = new()
-            {
-                Vertices = mVerts.ToArray()
-            };
+            Mesh m = new();
+            m.SetVertices(mVerts.ToArray());
             if (HasNormals)
-                m.Normals = mNormals.ToArray();
+                m.SetNormals(mNormals.ToArray());
             if (HasTexCoords)
-                m.UVs = mTexCoords.ToArray();
+                m.SetUVs(mTexCoords.ToArray());
 
-            m.Triangles = mTris.ToArray();
+            m.SetTriangles(mTris.ToArray());
             return m;
         }
 

--- a/src/Engine/Core/JometriMesh.cs
+++ b/src/Engine/Core/JometriMesh.cs
@@ -20,9 +20,9 @@ namespace Fusee.Engine.Core
         {
             ConvertToMesh(geometry, out var vertices, out var triangles, out var normals);
 
-            Vertices = vertices;
-            Triangles = triangles;
-            Normals = normals.ToArray();
+            SetVertices(vertices);
+            SetTriangles(triangles);
+            SetNormals(normals.ToArray());
         }
 
         //Geometry has to be triangulated! Translates a Jometri.Geometry into a Fusee.Mesh.

--- a/src/Engine/Core/MeshManager.cs
+++ b/src/Engine/Core/MeshManager.cs
@@ -78,35 +78,69 @@ namespace Fusee.Engine.Core
                     _renderContextImp.SetVertices(toBeUpdatedMeshImp, mesh.Vertices);
                     mesh.BoundingBox = new AABBf(mesh.Vertices.ToArray());
                     break;
+                case MeshChangedEnum.Vertex:
+                    _renderContextImp.SetVertex(toBeUpdatedMeshImp, meshDataEventArgs.Data.Index, (float3)meshDataEventArgs.Data.Value);
+                    mesh.BoundingBox = new AABBf(mesh.Vertices.ToArray());
+                    break;
                 case MeshChangedEnum.Triangles:
                     _renderContextImp.SetTriangles(toBeUpdatedMeshImp, mesh.Triangles);
+                    break;
+                case MeshChangedEnum.Triangle:
+                    _renderContextImp.SetTriangle(toBeUpdatedMeshImp, meshDataEventArgs.Data.Index, (ushort)meshDataEventArgs.Data.Value);
                     break;
                 case MeshChangedEnum.Colors:
                     _renderContextImp.SetColors(toBeUpdatedMeshImp, mesh.Colors);
                     break;
+                case MeshChangedEnum.Color:
+                    _renderContextImp.SetColor(toBeUpdatedMeshImp, meshDataEventArgs.Data.Index, (uint)meshDataEventArgs.Data.Value);
+                    break;
                 case MeshChangedEnum.Colors1:
                     _renderContextImp.SetColors(toBeUpdatedMeshImp, mesh.Colors1);
+                    break;
+                case MeshChangedEnum.Color1:
+                    _renderContextImp.SetColor1(toBeUpdatedMeshImp, meshDataEventArgs.Data.Index, (uint)meshDataEventArgs.Data.Value);
                     break;
                 case MeshChangedEnum.Colors2:
                     _renderContextImp.SetColors(toBeUpdatedMeshImp, mesh.Colors2);
                     break;
+                case MeshChangedEnum.Color2:
+                    _renderContextImp.SetColor2(toBeUpdatedMeshImp, meshDataEventArgs.Data.Index, (uint)meshDataEventArgs.Data.Value);
+                    break;
                 case MeshChangedEnum.Normals:
                     _renderContextImp.SetNormals(toBeUpdatedMeshImp, mesh.Normals);
+                    break;
+                case MeshChangedEnum.Normal:
+                    _renderContextImp.SetNormal(toBeUpdatedMeshImp, meshDataEventArgs.Data.Index, (float3)meshDataEventArgs.Data.Value);
                     break;
                 case MeshChangedEnum.Uvs:
                     _renderContextImp.SetUVs(toBeUpdatedMeshImp, mesh.UVs);
                     break;
+                case MeshChangedEnum.Uv:
+                    _renderContextImp.SetUV(toBeUpdatedMeshImp, meshDataEventArgs.Data.Index, (float2)meshDataEventArgs.Data.Value);
+                    break;
                 case MeshChangedEnum.BoneIndices:
                     _renderContextImp.SetBoneIndices(toBeUpdatedMeshImp, mesh.BoneIndices);
+                    break;
+                case MeshChangedEnum.BondeIndex:
+                    _renderContextImp.SetBoneIndex(toBeUpdatedMeshImp, meshDataEventArgs.Data.Index, (float4)meshDataEventArgs.Data.Value);
                     break;
                 case MeshChangedEnum.BoneWeights:
                     _renderContextImp.SetBoneWeights(toBeUpdatedMeshImp, mesh.BoneWeights);
                     break;
+                case MeshChangedEnum.BoneWeight:
+                    _renderContextImp.SetBoneWeight(toBeUpdatedMeshImp, meshDataEventArgs.Data.Index, (float4)meshDataEventArgs.Data.Value);
+                    break;
                 case MeshChangedEnum.Tangents:
                     _renderContextImp.SetTangents(toBeUpdatedMeshImp, mesh.Tangents);
                     break;
+                case MeshChangedEnum.Tangent:
+                    _renderContextImp.SetTangent(toBeUpdatedMeshImp, meshDataEventArgs.Data.Index, (float4)meshDataEventArgs.Data.Value);
+                    break;
                 case MeshChangedEnum.BiTangents:
                     _renderContextImp.SetBiTangents(toBeUpdatedMeshImp, mesh.BiTangents);
+                    break;
+                case MeshChangedEnum.BiTangent:
+                    _renderContextImp.SetBiTangent(toBeUpdatedMeshImp, meshDataEventArgs.Data.Index, (float3)meshDataEventArgs.Data.Value);
                     break;
             }
         }

--- a/src/Engine/Core/MeshManager.cs
+++ b/src/Engine/Core/MeshManager.cs
@@ -76,7 +76,7 @@ namespace Fusee.Engine.Core
             {
                 case MeshChangedEnum.Vertices:
                     _renderContextImp.SetVertices(toBeUpdatedMeshImp, mesh.Vertices);
-                    mesh.BoundingBox = new AABBf(mesh.Vertices);
+                    mesh.BoundingBox = new AABBf(mesh.Vertices.ToArray());
                     break;
                 case MeshChangedEnum.Triangles:
                     _renderContextImp.SetTriangles(toBeUpdatedMeshImp, mesh.Triangles);

--- a/src/Engine/Core/ParticleEmitter.cs
+++ b/src/Engine/Core/ParticleEmitter.cs
@@ -40,12 +40,12 @@ namespace Fusee.Engine.Core
             varying vec3 vNormal;
             varying vec2 vUv;
             varying float vTransparency;
-        
+
             uniform mat4 FUSEE_MVP;
             uniform mat4 FUSEE_MV;
             uniform mat4 FUSEE_P;
             uniform mat4 FUSEE_ITMV;
-            
+
             uniform float timer;
             attribute vec4 position;
             varying vec2 texcoord;
@@ -53,14 +53,14 @@ namespace Fusee.Engine.Core
 
             void main()
             {
-     
+
                 vec4 vPos = FUSEE_MV * vec4(fuVertex, 1.0);//umwandlung in Kamerakoordinaten
-               
+
                 //Offset rotieren um fuNormal.x
                 vec2 offset = fuUV;
                 offset.x  = fuUV.x*cos(fuNormal.x) - fuUV.y*sin(fuNormal.x);
                 offset.y =  fuUV.y*cos(fuNormal.x) + fuUV.x*sin(fuNormal.x);
-                vPos = vPos + vec4(100.0*offset, 0, 1.0);   //Offset  aus Partikelzentrum in Partikel-Eckpunkt          
+                vPos = vPos + vec4(100.0*offset, 0, 1.0);   //Offset  aus Partikelzentrum in Partikel-Eckpunkt
                 gl_Position = FUSEE_P * vPos; //Perspektive-Projektion
                 vNormal = mat3(FUSEE_ITMV[0].xyz, FUSEE_ITMV[1].xyz, FUSEE_ITMV[2].xyz) * fuNormal;
                 vNormal = vec3(0, 0, 1);
@@ -89,10 +89,10 @@ namespace Fusee.Engine.Core
             varying vec2 vUv;
 
             void main()
-            {    
-              // The most basic texturing function, expecting the above mentioned parameters  
+            {
+              // The most basic texturing function, expecting the above mentioned parameters
              vec4 AlphaColor = vec4(1.0, 1.0, 1.0, vTransparency);
-             gl_FragColor = texture2D(texture1, vUv)*AlphaColor;        
+             gl_FragColor = texture2D(texture1, vUv)*AlphaColor;
             }";
 
         #endregion
@@ -374,10 +374,10 @@ namespace Fusee.Engine.Core
                 }
             }
 
-            ParticleMesh.Vertices = vertices;
-            ParticleMesh.Triangles = triangles;
-            ParticleMesh.Normals = normals;
-            ParticleMesh.UVs = uVs;
+            ParticleMesh.SetVertices(vertices);
+            ParticleMesh.SetTriangles(triangles);
+            ParticleMesh.SetNormals(normals);
+            ParticleMesh.SetUVs(uVs);
 
             //Updates information
             for (var i = 0; i < _particleList.Count; i++)
@@ -403,7 +403,7 @@ namespace Fusee.Engine.Core
                     changeParticle.Life -= 1;
                 }
                 _particleList[i] = changeParticle;
-                //Death 
+                //Death
                 if (changeParticle.Life == 0 || changeParticle.Life <= 0)
                 {
                     _particleList.Remove(changeParticle);

--- a/src/Engine/Core/Primitives/Circle.cs
+++ b/src/Engine/Core/Primitives/Circle.cs
@@ -108,9 +108,9 @@ namespace Fusee.Engine.Core.Primitives
             }
 
             SetVertices(verts.ToArray());
-            SetNormals( normals.ToArray());
-            SetTriangles( triangles.ToArray());
-            SetUVs( uvs.ToArray());
+            SetNormals(normals.ToArray());
+            SetTriangles(triangles.ToArray());
+            SetUVs(uvs.ToArray());
         }
 
         private float Normalize(float input, float max, float min)

--- a/src/Engine/Core/Primitives/Circle.cs
+++ b/src/Engine/Core/Primitives/Circle.cs
@@ -107,10 +107,10 @@ namespace Fusee.Engine.Core.Primitives
                 currentAngle += angleByStep;
             }
 
-            Vertices = verts.ToArray();
-            Normals = normals.ToArray();
-            Triangles = triangles.ToArray();
-            UVs = uvs.ToArray();
+            SetVertices(verts.ToArray());
+            SetNormals( normals.ToArray());
+            SetTriangles( triangles.ToArray());
+            SetUVs( uvs.ToArray());
         }
 
         private float Normalize(float input, float max, float min)

--- a/src/Engine/Core/Primitives/Cube.cs
+++ b/src/Engine/Core/Primitives/Cube.cs
@@ -169,7 +169,7 @@ namespace Fusee.Engine.Core.Primitives
                 new float2(0, 1),
                 new float2(0, 0)
             });
-            BoundingBox = new AABBf(Vertices);
+            BoundingBox = new AABBf(Vertices.ToArray());
 
         }
         #endregion

--- a/src/Engine/Core/Primitives/Cube.cs
+++ b/src/Engine/Core/Primitives/Cube.cs
@@ -17,7 +17,7 @@ namespace Fusee.Engine.Core.Primitives
         public WireframeCube()
         {
             MeshType = PrimitiveType.Lines;
-            Vertices = new float3[]
+            SetVertices(new float3[]
             {
                 new float3(+0.5f, +0.5f, +0.5f),
                 new float3(+0.5f, -0.5f, +0.5f),
@@ -27,8 +27,8 @@ namespace Fusee.Engine.Core.Primitives
                 new float3(-0.5f, -0.5f, +0.5f),
                 new float3(-0.5f, +0.5f, -0.5f),
                 new float3(-0.5f, -0.5f, -0.5f)
-            };
-            Triangles = new ushort[] // these are our lines
+            });
+            SetTriangles(new ushort[] // these are our lines
             {
                 0,4, // back
                 4,5,
@@ -45,7 +45,7 @@ namespace Fusee.Engine.Core.Primitives
 
                 6,4, // left, the rest
                 7,5
-            };
+            });
         }
     }
 
@@ -63,7 +63,7 @@ namespace Fusee.Engine.Core.Primitives
             #region Fields
 
             // TODO: Remove redundant vertices
-            Vertices = new[]
+            SetVertices(new[]
             {
                 new float3 {x = +0.5f, y = -0.5f, z = +0.5f},
                 new float3 {x = +0.5f, y = +0.5f, z = +0.5f},
@@ -90,31 +90,31 @@ namespace Fusee.Engine.Core.Primitives
                 new float3 {x = -0.5f, y = -0.5f, z = +0.5f},
                 new float3 {x = -0.5f, y = -0.5f, z = -0.5f}
 
-            };
+            });
 
-            Triangles = new ushort[]
+            SetTriangles(new ushort[]
             {
                 // front face
                 0, 2, 1, 0, 3, 2,
 
                 // right face
                 4, 6, 5, 4, 7, 6,
-                
+
                 // back face
                 8, 10, 9, 8, 11, 10,
-               
+
                 // left face
                 12, 14, 13, 12, 15, 14,
-                
+
                 // top face
                 16, 18, 17, 16, 19, 18,
 
                 // bottom face
                 20, 22, 21, 20, 23, 22
 
-            };
+            });
 
-            Normals = new[]
+            SetNormals(new[]
             {
                 new float3(0, 0, 1),
                 new float3(0, 0, 1),
@@ -140,9 +140,9 @@ namespace Fusee.Engine.Core.Primitives
                 new float3(0, -1, 0),
                 new float3(0, -1, 0),
                 new float3(0, -1, 0)
-            };
+            });
 
-            UVs = new[]
+            SetUVs(new[]
             {
                 new float2(1, 0),
                 new float2(1, 1),
@@ -168,7 +168,7 @@ namespace Fusee.Engine.Core.Primitives
                 new float2(1, 1),
                 new float2(0, 1),
                 new float2(0, 0)
-            };
+            });
             BoundingBox = new AABBf(Vertices);
 
         }

--- a/src/Engine/Core/Primitives/Line.cs
+++ b/src/Engine/Core/Primitives/Line.cs
@@ -15,7 +15,7 @@ namespace Fusee.Engine.Core.Primitives
         /// <param name="points">The vertices, the line should connect.</param>
         /// <param name="lineThickness">The thickness of the line.</param>
         /// <param name="rectWidth"></param>
-        /// <param name="rectHeight"></param>       
+        /// <param name="rectHeight"></param>
         public Line(List<float3> points, float lineThickness, float rectWidth = 1, float rectHeight = 1)
         {
             var segmentCache = new float3[4];
@@ -45,11 +45,11 @@ namespace Fusee.Engine.Core.Primitives
                 }
 
                 var dirVec = end - start;
-                dirVec.Normalize();
+                _ = dirVec.Normalize();
                 var angleToXAxis = (float)System.Math.Atan2(end.y - start.y, end.x - start.x);
 
                 var perpendicularVec = RotateVectorInXYPlane(float3.UnitY, angleToXAxis);
-                perpendicularVec.Normalize();
+                _ = perpendicularVec.Normalize();
 
                 var v0 = start + -perpendicularVec * lineThickness / 2;
                 var v1 = start + perpendicularVec * lineThickness / 2;
@@ -89,26 +89,26 @@ namespace Fusee.Engine.Core.Primitives
                     {
                         var vec03Cache = segmentCache[3] - segmentCache[0];
                         var vec03CacheLength = vec03Cache.Length;
-                        vec03Cache.Normalize();
+                        _ = vec03Cache.Normalize();
 
                         var vec30 = v0 - v3;
                         var vec30Length = vec30.Length;
-                        vec30.Normalize();
+                        _ = vec30.Normalize();
 
                         var vec12Cache = segmentCache[2] - segmentCache[1];
                         var vec12CacheLength = vec12Cache.Length;
-                        vec12Cache.Normalize();
+                        _ = vec12Cache.Normalize();
 
                         var vec21 = v1 - v2;
                         var vec21Length = vec21.Length;
-                        vec21.Normalize();
+                        _ = vec21.Normalize();
 
                         //calculate inter-segment vertices
-                        Jometri.GeometricOperations.IsLineIntersectingLine(segmentCache[0],
+                        _ = Jometri.GeometricOperations.IsLineIntersectingLine(segmentCache[0],
                             segmentCache[3] + (vec03CacheLength * vec03Cache), v0 + (vec30Length * vec30), v3,
                             out var intersectionPoint1);
 
-                        Jometri.GeometricOperations.IsLineIntersectingLine(segmentCache[1],
+                        _ = Jometri.GeometricOperations.IsLineIntersectingLine(segmentCache[1],
                             segmentCache[2] + (vec12CacheLength * vec12Cache), v1 + (vec21Length * vec21), v2,
                             out var intersectionPoint2);
 
@@ -137,26 +137,26 @@ namespace Fusee.Engine.Core.Primitives
                     {
                         var vec03Cache = segmentCache[3] - segmentCache[0];
                         var vec03CacheLength = vec03Cache.Length;
-                        vec03Cache.Normalize();
+                        _ = vec03Cache.Normalize();
 
                         var vec30 = v0 - v3;
                         var vec30Length = vec30.Length;
-                        vec30.Normalize();
+                        _ = vec30.Normalize();
 
                         var vec12Cache = segmentCache[2] - segmentCache[1];
                         var vec12CacheLength = vec12Cache.Length;
-                        vec12Cache.Normalize();
+                        _ = vec12Cache.Normalize();
 
                         var vec21 = v1 - v2;
                         var vec21Length = vec21.Length;
-                        vec21.Normalize();
+                        _ = vec21.Normalize();
 
                         //calculate inter-segment vertices
-                        Jometri.GeometricOperations.IsLineIntersectingLine(segmentCache[0],
+                        _ = Jometri.GeometricOperations.IsLineIntersectingLine(segmentCache[0],
                             segmentCache[3] + (vec03CacheLength * vec03Cache), v0 + (vec30Length * vec30), v3,
                             out var intersectionPoint1);
 
-                        Jometri.GeometricOperations.IsLineIntersectingLine(segmentCache[1],
+                        _ = Jometri.GeometricOperations.IsLineIntersectingLine(segmentCache[1],
                             segmentCache[2] + (vec12CacheLength * vec12Cache), v1 + (vec21Length * vec21), v2,
                             out var intersectionPoint2);
 
@@ -214,10 +214,10 @@ namespace Fusee.Engine.Core.Primitives
 
             }
 
-            Vertices = verts.ToArray();
-            Normals = normals.ToArray();
-            Triangles = tris.ToArray();
-            UVs = uvs.ToArray();
+            SetVertices(verts.ToArray());
+            SetNormals(normals.ToArray());
+            SetTriangles(tris.ToArray());
+            SetUVs(uvs.ToArray());
         }
 
         private float3 RotateVectorInXYPlane(float3 vec, float angle)

--- a/src/Engine/Core/Primitives/NineSlicePlane.cs
+++ b/src/Engine/Core/Primitives/NineSlicePlane.cs
@@ -18,7 +18,7 @@ namespace Fusee.Engine.Core.Primitives
         {
             #region Fields
 
-            Vertices = new[]
+            SetVertices(new[]
             {
                 new float3 {x = -0.5f, y = -0.5f, z = 0},
                 new float3 {x = -0.5f, y = -1/6f, z = 0},
@@ -37,10 +37,10 @@ namespace Fusee.Engine.Core.Primitives
                 new float3 {x = -1/6f, y = 1/6f, z = 0},
                 new float3 {x = 1/6f, y = 1/6f, z = 0},
                 new float3 {x = 1/6f, y = -1/6f, z = 0},
-            };
+            });
 
 
-            Triangles = new ushort[]
+            SetTriangles(new ushort[]
             {
                 0,12,1,
                 0,11,12,
@@ -70,9 +70,9 @@ namespace Fusee.Engine.Core.Primitives
                 14,7,6
 
 
-            };
+            });
 
-            Normals = new[]
+            SetNormals(new[]
             {
                 new float3(0, 0, -1),
                 new float3(0, 0, -1),
@@ -90,9 +90,9 @@ namespace Fusee.Engine.Core.Primitives
                 new float3(0, 0, -1),
                 new float3(0, 0, -1),
                 new float3(0, 0, -1)
-            };
+            });
 
-            UVs = Vertices.Select(vert => new float2(vert.x, vert.y) + new float2(0.5f, 0.5f)).ToArray();
+            SetUVs(Vertices.ToArray().Select(vert => new float2(vert.x, vert.y) + new float2(0.5f, 0.5f)).ToArray());
         }
         #endregion
     }

--- a/src/Engine/Core/Primitives/Plane.cs
+++ b/src/Engine/Core/Primitives/Plane.cs
@@ -17,36 +17,36 @@ namespace Fusee.Engine.Core.Primitives
             #region Fields
 
             // TODO: Remove redundant vertices
-            Vertices = new[]
+            SetVertices(new[]
             {
                 new float3 {x = -0.5f, y = -0.5f, z = 0},
                 new float3 {x = -0.5f, y = +0.5f, z = 0},
                 new float3 {x = +0.5f, y = +0.5f, z = 0},
                 new float3 {x = +0.5f, y = -0.5f, z = 0}
-            };
+            });
 
 
-            Triangles = new ushort[]
+            SetTriangles(new ushort[]
             {
                 0, 2, 1, 0, 3, 2
-            };
+            });
 
-            Normals = new[]
+            SetNormals(new[]
             {
                 new float3(0, 0, -1),
                 new float3(0, 0, -1),
                 new float3(0, 0, -1),
                 new float3(0, 0, -1)
-            };
+            });
 
-            UVs = new[]
+            SetUVs(new[]
             {
                 new float2(0, 0),
                 new float2(0, 1),
                 new float2(1, 1),
                 new float2(1, 0),
 
-            };
+            });
             #endregion
         }
 

--- a/src/Engine/Core/Primitives/Sphere.cs
+++ b/src/Engine/Core/Primitives/Sphere.cs
@@ -46,12 +46,12 @@ namespace Fusee.Engine.Core.Primitives
             vertices[^1] = float3.UnitY * -radius;
             #endregion
 
-            #region Normals		
+            #region Normals
             var normals = new float3[vertices.Length];
             for (var n = 0; n < vertices.Length; n++)
             {
                 var norm = vertices[n];
-                norm.Normalize();
+                _ = norm.Normalize();
                 normals[n] = norm;
             }
             #endregion
@@ -113,10 +113,10 @@ namespace Fusee.Engine.Core.Primitives
             }
             #endregion
 
-            Vertices = vertices;
-            Triangles = triangles;
-            Normals = normals;
-            UVs = uvs;
+            SetVertices(vertices);
+            SetTriangles(triangles);
+            SetNormals(normals);
+            SetUVs(uvs);
 
         }
 

--- a/src/Engine/Core/RenderContext.cs
+++ b/src/Engine/Core/RenderContext.cs
@@ -1898,7 +1898,7 @@ namespace Fusee.Engine.Core
             var mesh = new GpuMesh
             {
                 MeshType = primitiveType,
-                BoundingBox = new AABBf(vertices.AsSpan())
+                BoundingBox = new AABBf(vertices)
             };
             _meshManager.RegisterNewMesh(mesh, vertices, triangles, uvs,
             normals, colors, colors1, colors2,

--- a/src/Engine/Core/RenderContext.cs
+++ b/src/Engine/Core/RenderContext.cs
@@ -1898,7 +1898,7 @@ namespace Fusee.Engine.Core
             var mesh = new GpuMesh
             {
                 MeshType = primitiveType,
-                BoundingBox = new AABBf(vertices)
+                BoundingBox = new AABBf(vertices.AsSpan())
             };
             _meshManager.RegisterNewMesh(mesh, vertices, triangles, uvs,
             normals, colors, colors1, colors2,

--- a/src/Engine/Core/Scene/Mesh.cs
+++ b/src/Engine/Core/Scene/Mesh.cs
@@ -1,5 +1,6 @@
 ﻿using Fusee.Engine.Common;
 using Fusee.Math.Core;
+using Microsoft.Toolkit.Diagnostics;
 using System;
 
 namespace Fusee.Engine.Core.Scene
@@ -48,19 +49,35 @@ namespace Fusee.Engine.Core.Scene
         #endregion
 
         /// <summary>
-        /// Gets and sets the vertices.
+        /// Gets the vertices.
         /// </summary>
         /// <value>
         /// The vertices.
         /// </value>
-        public float3[] Vertices
+        public ReadOnlySpan<float3> Vertices => _vertices;
+
+        /// <summary>
+        /// Set all vertices of the mesh.
+        /// </summary>
+        /// <param name="vertices"></param>
+        public void SetVertices(float3[] vertices)
         {
-            get => _vertices;
-            set
-            {
-                _vertices = value;
-                MeshChanged?.Invoke(this, new MeshChangedEventArgs(this, MeshChangedEnum.Vertices));
-            }
+            Guard.IsNotNull(vertices, nameof(vertices));
+            _vertices = vertices;
+            MeshChanged?.Invoke(this, new MeshChangedEventArgs(this, MeshChangedEnum.Vertices));
+        }
+
+        /// <summary>
+        /// Set/alter one vertex of given mesh.
+        /// </summary>
+        /// <param name="idx"></param>
+        /// <param name="vertex"></param>
+        public void SetVertex(int idx, float3 vertex)
+        {
+            Guard.IsNotNull(_vertices, nameof(_vertices));
+            Guard.IsInRange(idx, 0, _vertices.Length, nameof(idx));
+            _vertices[idx] = vertex;
+            MeshChanged?.Invoke(this, new MeshChangedEventArgs(this, MeshChangedEnum.Vertices));
         }
 
         /// <summary>
@@ -71,22 +88,6 @@ namespace Fusee.Engine.Core.Scene
         /// </value>
         public bool VerticesSet => _vertices?.Length > 0;
 
-        /// <summary>
-        /// Gets a value indicating whether tangents are set.
-        /// </summary>
-        /// <value>
-        ///   <c>true</c> if tangents are set; otherwise, <c>false</c>.
-        /// </value>
-        public bool TangentsSet => _tangents?.Length > 0;
-
-        /// <summary>
-        /// Gets a value indicating whether bi tangents are set.
-        /// </summary>
-        /// <value>
-        ///   <c>true</c> if bi tangents are set; otherwise, <c>false</c>.
-        /// </value>
-        public bool BiTangentsSet => _biTangents?.Length > 0;
-
 
         /// <summary>
         /// Gets and sets the color of a single vertex.
@@ -94,14 +95,31 @@ namespace Fusee.Engine.Core.Scene
         /// <value>
         /// The color.
         /// </value>
-        public uint[] Colors
+        public ReadOnlySpan<uint> Colors => _colors;
+
+
+        /// <summary>
+        /// Set all colors of the mesh.
+        /// </summary>
+        /// <param name="colors"></param>
+        public void SetColors(uint[] colors)
         {
-            get => _colors;
-            set
-            {
-                _colors = value;
-                MeshChanged?.Invoke(this, new MeshChangedEventArgs(this, MeshChangedEnum.Colors));
-            }
+            Guard.IsNotNull(colors, nameof(colors));
+            _colors = colors;
+            MeshChanged?.Invoke(this, new MeshChangedEventArgs(this, MeshChangedEnum.Colors));
+        }
+
+        /// <summary>
+        /// Set/alter one color of a single vertex.
+        /// </summary>
+        /// <param name="idx"></param>
+        /// <param name="color"></param>
+        public void SetColor(int idx, uint color)
+        {
+            Guard.IsNotNull(_colors, nameof(_colors));
+            Guard.IsInRange(idx, 0, _colors.Length, nameof(idx));
+            _colors[idx] = color;
+            MeshChanged?.Invoke(this, new MeshChangedEventArgs(this, MeshChangedEnum.Colors));
         }
 
         /// <summary>
@@ -118,14 +136,30 @@ namespace Fusee.Engine.Core.Scene
         /// <value>
         /// The color.
         /// </value>
-        public uint[] Colors1
+        public ReadOnlySpan<uint> Colors1 => _colors1;
+
+        /// <summary>
+        /// Set all colors1 of the mesh.
+        /// </summary>
+        /// <param name="colors1"></param>
+        public void SetColors1(uint[] colors1)
         {
-            get => _colors1;
-            set
-            {
-                _colors1 = value;
-                MeshChanged?.Invoke(this, new MeshChangedEventArgs(this, MeshChangedEnum.Colors1));
-            }
+            Guard.IsNotNull(colors1, nameof(colors1));
+            _colors1 = colors1;
+            MeshChanged?.Invoke(this, new MeshChangedEventArgs(this, MeshChangedEnum.Colors1));
+        }
+
+        /// <summary>
+        /// Set/alter one color1 of a single vertex.
+        /// </summary>
+        /// <param name="idx"></param>
+        /// <param name="color1"></param>
+        public void SetColor1(int idx, uint color1)
+        {
+            Guard.IsNotNull(_colors1, nameof(_colors1));
+            Guard.IsInRange(idx, 0, _colors1.Length, nameof(idx));
+            _colors1[idx] = color1;
+            MeshChanged?.Invoke(this, new MeshChangedEventArgs(this, MeshChangedEnum.Colors1));
         }
 
         /// <summary>
@@ -142,14 +176,30 @@ namespace Fusee.Engine.Core.Scene
         /// <value>
         /// The color.
         /// </value>
-        public uint[] Colors2
+        public ReadOnlySpan<uint> Colors2 => _colors2;
+
+        /// <summary>
+        /// Set all colors2 of the mesh.
+        /// </summary>
+        /// <param name="colors2"></param>
+        public void SetColors2(uint[] colors2)
         {
-            get => _colors2;
-            set
-            {
-                _colors2 = value;
-                MeshChanged?.Invoke(this, new MeshChangedEventArgs(this, MeshChangedEnum.Colors2));
-            }
+            Guard.IsNotNull(colors2, nameof(colors2));
+            _colors2 = colors2;
+            MeshChanged?.Invoke(this, new MeshChangedEventArgs(this, MeshChangedEnum.Colors2));
+        }
+
+        /// <summary>
+        /// Set/alter one color2 of a single vertex.
+        /// </summary>
+        /// <param name="idx"></param>
+        /// <param name="color2"></param>
+        public void SetColor2(int idx, uint color2)
+        {
+            Guard.IsNotNull(_colors2, nameof(_colors2));
+            Guard.IsInRange(idx, 0, _colors2.Length, nameof(idx));
+            _colors2[idx] = color2;
+            MeshChanged?.Invoke(this, new MeshChangedEventArgs(this, MeshChangedEnum.Colors2));
         }
 
         /// <summary>
@@ -167,15 +217,32 @@ namespace Fusee.Engine.Core.Scene
         /// <value>
         /// The normals..
         /// </value>
-        public float3[] Normals
+        public ReadOnlySpan<float3> Normals => _normals;
+
+        /// <summary>
+        /// Set all normals of the mesh.
+        /// </summary>
+        /// <param name="normals"></param>
+        public void SetNormals(float3[] normals)
         {
-            get => _normals;
-            set
-            {
-                _normals = value;
-                MeshChanged?.Invoke(this, new MeshChangedEventArgs(this, MeshChangedEnum.Normals));
-            }
+            Guard.IsNotNull(normals, nameof(normals));
+            _normals = normals;
+            MeshChanged?.Invoke(this, new MeshChangedEventArgs(this, MeshChangedEnum.Normals));
         }
+
+        /// <summary>
+        /// Set/alter one normal of a single vertex.
+        /// </summary>
+        /// <param name="idx"></param>
+        /// <param name="normal"></param>
+        public void SetNormal(int idx, float3 normal)
+        {
+            Guard.IsNotNull(_normals, nameof(_normals));
+            Guard.IsInRange(idx, 0, _normals.Length, nameof(idx));
+            _normals[idx] = normal;
+            MeshChanged?.Invoke(this, new MeshChangedEventArgs(this, MeshChangedEnum.Normals));
+        }
+
         /// <summary>
         /// Gets a value indicating whether normals are set.
         /// </summary>
@@ -190,14 +257,30 @@ namespace Fusee.Engine.Core.Scene
         /// <value>
         /// The UV-coordinates.
         /// </value>
-        public float2[] UVs
+        public ReadOnlySpan<float2> UVs => _uvs;
+
+        /// <summary>
+        /// Set all uvs of the mesh.
+        /// </summary>
+        /// <param name="uv"></param>
+        public void SetUVs(float2[] uv)
         {
-            get => _uvs;
-            set
-            {
-                _uvs = value;
-                MeshChanged?.Invoke(this, new MeshChangedEventArgs(this, MeshChangedEnum.Uvs));
-            }
+            Guard.IsNotNull(uv, nameof(uv));
+            _uvs = uv;
+            MeshChanged?.Invoke(this, new MeshChangedEventArgs(this, MeshChangedEnum.Uvs));
+        }
+
+        /// <summary>
+        /// Set/alter one uv of a single vertex.
+        /// </summary>
+        /// <param name="idx"></param>
+        /// <param name="uv"></param>
+        public void SetUV(int idx, float2 uv)
+        {
+            Guard.IsNotNull(_uvs, nameof(_uvs));
+            Guard.IsInRange(idx, 0, _uvs.Length, nameof(idx));
+            _uvs[idx] = uv;
+            MeshChanged?.Invoke(this, new MeshChangedEventArgs(this, MeshChangedEnum.Uvs));
         }
 
         /// <summary>
@@ -214,15 +297,32 @@ namespace Fusee.Engine.Core.Scene
         /// <value>
         /// The bone weights.
         /// </value>
-        public float4[] BoneWeights
+        public ReadOnlySpan<float4> BoneWeights => _boneWeights;
+
+        /// <summary>
+        /// Set all bone weights of the mesh.
+        /// </summary>
+        /// <param name="boneWeights"></param>
+        public void SetBoneWeights(float4[] boneWeights)
         {
-            get => _boneWeights;
-            set
-            {
-                _boneWeights = value;
-                MeshChanged?.Invoke(this, new MeshChangedEventArgs(this, MeshChangedEnum.BoneWeights));
-            }
+            Guard.IsNotNull(boneWeights, nameof(boneWeights));
+            _boneWeights = boneWeights;
+            MeshChanged?.Invoke(this, new MeshChangedEventArgs(this, MeshChangedEnum.BoneWeights));
         }
+
+        /// <summary>
+        /// Set/alter one bone weight of a single vertex.
+        /// </summary>
+        /// <param name="idx"></param>
+        /// <param name="boneWeight"></param>
+        public void SetBoneWeight(int idx, float4 boneWeight)
+        {
+            Guard.IsNotNull(_boneWeights, nameof(_boneWeights));
+            Guard.IsInRange(idx, 0, _boneWeights.Length, nameof(idx));
+            _boneWeights[idx] = boneWeight;
+            MeshChanged?.Invoke(this, new MeshChangedEventArgs(this, MeshChangedEnum.BoneWeights));
+        }
+
         /// <summary>
         /// Gets a value indicating whether bone weights are set.
         /// </summary>
@@ -237,15 +337,32 @@ namespace Fusee.Engine.Core.Scene
         /// <value>
         /// The bone indices.
         /// </value>
-        public float4[] BoneIndices
+        public ReadOnlySpan<float4> BoneIndices => _boneIndices;
+
+        /// <summary>
+        /// Set all bone indices of the mesh.
+        /// </summary>
+        /// <param name="boneIndices"></param>
+        public void SetBoneIndices(float4[] boneIndices)
         {
-            get => _boneIndices;
-            set
-            {
-                _boneIndices = value;
-                MeshChanged?.Invoke(this, new MeshChangedEventArgs(this, MeshChangedEnum.BoneIndices));
-            }
+            Guard.IsNotNull(boneIndices, nameof(boneIndices));
+            _boneIndices = boneIndices;
+            MeshChanged?.Invoke(this, new MeshChangedEventArgs(this, MeshChangedEnum.BoneIndices));
         }
+
+        /// <summary>
+        /// Set/alter one bone index of a single vertex.
+        /// </summary>
+        /// <param name="idx"></param>
+        /// <param name="boneIndex"></param>
+        public void SetBoneIndex(int idx, float4 boneIndex)
+        {
+            Guard.IsNotNull(_boneIndices, nameof(_boneIndices));
+            Guard.IsInRange(idx, 0, _boneIndices.Length, nameof(idx));
+            _boneIndices[idx] = boneIndex;
+            MeshChanged?.Invoke(this, new MeshChangedEventArgs(this, MeshChangedEnum.BoneIndices));
+        }
+
         /// <summary>
         /// Gets a value indicating whether bone indices are set.
         /// </summary>
@@ -260,15 +377,30 @@ namespace Fusee.Engine.Core.Scene
         /// <value>
         /// The triangles.
         /// </value>
-        public ushort[] Triangles
-        {
-            get => _triangles;
-            set
-            {
-                _triangles = value;
+        public ReadOnlySpan<ushort> Triangles => _triangles;
 
-                MeshChanged?.Invoke(this, new MeshChangedEventArgs(this, MeshChangedEnum.Triangles));
-            }
+        /// <summary>
+        /// Set all triangles of the mesh.
+        /// </summary>
+        /// <param name="triangles"></param>
+        public void SetTriangles(ushort[] triangles)
+        {
+            Guard.IsNotNull(triangles, nameof(triangles));
+            _triangles = triangles;
+            MeshChanged?.Invoke(this, new MeshChangedEventArgs(this, MeshChangedEnum.Triangles));
+        }
+
+        /// <summary>
+        /// Set/alter one triangle of a single vertex.
+        /// </summary>
+        /// <param name="idx"></param>
+        /// <param name="triangle"></param>
+        public void SetBoneIndex(int idx, ushort triangle)
+        {
+            Guard.IsNotNull(_triangles, nameof(_triangles));
+            Guard.IsInRange(idx, 0, _triangles.Length, nameof(idx));
+            _triangles[idx] = triangle;
+            MeshChanged?.Invoke(this, new MeshChangedEventArgs(this, MeshChangedEnum.Triangles));
         }
 
         /// <summary>
@@ -280,38 +412,84 @@ namespace Fusee.Engine.Core.Scene
         public bool TrianglesSet => _triangles?.Length > 0;
 
         /// <summary>
-        /// The bounding box of this geometry chunk.
-        /// </summary>
-        public AABBf BoundingBox;
-
-        /// <summary>
         /// The tangent of each triangle for normal mapping.
         /// w-component is handedness
         /// </summary>
-        public float4[] Tangents
-        {
-            get => _tangents;
-            set
-            {
-                _tangents = value;
+        public ReadOnlySpan<float4> Tangents => _tangents;
 
-                MeshChanged?.Invoke(this, new MeshChangedEventArgs(this, MeshChangedEnum.Tangents));
-            }
+        /// <summary>
+        /// Set all tangents of the mesh.
+        /// </summary>
+        /// <param name="tangents"></param>
+        public void SetTangents(float4[] tangents)
+        {
+            Guard.IsNotNull(tangents, nameof(tangents));
+            _tangents = tangents;
+            MeshChanged?.Invoke(this, new MeshChangedEventArgs(this, MeshChangedEnum.Tangents));
         }
+
+        /// <summary>
+        /// Set/alter one tangent of a single vertex.
+        /// </summary>
+        /// <param name="idx"></param>
+        /// <param name="tangents"></param>
+        public void SetTangent(int idx, float4 tangents)
+        {
+            Guard.IsNotNull(_tangents, nameof(_tangents));
+            Guard.IsInRange(idx, 0, _tangents.Length, nameof(idx));
+            _tangents[idx] = tangents;
+            MeshChanged?.Invoke(this, new MeshChangedEventArgs(this, MeshChangedEnum.Tangents));
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether tangents are set.
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> if tangents are set; otherwise, <c>false</c>.
+        /// </value>
+        public bool TangentsSet => _tangents?.Length > 0;
 
         /// <summary>
         /// The bi tangent of each triangle for normal mapping.
         /// </summary>
-        public float3[] BiTangents
-        {
-            get => _biTangents;
-            set
-            {
-                _biTangents = value;
+        public ReadOnlySpan<float3> BiTangents => _biTangents;
 
-                MeshChanged?.Invoke(this, new MeshChangedEventArgs(this, MeshChangedEnum.BiTangents));
-            }
+        /// <summary>
+        /// Set all bitangents of the mesh.
+        /// </summary>
+        /// <param name="biTangents"></param>
+        public void SetBiTangents(float3[] biTangents)
+        {
+            Guard.IsNotNull(biTangents, nameof(biTangents));
+            _biTangents = biTangents;
+            MeshChanged?.Invoke(this, new MeshChangedEventArgs(this, MeshChangedEnum.BiTangents));
         }
+
+        /// <summary>
+        /// Set/alter one bitangent of a single vertex.
+        /// </summary>
+        /// <param name="idx"></param>
+        /// <param name="biTangent"></param>
+        public void SetBiTangent(int idx, float3 biTangent)
+        {
+            Guard.IsNotNull(_biTangents, nameof(_biTangents));
+            Guard.IsInRange(idx, 0, _biTangents.Length, nameof(idx));
+            _biTangents[idx] = biTangent;
+            MeshChanged?.Invoke(this, new MeshChangedEventArgs(this, MeshChangedEnum.BiTangents));
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether bi tangents are set.
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> if bi tangents are set; otherwise, <c>false</c>.
+        /// </value>
+        public bool BiTangentsSet => _biTangents?.Length > 0;
+
+        /// <summary>
+        /// The bounding box of this geometry chunk.
+        /// </summary>
+        public AABBf BoundingBox;
 
         /// <summary>
         /// The type of mesh which is represented by this instance (e. g. triangle mesh, point, line, etc...)
@@ -328,7 +506,6 @@ namespace Fusee.Engine.Core.Scene
         public void Dispose()
         {
             Dispose(true);
-
             GC.SuppressFinalize(this);
         }
 

--- a/src/Engine/Core/Scene/Mesh.cs
+++ b/src/Engine/Core/Scene/Mesh.cs
@@ -77,7 +77,7 @@ namespace Fusee.Engine.Core.Scene
             Guard.IsNotNull(_vertices, nameof(_vertices));
             Guard.IsInRange(idx, 0, _vertices.Length, nameof(idx));
             _vertices[idx] = vertex;
-            MeshChanged?.Invoke(this, new MeshChangedEventArgs(this, MeshChangedEnum.Vertex, new MeshChangedEventAdditionalData { Index = idx, Value = vertex}));
+            MeshChanged?.Invoke(this, new MeshChangedEventArgs(this, MeshChangedEnum.Vertex, new MeshChangedEventAdditionalData { Index = idx, Value = vertex }));
         }
 
         /// <summary>

--- a/src/Engine/Core/Scene/Mesh.cs
+++ b/src/Engine/Core/Scene/Mesh.cs
@@ -77,7 +77,7 @@ namespace Fusee.Engine.Core.Scene
             Guard.IsNotNull(_vertices, nameof(_vertices));
             Guard.IsInRange(idx, 0, _vertices.Length, nameof(idx));
             _vertices[idx] = vertex;
-            MeshChanged?.Invoke(this, new MeshChangedEventArgs(this, MeshChangedEnum.Vertices));
+            MeshChanged?.Invoke(this, new MeshChangedEventArgs(this, MeshChangedEnum.Vertex, new MeshChangedEventAdditionalData { Index = idx, Value = vertex}));
         }
 
         /// <summary>
@@ -119,7 +119,7 @@ namespace Fusee.Engine.Core.Scene
             Guard.IsNotNull(_colors, nameof(_colors));
             Guard.IsInRange(idx, 0, _colors.Length, nameof(idx));
             _colors[idx] = color;
-            MeshChanged?.Invoke(this, new MeshChangedEventArgs(this, MeshChangedEnum.Colors));
+            MeshChanged?.Invoke(this, new MeshChangedEventArgs(this, MeshChangedEnum.Color, new MeshChangedEventAdditionalData { Index = idx, Value = color }));
         }
 
         /// <summary>
@@ -159,7 +159,7 @@ namespace Fusee.Engine.Core.Scene
             Guard.IsNotNull(_colors1, nameof(_colors1));
             Guard.IsInRange(idx, 0, _colors1.Length, nameof(idx));
             _colors1[idx] = color1;
-            MeshChanged?.Invoke(this, new MeshChangedEventArgs(this, MeshChangedEnum.Colors1));
+            MeshChanged?.Invoke(this, new MeshChangedEventArgs(this, MeshChangedEnum.Color1, new MeshChangedEventAdditionalData { Index = idx, Value = color1 }));
         }
 
         /// <summary>
@@ -199,7 +199,7 @@ namespace Fusee.Engine.Core.Scene
             Guard.IsNotNull(_colors2, nameof(_colors2));
             Guard.IsInRange(idx, 0, _colors2.Length, nameof(idx));
             _colors2[idx] = color2;
-            MeshChanged?.Invoke(this, new MeshChangedEventArgs(this, MeshChangedEnum.Colors2));
+            MeshChanged?.Invoke(this, new MeshChangedEventArgs(this, MeshChangedEnum.Color2, new MeshChangedEventAdditionalData { Index = idx, Value = color2 }));
         }
 
         /// <summary>
@@ -240,7 +240,7 @@ namespace Fusee.Engine.Core.Scene
             Guard.IsNotNull(_normals, nameof(_normals));
             Guard.IsInRange(idx, 0, _normals.Length, nameof(idx));
             _normals[idx] = normal;
-            MeshChanged?.Invoke(this, new MeshChangedEventArgs(this, MeshChangedEnum.Normals));
+            MeshChanged?.Invoke(this, new MeshChangedEventArgs(this, MeshChangedEnum.Normal, new MeshChangedEventAdditionalData { Index = idx, Value = normal }));
         }
 
         /// <summary>
@@ -280,7 +280,7 @@ namespace Fusee.Engine.Core.Scene
             Guard.IsNotNull(_uvs, nameof(_uvs));
             Guard.IsInRange(idx, 0, _uvs.Length, nameof(idx));
             _uvs[idx] = uv;
-            MeshChanged?.Invoke(this, new MeshChangedEventArgs(this, MeshChangedEnum.Uvs));
+            MeshChanged?.Invoke(this, new MeshChangedEventArgs(this, MeshChangedEnum.Uv, new MeshChangedEventAdditionalData { Index = idx, Value = uv }));
         }
 
         /// <summary>
@@ -320,7 +320,7 @@ namespace Fusee.Engine.Core.Scene
             Guard.IsNotNull(_boneWeights, nameof(_boneWeights));
             Guard.IsInRange(idx, 0, _boneWeights.Length, nameof(idx));
             _boneWeights[idx] = boneWeight;
-            MeshChanged?.Invoke(this, new MeshChangedEventArgs(this, MeshChangedEnum.BoneWeights));
+            MeshChanged?.Invoke(this, new MeshChangedEventArgs(this, MeshChangedEnum.BoneWeight, new MeshChangedEventAdditionalData { Index = idx, Value = boneWeight }));
         }
 
         /// <summary>
@@ -360,7 +360,7 @@ namespace Fusee.Engine.Core.Scene
             Guard.IsNotNull(_boneIndices, nameof(_boneIndices));
             Guard.IsInRange(idx, 0, _boneIndices.Length, nameof(idx));
             _boneIndices[idx] = boneIndex;
-            MeshChanged?.Invoke(this, new MeshChangedEventArgs(this, MeshChangedEnum.BoneIndices));
+            MeshChanged?.Invoke(this, new MeshChangedEventArgs(this, MeshChangedEnum.BondeIndex, new MeshChangedEventAdditionalData { Index = idx, Value = boneIndex }));
         }
 
         /// <summary>
@@ -395,12 +395,12 @@ namespace Fusee.Engine.Core.Scene
         /// </summary>
         /// <param name="idx"></param>
         /// <param name="triangle"></param>
-        public void SetBoneIndex(int idx, ushort triangle)
+        public void SetTriangle(int idx, ushort triangle)
         {
             Guard.IsNotNull(_triangles, nameof(_triangles));
             Guard.IsInRange(idx, 0, _triangles.Length, nameof(idx));
             _triangles[idx] = triangle;
-            MeshChanged?.Invoke(this, new MeshChangedEventArgs(this, MeshChangedEnum.Triangles));
+            MeshChanged?.Invoke(this, new MeshChangedEventArgs(this, MeshChangedEnum.Triangle, new MeshChangedEventAdditionalData { Index = idx, Value = triangle }));
         }
 
         /// <summary>
@@ -432,13 +432,13 @@ namespace Fusee.Engine.Core.Scene
         /// Set/alter one tangent of a single vertex.
         /// </summary>
         /// <param name="idx"></param>
-        /// <param name="tangents"></param>
-        public void SetTangent(int idx, float4 tangents)
+        /// <param name="tangent"></param>
+        public void SetTangent(int idx, float4 tangent)
         {
             Guard.IsNotNull(_tangents, nameof(_tangents));
             Guard.IsInRange(idx, 0, _tangents.Length, nameof(idx));
-            _tangents[idx] = tangents;
-            MeshChanged?.Invoke(this, new MeshChangedEventArgs(this, MeshChangedEnum.Tangents));
+            _tangents[idx] = tangent;
+            MeshChanged?.Invoke(this, new MeshChangedEventArgs(this, MeshChangedEnum.Tangent, new MeshChangedEventAdditionalData { Index = idx, Value = tangent }));
         }
 
         /// <summary>
@@ -475,7 +475,7 @@ namespace Fusee.Engine.Core.Scene
             Guard.IsNotNull(_biTangents, nameof(_biTangents));
             Guard.IsInRange(idx, 0, _biTangents.Length, nameof(idx));
             _biTangents[idx] = biTangent;
-            MeshChanged?.Invoke(this, new MeshChangedEventArgs(this, MeshChangedEnum.BiTangents));
+            MeshChanged?.Invoke(this, new MeshChangedEventArgs(this, MeshChangedEnum.BiTangent, new MeshChangedEventAdditionalData { Index = idx, Value = biTangent }));
         }
 
         /// <summary>

--- a/src/Engine/Core/SceneRendererForward.cs
+++ b/src/Engine/Core/SceneRendererForward.cs
@@ -799,8 +799,8 @@ namespace Fusee.Engine.Core
                 boneWeights[iVert].Normalize1();
             }
 
-            mesh.BoneIndices = boneIndices;
-            mesh.BoneWeights = boneWeights;
+            mesh.SetBoneIndices(boneIndices);
+            mesh.SetBoneWeights(boneWeights);
         }
         #endregion
 

--- a/src/Engine/Core/TangentSpaceCalculator.cs
+++ b/src/Engine/Core/TangentSpaceCalculator.cs
@@ -71,7 +71,7 @@ namespace Fusee.Engine.Core
                 tangents[m.Triangles[i + 2]].Normalize();
                 tangents[m.Triangles[i + 2]].w = 1;
             }
-            m.Tangents = tangents;
+            m.SetTangents(tangents);
         }
 
         /// <summary>
@@ -84,7 +84,7 @@ namespace Fusee.Engine.Core
             if (m == null)
                 throw new ArgumentException("Mesh cannot be empty!");
 
-            if (m?.Normals == null || m.Normals.Length < 0)
+            if (m.Normals == null || m.Normals.Length < 0)
                 throw new ArgumentException($"Can not calculate bitangents, empty normals in this mesh: {m.Name}");
 
             if (m.Tangents == null || m.Tangents.Length < 1)
@@ -99,7 +99,7 @@ namespace Fusee.Engine.Core
             for (var i = 0; i < m.Tangents.Length; i++)
                 bitangents[i] = float3.Cross(m.Normals[i], m.Tangents[i].xyz) * m.Tangents[i].w;
 
-            m.BiTangents = bitangents;
+            m.SetBiTangents(bitangents);
         }
     }
 }

--- a/src/Engine/GUI/GuiText.cs
+++ b/src/Engine/GUI/GuiText.cs
@@ -52,7 +52,7 @@ namespace Fusee.Engine.Gui
         public List<List<float2>> LineUVs { get; private set; }
 
         /// <summary>
-        /// Defines the <see cref="HorizontalAlignment"/> of the text. 
+        /// Defines the <see cref="HorizontalAlignment"/> of the text.
         /// This is needed here because it changes the shape of the mesh.
         /// The mesh's vertices will be recalculated the value is set.
         /// </summary>
@@ -77,7 +77,7 @@ namespace Fusee.Engine.Gui
         /// </summary>
         public float Height { get; private set; }
 
-        //The min and max coordinates of the bounding box, as received from the font imp.      
+        //The min and max coordinates of the bounding box, as received from the font imp.
         private float2 _min;
         private float2 _max;
 
@@ -86,7 +86,7 @@ namespace Fusee.Engine.Gui
         /// </summary>
         /// <param name="fontMap"></param>
         /// <param name="text"></param>
-        /// <param name="horizontalAlignment">Defines the <see cref="HorizontalAlignment"/> of the text. 
+        /// <param name="horizontalAlignment">Defines the <see cref="HorizontalAlignment"/> of the text.
         /// This is needed here because it changes the shape of the mesh.</param>
         public GuiText(FontMap fontMap, string text, HorizontalTextAlignment horizontalAlignment)
         {
@@ -159,10 +159,10 @@ namespace Fusee.Engine.Gui
                 allUvs.AddRange(LineUVs[i]);
             }
 
-            Vertices = allVerts.ToArray();
-            Triangles = allTriangles.ToArray();
-            Normals = allNormals.ToArray();
-            UVs = allUvs.ToArray();
+            SetVertices ( allVerts.ToArray());
+            SetTriangles( allTriangles.ToArray());
+            SetNormals (allNormals.ToArray());
+            SetUVs (allUvs.ToArray());
 
         }
 
@@ -189,7 +189,7 @@ namespace Fusee.Engine.Gui
             var advanceX = 0f;
             var advanceY = 0f;
 
-            var lineBreakOffset = _fontMap.PixelHeight * 1.5f; //TODO: add user-field. At the moment we have a fixed line height of 150% of pixel height, 
+            var lineBreakOffset = _fontMap.PixelHeight * 1.5f; //TODO: add user-field. At the moment we have a fixed line height of 150% of pixel height,
             var lineCnt = 0;
 
             _min = float2.One * float.MaxValue;

--- a/src/Engine/GUI/GuiText.cs
+++ b/src/Engine/GUI/GuiText.cs
@@ -159,10 +159,10 @@ namespace Fusee.Engine.Gui
                 allUvs.AddRange(LineUVs[i]);
             }
 
-            SetVertices ( allVerts.ToArray());
-            SetTriangles( allTriangles.ToArray());
-            SetNormals (allNormals.ToArray());
-            SetUVs (allUvs.ToArray());
+            SetVertices(allVerts.ToArray());
+            SetTriangles(allTriangles.ToArray());
+            SetNormals(allNormals.ToArray());
+            SetUVs(allUvs.ToArray());
 
         }
 

--- a/src/Engine/Imp/Graphics/Android/RenderContextImp.cs
+++ b/src/Engine/Imp/Graphics/Android/RenderContextImp.cs
@@ -10,6 +10,7 @@ using OpenTK.Graphics.ES31;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Text;
 
 namespace Fusee.Engine.Imp.Graphics.Android
@@ -1226,7 +1227,7 @@ namespace Fusee.Engine.Imp.Graphics.Android
         /// <param name="vertices">The vertices.</param>
         /// <exception cref="System.ArgumentException">Vertices must not be null or empty</exception>
         /// <exception cref="System.ApplicationException"></exception>
-        public void SetVertices(IMeshImp mr, float3[] vertices)
+        public void SetVertices(IMeshImp mr, ReadOnlySpan<float3> vertices)
         {
             if (vertices == null || vertices.Length == 0)
             {
@@ -1240,7 +1241,7 @@ namespace Fusee.Engine.Imp.Graphics.Android
                 ((MeshImp)mr).VertexBufferObject = bufferIdx;
             }
             GL.BindBuffer(BufferTarget.ArrayBuffer, ((MeshImp)mr).VertexBufferObject);
-            GL.BufferData(BufferTarget.ArrayBuffer, (IntPtr)(vertsBytes), vertices, BufferUsage.StaticDraw);
+            GL.BufferData(BufferTarget.ArrayBuffer, (IntPtr)(vertsBytes), ref MemoryMarshal.GetReference(vertices), BufferUsage.StaticDraw);
             GL.GetBufferParameter(BufferTarget.ArrayBuffer, BufferParameterName.BufferSize, out int vboBytes);
             if (vboBytes != vertsBytes)
                 throw new ApplicationException(string.Format(
@@ -1256,7 +1257,7 @@ namespace Fusee.Engine.Imp.Graphics.Android
         /// <param name="tangents">The tangents.</param>
         /// <exception cref="System.ArgumentException">Tangents must not be null or empty</exception>
         /// <exception cref="System.ApplicationException"></exception>
-        public void SetTangents(IMeshImp mr, float4[] tangents)
+        public void SetTangents(IMeshImp mr, ReadOnlySpan<float4> tangents)
         {
             if (tangents == null || tangents.Length == 0)
             {
@@ -1271,7 +1272,7 @@ namespace Fusee.Engine.Imp.Graphics.Android
             }
 
             GL.BindBuffer(BufferTarget.ArrayBuffer, ((MeshImp)mr).TangentBufferObject);
-            GL.BufferData(BufferTarget.ArrayBuffer, (IntPtr)(vertsBytes), tangents, BufferUsage.StaticDraw);
+            GL.BufferData(BufferTarget.ArrayBuffer, (IntPtr)(vertsBytes), ref MemoryMarshal.GetReference(tangents), BufferUsage.StaticDraw);
             GL.GetBufferParameter(BufferTarget.ArrayBuffer, BufferParameterName.BufferSize, out int vboBytes);
             if (vboBytes != vertsBytes)
                 throw new ApplicationException(String.Format(
@@ -1286,7 +1287,7 @@ namespace Fusee.Engine.Imp.Graphics.Android
         /// <param name = "bitangents">The bitangents.</param>
         /// <exception cref="System.ArgumentException">BiTangents must not be null or empty</exception>
         /// <exception cref="System.ApplicationException"></exception>
-        public void SetBiTangents(IMeshImp mr, float3[] bitangents)
+        public void SetBiTangents(IMeshImp mr, ReadOnlySpan<float3> bitangents)
         {
             if (bitangents == null || bitangents.Length == 0)
             {
@@ -1301,7 +1302,7 @@ namespace Fusee.Engine.Imp.Graphics.Android
             }
 
             GL.BindBuffer(BufferTarget.ArrayBuffer, ((MeshImp)mr).BitangentBufferObject);
-            GL.BufferData(BufferTarget.ArrayBuffer, (IntPtr)(vertsBytes), bitangents, BufferUsage.StaticDraw);
+            GL.BufferData(BufferTarget.ArrayBuffer, (IntPtr)(vertsBytes), ref MemoryMarshal.GetReference(bitangents), BufferUsage.StaticDraw);
             GL.GetBufferParameter(BufferTarget.ArrayBuffer, BufferParameterName.BufferSize, out int vboBytes);
             if (vboBytes != vertsBytes)
                 throw new ApplicationException(String.Format(
@@ -1317,7 +1318,7 @@ namespace Fusee.Engine.Imp.Graphics.Android
         /// <param name="normals">The normals.</param>
         /// <exception cref="System.ArgumentException">Normals must not be null or empty</exception>
         /// <exception cref="System.ApplicationException"></exception>
-        public void SetNormals(IMeshImp mr, float3[] normals)
+        public void SetNormals(IMeshImp mr, ReadOnlySpan<float3> normals)
         {
             if (normals == null || normals.Length == 0)
             {
@@ -1332,7 +1333,7 @@ namespace Fusee.Engine.Imp.Graphics.Android
             }
 
             GL.BindBuffer(BufferTarget.ArrayBuffer, ((MeshImp)mr).NormalBufferObject);
-            GL.BufferData(BufferTarget.ArrayBuffer, (IntPtr)(normsBytes), normals, BufferUsage.StaticDraw);
+            GL.BufferData(BufferTarget.ArrayBuffer, (IntPtr)(normsBytes), ref MemoryMarshal.GetReference(normals), BufferUsage.StaticDraw);
             GL.GetBufferParameter(BufferTarget.ArrayBuffer, BufferParameterName.BufferSize, out int vboBytes);
             if (vboBytes != normsBytes)
                 throw new ApplicationException(String.Format(
@@ -1347,7 +1348,7 @@ namespace Fusee.Engine.Imp.Graphics.Android
         /// <param name="boneIndices">The bone indices.</param>
         /// <exception cref="System.ArgumentException">BoneIndices must not be null or empty</exception>
         /// <exception cref="System.ApplicationException"></exception>
-        public void SetBoneIndices(IMeshImp mr, float4[] boneIndices)
+        public void SetBoneIndices(IMeshImp mr, ReadOnlySpan<float4> boneIndices)
         {
             if (boneIndices == null || boneIndices.Length == 0)
             {
@@ -1362,7 +1363,7 @@ namespace Fusee.Engine.Imp.Graphics.Android
             }
 
             GL.BindBuffer(BufferTarget.ArrayBuffer, ((MeshImp)mr).BoneIndexBufferObject);
-            GL.BufferData(BufferTarget.ArrayBuffer, (IntPtr)(indicesBytes), boneIndices, BufferUsage.StaticDraw);
+            GL.BufferData(BufferTarget.ArrayBuffer, (IntPtr)(indicesBytes), ref MemoryMarshal.GetReference(boneIndices), BufferUsage.StaticDraw);
             GL.GetBufferParameter(BufferTarget.ArrayBuffer, BufferParameterName.BufferSize, out int vboBytes);
             if (vboBytes != indicesBytes)
                 throw new ApplicationException(String.Format(
@@ -1377,7 +1378,7 @@ namespace Fusee.Engine.Imp.Graphics.Android
         /// <param name="boneWeights">The bone weights.</param>
         /// <exception cref="System.ArgumentException">BoneWeights must not be null or empty</exception>
         /// <exception cref="System.ApplicationException"></exception>
-        public void SetBoneWeights(IMeshImp mr, float4[] boneWeights)
+        public void SetBoneWeights(IMeshImp mr, ReadOnlySpan<float4> boneWeights)
         {
             if (boneWeights == null || boneWeights.Length == 0)
             {
@@ -1392,7 +1393,7 @@ namespace Fusee.Engine.Imp.Graphics.Android
             }
 
             GL.BindBuffer(BufferTarget.ArrayBuffer, ((MeshImp)mr).BoneWeightBufferObject);
-            GL.BufferData(BufferTarget.ArrayBuffer, (IntPtr)(weightsBytes), boneWeights, BufferUsage.StaticDraw);
+            GL.BufferData(BufferTarget.ArrayBuffer, (IntPtr)(weightsBytes), ref MemoryMarshal.GetReference(boneWeights), BufferUsage.StaticDraw);
             GL.GetBufferParameter(BufferTarget.ArrayBuffer, BufferParameterName.BufferSize, out int vboBytes);
             if (vboBytes != weightsBytes)
                 throw new ApplicationException(String.Format(
@@ -1407,7 +1408,7 @@ namespace Fusee.Engine.Imp.Graphics.Android
         /// <param name="uvs">The UV's.</param>
         /// <exception cref="System.ArgumentException">UVs must not be null or empty</exception>
         /// <exception cref="System.ApplicationException"></exception>
-        public void SetUVs(IMeshImp mr, float2[] uvs)
+        public void SetUVs(IMeshImp mr, ReadOnlySpan<float2> uvs)
         {
             if (uvs == null || uvs.Length == 0)
             {
@@ -1422,7 +1423,7 @@ namespace Fusee.Engine.Imp.Graphics.Android
             }
 
             GL.BindBuffer(BufferTarget.ArrayBuffer, ((MeshImp)mr).UVBufferObject);
-            GL.BufferData(BufferTarget.ArrayBuffer, (IntPtr)(uvsBytes), uvs, BufferUsage.StaticDraw);
+            GL.BufferData(BufferTarget.ArrayBuffer, (IntPtr)(uvsBytes), ref MemoryMarshal.GetReference(uvs), BufferUsage.StaticDraw);
             GL.GetBufferParameter(BufferTarget.ArrayBuffer, BufferParameterName.BufferSize, out int vboBytes);
             if (vboBytes != uvsBytes)
                 throw new ApplicationException(String.Format(
@@ -1437,7 +1438,7 @@ namespace Fusee.Engine.Imp.Graphics.Android
         /// <param name="colors">The colors.</param>
         /// <exception cref="System.ArgumentException">colors must not be null or empty</exception>
         /// <exception cref="System.ApplicationException"></exception>
-        public void SetColors(IMeshImp mr, uint[] colors)
+        public void SetColors(IMeshImp mr, ReadOnlySpan<uint> colors)
         {
             if (colors == null || colors.Length == 0)
             {
@@ -1452,7 +1453,7 @@ namespace Fusee.Engine.Imp.Graphics.Android
             }
 
             GL.BindBuffer(BufferTarget.ArrayBuffer, ((MeshImp)mr).ColorBufferObject);
-            GL.BufferData(BufferTarget.ArrayBuffer, (IntPtr)(colsBytes), colors, BufferUsage.StaticDraw);
+            GL.BufferData(BufferTarget.ArrayBuffer, (IntPtr)(colsBytes), ref MemoryMarshal.GetReference(colors), BufferUsage.StaticDraw);
             GL.GetBufferParameter(BufferTarget.ArrayBuffer, BufferParameterName.BufferSize, out int vboBytes);
             if (vboBytes != colsBytes)
                 throw new ApplicationException(String.Format(
@@ -1467,7 +1468,7 @@ namespace Fusee.Engine.Imp.Graphics.Android
         /// <param name="colors">The colors.</param>
         /// <exception cref="System.ArgumentException">colors must not be null or empty</exception>
         /// <exception cref="System.ApplicationException"></exception>
-        public void SetColors1(IMeshImp mr, uint[] colors)
+        public void SetColors1(IMeshImp mr, ReadOnlySpan<uint> colors)
         {
             if (colors == null || colors.Length == 0)
             {
@@ -1482,7 +1483,7 @@ namespace Fusee.Engine.Imp.Graphics.Android
             }
 
             GL.BindBuffer(BufferTarget.ArrayBuffer, ((MeshImp)mr).ColorBufferObject1);
-            GL.BufferData(BufferTarget.ArrayBuffer, (IntPtr)(colsBytes), colors, BufferUsage.StaticDraw);
+            GL.BufferData(BufferTarget.ArrayBuffer, (IntPtr)(colsBytes), ref MemoryMarshal.GetReference(colors), BufferUsage.StaticDraw);
             GL.GetBufferParameter(BufferTarget.ArrayBuffer, BufferParameterName.BufferSize, out int vboBytes);
             if (vboBytes != colsBytes)
                 throw new ApplicationException(String.Format(
@@ -1497,7 +1498,7 @@ namespace Fusee.Engine.Imp.Graphics.Android
         /// <param name="colors">The colors.</param>
         /// <exception cref="System.ArgumentException">colors must not be null or empty</exception>
         /// <exception cref="System.ApplicationException"></exception>
-        public void SetColors2(IMeshImp mr, uint[] colors)
+        public void SetColors2(IMeshImp mr, ReadOnlySpan<uint> colors)
         {
             if (colors == null || colors.Length == 0)
             {
@@ -1512,7 +1513,7 @@ namespace Fusee.Engine.Imp.Graphics.Android
             }
 
             GL.BindBuffer(BufferTarget.ArrayBuffer, ((MeshImp)mr).ColorBufferObject2);
-            GL.BufferData(BufferTarget.ArrayBuffer, (IntPtr)(colsBytes), colors, BufferUsage.StaticDraw);
+            GL.BufferData(BufferTarget.ArrayBuffer, (IntPtr)(colsBytes), ref MemoryMarshal.GetReference(colors), BufferUsage.StaticDraw);
             GL.GetBufferParameter(BufferTarget.ArrayBuffer, BufferParameterName.BufferSize, out int vboBytes);
             if (vboBytes != colsBytes)
                 throw new ApplicationException(String.Format(
@@ -1527,7 +1528,7 @@ namespace Fusee.Engine.Imp.Graphics.Android
         /// <param name="triangleIndices">The triangle indices.</param>
         /// <exception cref="System.ArgumentException">triangleIndices must not be null or empty</exception>
         /// <exception cref="System.ApplicationException"></exception>
-        public void SetTriangles(IMeshImp mr, ushort[] triangleIndices)
+        public void SetTriangles(IMeshImp mr, ReadOnlySpan<ushort> triangleIndices)
         {
             if (triangleIndices == null || triangleIndices.Length == 0)
             {
@@ -1543,13 +1544,236 @@ namespace Fusee.Engine.Imp.Graphics.Android
             }
             // Upload the index buffer (elements inside the vertex buffer, not color indices as per the IndexPointer function!)
             GL.BindBuffer(BufferTarget.ElementArrayBuffer, ((MeshImp)mr).ElementBufferObject);
-            GL.BufferData(BufferTarget.ElementArrayBuffer, (IntPtr)(trisBytes), triangleIndices,
+            GL.BufferData(BufferTarget.ElementArrayBuffer, (IntPtr)(trisBytes), ref MemoryMarshal.GetReference(triangleIndices),
                 BufferUsage.StaticDraw);
             GL.GetBufferParameter(BufferTarget.ElementArrayBuffer, BufferParameterName.BufferSize, out int vboBytes);
             if (vboBytes != trisBytes)
                 throw new ApplicationException(String.Format(
                     "Problem uploading vertex buffer to VBO (offsets). Tried to upload {0} bytes, uploaded {1}.",
                     trisBytes, vboBytes));
+        }
+
+        /// <summary>
+        /// Binds the vertices onto the GL render context and assigns one vertex to the passed <see cref="IMeshImp" /> instance.
+        /// </summary>
+        /// <param name="mr">The <see cref="IMeshImp" /> instance.</param>
+        /// <param name="idx">The index position</param>
+        /// <param name="vertex">The vertex.</param>
+        public void SetVertex(IMeshImp mr, int idx, float3 vertex)
+        {
+            int vertsBytes = 3 * sizeof(float);
+            int offsetInBytes = idx * sizeof(float) * 3;
+            if (((MeshImp)mr).VertexBufferObject == 0)
+            {
+                GL.GenBuffers(1, out int bufferObj);
+                ((MeshImp)mr).VertexBufferObject = bufferObj;
+            }
+
+            GL.BindBuffer(BufferTarget.ArrayBuffer, ((MeshImp)mr).VertexBufferObject);
+            GL.BufferSubData(BufferTarget.ArrayBuffer, (IntPtr)offsetInBytes, (IntPtr)vertsBytes, ref vertex);
+        }
+
+        /// <summary>
+        /// Binds the tangents onto the GL render context and assigns one tangent index to the passed <see cref="IMeshImp" /> instance.
+        /// </summary>
+        /// <param name="mr">The <see cref="IMeshImp" /> instance.</param>
+        /// <param name="idx">The index position</param>
+        /// <param name="tangents">The tangents.</param>
+        public void SetTangent(IMeshImp mr, int idx, float4 tangents)
+        {
+            int tangentBytes = 4 * sizeof(float);
+            int offsetInBytes = idx * sizeof(float) * 4;
+
+            if (((MeshImp)mr).TangentBufferObject == 0)
+            {
+                GL.GenBuffers(1, out int bufferObj);
+                ((MeshImp)mr).TangentBufferObject = bufferObj;
+            }
+
+            GL.BindBuffer(BufferTarget.ArrayBuffer, ((MeshImp)mr).TangentBufferObject);
+            GL.BufferSubData(BufferTarget.ArrayBuffer, (IntPtr)offsetInBytes, (IntPtr)tangentBytes, ref tangents);
+        }
+
+        /// <summary>
+        /// Binds the bitangents onto the GL render context and assigns one BiTangent index to the passed <see cref="IMeshImp" /> instance.
+        /// </summary>
+        /// <param name="mr">The <see cref="IMeshImp" /> instance.</param>
+        /// <param name="idx">The index position</param>
+        /// <param name = "bitangent">The bitangent.</param>
+        public void SetBiTangent(IMeshImp mr, int idx, float3 bitangent)
+        {
+            int bitangentBytes = sizeof(float) * 3;
+            int offsetInBytes = idx * sizeof(float) * 3;
+
+            if (((MeshImp)mr).BitangentBufferObject == 0)
+            {
+                GL.GenBuffers(1, out int bufferObj);
+                ((MeshImp)mr).BitangentBufferObject = bufferObj;
+            }
+
+            GL.BindBuffer(BufferTarget.ArrayBuffer, ((MeshImp)mr).BitangentBufferObject);
+            GL.BufferSubData(BufferTarget.ArrayBuffer, (IntPtr)offsetInBytes, (IntPtr)bitangentBytes, ref bitangent);
+        }
+
+        /// <summary>
+        /// Binds the normals onto the GL render context and assigns one NormalBuffer index to the passed <see cref="IMeshImp" /> instance.
+        /// </summary>
+        /// <param name="mr">The <see cref="IMeshImp" /> instance.</param>
+        /// <param name="idx">The index position</param>
+        /// <param name="normal">The normal.</param>
+        public void SetNormal(IMeshImp mr, int idx, float3 normal)
+        {
+            int normalBytes = sizeof(float) * 3;
+            int offsetInBytes = idx * sizeof(float) * 3;
+
+            if (((MeshImp)mr).NormalBufferObject == 0)
+            {
+                GL.GenBuffers(1, out int bufferObj);
+                ((MeshImp)mr).NormalBufferObject = bufferObj;
+            }
+            GL.BindBuffer(BufferTarget.ArrayBuffer, ((MeshImp)mr).NormalBufferObject);
+            GL.BufferSubData(BufferTarget.ArrayBuffer, (IntPtr)offsetInBytes, (IntPtr)normalBytes, ref normal);
+        }
+
+        /// <summary>
+        /// Binds the UV coordinates onto the GL render context and assigns one UVBuffer index to the passed <see cref="IMeshImp" /> instance.
+        /// </summary>
+        /// <param name="mr">The <see cref="IMeshImp" /> instance.</param>
+        /// <param name="idx">The index position</param>
+        /// <param name="uv">The UV.</param>
+        public void SetUV(IMeshImp mr, int idx, float2 uv)
+        {
+            int uvBytes = sizeof(float) * 2;
+            int offsetInBytes = idx * sizeof(float) * 2;
+
+            if (((MeshImp)mr).UVBufferObject == 0)
+            {
+                GL.GenBuffers(1, out int bufferObj);
+                ((MeshImp)mr).UVBufferObject = bufferObj;
+            }
+
+            GL.BindBuffer(BufferTarget.ArrayBuffer, ((MeshImp)mr).UVBufferObject);
+            GL.BufferSubData(BufferTarget.ArrayBuffer, (IntPtr)offsetInBytes, (IntPtr)uvBytes, ref uv);
+        }
+
+        /// <summary>
+        /// Binds the colors onto the GL render context and assigns one ColorBuffer index to the passed <see cref="IMeshImp" /> instance.
+        /// </summary>
+        /// <param name="mr">The <see cref="IMeshImp" /> instance.</param>
+        /// <param name="idx">The index position</param>
+        /// <param name="color">The colors.</param>
+        public void SetColor(IMeshImp mr, int idx, uint color)
+        {
+            int colorBytes = sizeof(uint);
+            int offsetInBytes = idx * sizeof(uint);
+
+            if (((MeshImp)mr).ColorBufferObject == 0)
+            {
+                GL.GenBuffers(1, out int bufferObj);
+                ((MeshImp)mr).ColorBufferObject = bufferObj;
+            }
+            GL.BindBuffer(BufferTarget.ArrayBuffer, ((MeshImp)mr).ColorBufferObject);
+            GL.BufferSubData(BufferTarget.ArrayBuffer, (IntPtr)offsetInBytes, (IntPtr)colorBytes, ref color);
+        }
+
+        /// <summary>
+        /// Binds the colors onto the GL render context and assigns one ColorBuffer index to the passed <see cref="IMeshImp" /> instance.
+        /// </summary>
+        /// <param name="mr">The <see cref="IMeshImp" /> instance.</param>
+        /// <param name="idx">The index position</param>
+        /// <param name="color">The color.</param>
+        public void SetColor1(IMeshImp mr, int idx, uint color)
+        {
+            int colorBytes = sizeof(uint);
+            int offsetInBytes = idx * sizeof(uint);
+
+            if (((MeshImp)mr).ColorBufferObject1 == 0)
+            {
+                GL.GenBuffers(1, out int bufferObj);
+                ((MeshImp)mr).ColorBufferObject1 = bufferObj;
+            }
+            GL.BindBuffer(BufferTarget.ArrayBuffer, ((MeshImp)mr).ColorBufferObject1);
+            GL.BufferSubData(BufferTarget.ArrayBuffer, (IntPtr)offsetInBytes, (IntPtr)colorBytes, ref color);
+        }
+
+        /// <summary>
+        /// Binds the colors onto the GL render context and assigns one ColorBuffer index to the passed <see cref="IMeshImp" /> instance.
+        /// </summary>
+        /// <param name="mr">The <see cref="IMeshImp" /> instance.</param>
+        /// <param name="idx">The index position</param>
+        /// <param name="color">The color.</param>
+        public void SetColor2(IMeshImp mr, int idx, uint color)
+        {
+            int colorBytes = sizeof(uint);
+            int offsetInBytes = idx * sizeof(uint);
+
+            if (((MeshImp)mr).ColorBufferObject2 == 0)
+            {
+                GL.GenBuffers(1, out int bufferObj);
+                ((MeshImp)mr).ColorBufferObject2 = bufferObj;
+            }
+            GL.BindBuffer(BufferTarget.ArrayBuffer, ((MeshImp)mr).ColorBufferObject2);
+            GL.BufferSubData(BufferTarget.ArrayBuffer, (IntPtr)offsetInBytes, (IntPtr)colorBytes, ref color);
+        }
+
+        /// <summary>
+        /// Binds the triangles onto the GL render context and assigns one ElementBuffer index to the passed <see cref="IMeshImp" /> instance.
+        /// </summary>
+        /// <param name="mr">The <see cref="IMeshImp" /> instance.</param>
+        /// <param name="idx">The index position</param>
+        /// <param name="triangleIndex">The triangle index.</param>
+        public void SetTriangle(IMeshImp mr, int idx, ushort triangleIndex)
+        {
+            int triangleBytes = sizeof(ushort);
+            int offsetInBytes = idx * sizeof(ushort);
+
+            if (((MeshImp)mr).ElementBufferObject == 0)
+            {
+                GL.GenBuffers(1, out int bufferObj);
+                ((MeshImp)mr).ElementBufferObject = bufferObj;
+            }
+            GL.BindBuffer(BufferTarget.ElementArrayBuffer, ((MeshImp)mr).ElementBufferObject);
+            GL.BufferSubData(BufferTarget.ElementArrayBuffer, (IntPtr)offsetInBytes, (IntPtr)triangleBytes, ref triangleIndex);
+        }
+
+        /// <summary>
+        /// Binds the bone indices onto the GL render context and assigns one BoneBuffer index to the passed <see cref="IMeshImp" /> instance.
+        /// </summary>
+        /// <param name="mr">The <see cref="IMeshImp" /> instance.</param>
+        /// <param name="idx">The index position</param>
+        /// <param name="boneIndex">The bone index.</param>
+        public void SetBoneIndex(IMeshImp mr, int idx, float4 boneIndex)
+        {
+            int boneBytes = sizeof(float) * 4;
+            int offsetInBytes = idx * sizeof(float) * 4;
+
+            if (((MeshImp)mr).BoneIndexBufferObject == 0)
+            {
+                GL.GenBuffers(1, out int bufferObj);
+                ((MeshImp)mr).BoneIndexBufferObject = bufferObj;
+            }
+            GL.BindBuffer(BufferTarget.ArrayBuffer, ((MeshImp)mr).BoneIndexBufferObject);
+            GL.BufferSubData(BufferTarget.ArrayBuffer, (IntPtr)offsetInBytes, (IntPtr)boneBytes, ref boneIndex);
+        }
+
+        /// <summary>
+        /// Binds the bone weights onto the GL render context and assigns one BoneWeight index to the passed <see cref="IMeshImp" /> instance.
+        /// </summary>
+        /// <param name="mr">The <see cref="IMeshImp" /> instance.</param>
+        /// <param name="idx">The index position</param>
+        /// <param name="boneWeight">The bone weight.</param>
+        public void SetBoneWeight(IMeshImp mr, int idx, float4 boneWeight)
+        {
+            int boneWeightBytes = sizeof(float) * 4;
+            int offsetInBytes = idx * sizeof(float) * 4;
+
+            if (((MeshImp)mr).BoneWeightBufferObject == 0)
+            {
+                GL.GenBuffers(1, out int bufferObj);
+                ((MeshImp)mr).BoneWeightBufferObject = bufferObj;
+            }
+            GL.BindBuffer(BufferTarget.ArrayBuffer, ((MeshImp)mr).BoneWeightBufferObject);
+            GL.BufferSubData(BufferTarget.ArrayBuffer, (IntPtr)offsetInBytes, (IntPtr)boneWeightBytes, ref boneWeight);
         }
 
         /// <summary>

--- a/src/Engine/Imp/Graphics/Blazor/RenderContextImp.cs
+++ b/src/Engine/Imp/Graphics/Blazor/RenderContextImp.cs
@@ -8,6 +8,7 @@ using Fusee.Math.Core;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.InteropServices;
 using static Fusee.Engine.Imp.Graphics.Blazor.WebGL2RenderingContextBase;
 using static Fusee.Engine.Imp.Graphics.Blazor.WebGLRenderingContextBase;
 
@@ -67,7 +68,7 @@ namespace Fusee.Engine.Imp.Graphics.Blazor
             };
         }
 
-        private Tuple<int, int> GetMinMagFilter(TextureFilterMode filterMode)
+        private static Tuple<int, int> GetMinMagFilter(TextureFilterMode filterMode)
         {
             int minFilter;
             int magFilter;
@@ -1061,7 +1062,7 @@ namespace Fusee.Engine.Imp.Graphics.Blazor
         /// <param name="vertices">The vertices.</param>
         /// <exception cref="ArgumentException">Vertices must not be null or empty</exception>
         /// <exception cref="ApplicationException"></exception>
-        public void SetVertices(IMeshImp mr, float3[] vertices)
+        public void SetVertices(IMeshImp mr, ReadOnlySpan<float3> vertices)
         {
             if (vertices == null || vertices.Length == 0)
             {
@@ -1107,7 +1108,7 @@ namespace Fusee.Engine.Imp.Graphics.Blazor
         /// <param name="tangents">The tangents.</param>
         /// <exception cref="ArgumentException">Tangents must not be null or empty</exception>
         /// <exception cref="ApplicationException"></exception>
-        public void SetTangents(IMeshImp mr, float4[] tangents)
+        public void SetTangents(IMeshImp mr, ReadOnlySpan<float4> tangents)
         {
             if (tangents == null || tangents.Length == 0)
             {
@@ -1148,7 +1149,7 @@ namespace Fusee.Engine.Imp.Graphics.Blazor
         /// <param name="bitangents">The BiTangents.</param>
         /// <exception cref="ArgumentException">BiTangents must not be null or empty</exception>
         /// <exception cref="ApplicationException"></exception>
-        public void SetBiTangents(IMeshImp mr, float3[] bitangents)
+        public void SetBiTangents(IMeshImp mr, ReadOnlySpan<float3> bitangents)
         {
             if (bitangents == null || bitangents.Length == 0)
             {
@@ -1193,7 +1194,7 @@ namespace Fusee.Engine.Imp.Graphics.Blazor
         /// <param name="normals">The normals.</param>
         /// <exception cref="ArgumentException">Normals must not be null or empty</exception>
         /// <exception cref="ApplicationException"></exception>
-        public void SetNormals(IMeshImp mr, float3[] normals)
+        public void SetNormals(IMeshImp mr, ReadOnlySpan<float3> normals)
         {
             if (normals == null || normals.Length == 0)
             {
@@ -1239,7 +1240,7 @@ namespace Fusee.Engine.Imp.Graphics.Blazor
         /// <param name="boneIndices">The bone indices.</param>
         /// <exception cref="ArgumentException">BoneIndices must not be null or empty</exception>
         /// <exception cref="ApplicationException"></exception>
-        public void SetBoneIndices(IMeshImp mr, float4[] boneIndices)
+        public void SetBoneIndices(IMeshImp mr, ReadOnlySpan<float4> boneIndices)
         {
             if (boneIndices == null || boneIndices.Length == 0)
             {
@@ -1285,7 +1286,7 @@ namespace Fusee.Engine.Imp.Graphics.Blazor
         /// <param name="boneWeights">The bone weights.</param>
         /// <exception cref="ArgumentException">BoneWeights must not be null or empty</exception>
         /// <exception cref="ApplicationException"></exception>
-        public void SetBoneWeights(IMeshImp mr, float4[] boneWeights)
+        public void SetBoneWeights(IMeshImp mr, ReadOnlySpan<float4> boneWeights)
         {
             if (boneWeights == null || boneWeights.Length == 0)
             {
@@ -1332,7 +1333,7 @@ namespace Fusee.Engine.Imp.Graphics.Blazor
         /// <param name="uvs">The UV's.</param>
         /// <exception cref="ArgumentException">UVs must not be null or empty</exception>
         /// <exception cref="ApplicationException"></exception>
-        public void SetUVs(IMeshImp mr, float2[] uvs)
+        public void SetUVs(IMeshImp mr, ReadOnlySpan<float2> uvs)
         {
             if (uvs == null || uvs.Length == 0)
             {
@@ -1347,13 +1348,6 @@ namespace Fusee.Engine.Imp.Graphics.Blazor
             gl2.BindBuffer(ARRAY_BUFFER, ((MeshImp)mr).UVBufferObject);
 
             float[] uvsFlat = new float[uvs.Length * 2];
-
-            //{
-            ////fixed(float2* pBytes = &uvs[0])
-            //{
-            //Marshal.Copy((IntPtr)(pBytes), uvsFlat, 0, uvsFlat.Length);
-            //}
-            //}
 
             int i = 0;
             foreach (float2 v in uvs)
@@ -1377,7 +1371,7 @@ namespace Fusee.Engine.Imp.Graphics.Blazor
         /// <param name="colors">The colors.</param>
         /// <exception cref="ArgumentException">colors must not be null or empty</exception>
         /// <exception cref="ApplicationException"></exception>
-        public void SetColors(IMeshImp mr, uint[] colors)
+        public void SetColors(IMeshImp mr, ReadOnlySpan<uint> colors)
         {
             if (colors == null || colors.Length == 0)
             {
@@ -1390,7 +1384,7 @@ namespace Fusee.Engine.Imp.Graphics.Blazor
                 ((MeshImp)mr).ColorBufferObject = gl2.CreateBuffer();
 
             gl2.BindBuffer(ARRAY_BUFFER, ((MeshImp)mr).ColorBufferObject);
-            gl2.BufferData(ARRAY_BUFFER, colors, STATIC_DRAW);
+            gl2.BufferData(ARRAY_BUFFER, colors.ToArray(), STATIC_DRAW);
             vboBytes = (int)gl2.GetBufferParameter(ARRAY_BUFFER, BUFFER_SIZE);
             if (vboBytes != colsBytes)
                 throw new ApplicationException(string.Format("Problem uploading color buffer to VBO (colors). Tried to upload {0} bytes, uploaded {1}.", colsBytes, vboBytes));
@@ -1403,7 +1397,7 @@ namespace Fusee.Engine.Imp.Graphics.Blazor
         /// <param name="triangleIndices">The triangle indices.</param>
         /// <exception cref="ArgumentException">triangleIndices must not be null or empty</exception>
         /// <exception cref="ApplicationException"></exception>
-        public void SetTriangles(IMeshImp mr, ushort[] triangleIndices)
+        public void SetTriangles(IMeshImp mr, ReadOnlySpan<ushort> triangleIndices)
         {
             if (triangleIndices == null || triangleIndices.Length == 0)
             {
@@ -1417,12 +1411,217 @@ namespace Fusee.Engine.Imp.Graphics.Blazor
                 ((MeshImp)mr).ElementBufferObject = gl2.CreateBuffer();
             // Upload the index buffer (elements inside the vertex buffer, not color indices as per the IndexPointer function!)
             gl2.BindBuffer(ELEMENT_ARRAY_BUFFER, ((MeshImp)mr).ElementBufferObject);
-            gl2.BufferData(ELEMENT_ARRAY_BUFFER, triangleIndices, STATIC_DRAW);
+            gl2.BufferData(ELEMENT_ARRAY_BUFFER, triangleIndices.ToArray(), STATIC_DRAW);
             vboBytes = (int)gl2.GetBufferParameter(ELEMENT_ARRAY_BUFFER, BUFFER_SIZE);
             if (vboBytes != trisBytes)
                 throw new ApplicationException(string.Format("Problem uploading vertex buffer to VBO (offsets). Tried to upload {0} bytes, uploaded {1}.", trisBytes, vboBytes));
 
         }
+
+
+        /// <summary>
+        /// Binds the vertices onto the GL render context and assigns one vertex to the passed <see cref="IMeshImp" /> instance.
+        /// </summary>
+        /// <param name="mr">The <see cref="IMeshImp" /> instance.</param>
+        /// <param name="idx">The index position</param>
+        /// <param name="vertex">The vertex.</param>
+        public void SetVertex(IMeshImp mr, int idx, float3 vertex)
+        {
+            int offsetInBytes = idx * sizeof(float) * 3;
+            if (((MeshImp)mr).VertexBufferObject == null)
+            {
+                var bufferObj = gl2.CreateBuffer();
+                ((MeshImp)mr).VertexBufferObject = bufferObj;
+            }
+
+
+            gl2.BindBuffer(ARRAY_BUFFER, ((MeshImp)mr).VertexBufferObject);
+            gl2.BufferSubData(ARRAY_BUFFER, (uint)offsetInBytes, vertex.ToArray());
+        }
+
+        /// <summary>
+        /// Binds the tangents onto the GL render context and assigns one tangent index to the passed <see cref="IMeshImp" /> instance.
+        /// </summary>
+        /// <param name="mr">The <see cref="IMeshImp" /> instance.</param>
+        /// <param name="idx">The index position</param>
+        /// <param name="tangents">The tangents.</param>
+        public void SetTangent(IMeshImp mr, int idx, float4 tangents)
+        {
+            int offsetInBytes = idx * sizeof(float) * 4;
+
+            if (((MeshImp)mr).TangentBufferObject == null)
+            {
+                var bufferObj = gl2.CreateBuffer();
+                ((MeshImp)mr).TangentBufferObject = bufferObj;
+            }
+
+            gl2.BindBuffer(ARRAY_BUFFER, ((MeshImp)mr).TangentBufferObject);
+            gl2.BufferSubData(ARRAY_BUFFER, (uint)offsetInBytes, tangents.ToArray());
+
+        }
+
+        /// <summary>
+        /// Binds the bitangents onto the GL render context and assigns one BiTangent index to the passed <see cref="IMeshImp" /> instance.
+        /// </summary>
+        /// <param name="mr">The <see cref="IMeshImp" /> instance.</param>
+        /// <param name="idx">The index position</param>
+        /// <param name = "bitangent">The bitangent.</param>
+        public void SetBiTangent(IMeshImp mr, int idx, float3 bitangent)
+        {
+            int offsetInBytes = idx * sizeof(float) * 3;
+
+            if (((MeshImp)mr).BitangentBufferObject == null)
+            {
+                var bufferObj = gl2.CreateBuffer();
+                ((MeshImp)mr).BitangentBufferObject = bufferObj;
+            }
+
+            gl2.BindBuffer(ARRAY_BUFFER, ((MeshImp)mr).TangentBufferObject);
+            gl2.BufferSubData(ARRAY_BUFFER, (uint)offsetInBytes, bitangent.ToArray());
+
+        }
+
+        /// <summary>
+        /// Binds the normals onto the GL render context and assigns one NormalBuffer index to the passed <see cref="IMeshImp" /> instance.
+        /// </summary>
+        /// <param name="mr">The <see cref="IMeshImp" /> instance.</param>
+        /// <param name="idx">The index position</param>
+        /// <param name="normal">The normal.</param>
+        public void SetNormal(IMeshImp mr, int idx, float3 normal)
+        {
+            int offsetInBytes = idx * sizeof(float) * 3;
+
+            if (((MeshImp)mr).NormalBufferObject == null)
+            {
+                var bufferObj = gl2.CreateBuffer();
+                ((MeshImp)mr).NormalBufferObject = bufferObj;
+            }
+
+            gl2.BindBuffer(ARRAY_BUFFER, ((MeshImp)mr).NormalBufferObject);
+            gl2.BufferSubData(ARRAY_BUFFER, (uint)offsetInBytes, normal.ToArray());
+
+        }
+
+        /// <summary>
+        /// Binds the UV coordinates onto the GL render context and assigns one UVBuffer index to the passed <see cref="IMeshImp" /> instance.
+        /// </summary>
+        /// <param name="mr">The <see cref="IMeshImp" /> instance.</param>
+        /// <param name="idx">The index position</param>
+        /// <param name="uv">The UV.</param>
+        public void SetUV(IMeshImp mr, int idx, float2 uv)
+        {
+            int offsetInBytes = idx * sizeof(float) * 2;
+
+            if (((MeshImp)mr).UVBufferObject == null)
+            {
+                var bufferObj = gl2.CreateBuffer();
+                ((MeshImp)mr).UVBufferObject = bufferObj;
+            }
+
+            gl2.BindBuffer(ARRAY_BUFFER, ((MeshImp)mr).UVBufferObject);
+            gl2.BufferSubData(ARRAY_BUFFER, (uint)offsetInBytes, uv.ToArray());
+        }
+
+        /// <summary>
+        /// Binds the colors onto the GL render context and assigns one ColorBuffer index to the passed <see cref="IMeshImp" /> instance.
+        /// </summary>
+        /// <param name="mr">The <see cref="IMeshImp" /> instance.</param>
+        /// <param name="idx">The index position</param>
+        /// <param name="color">The colors.</param>
+        public void SetColor(IMeshImp mr, int idx, uint color)
+        {
+            int offsetInBytes = idx * sizeof(uint);
+            if (((MeshImp)mr).ColorBufferObject == null)
+            {
+
+                var bufferObj = gl2.CreateBuffer();
+                ((MeshImp)mr).ColorBufferObject = bufferObj;
+            }
+
+            gl2.BindBuffer(ARRAY_BUFFER, ((MeshImp)mr).ColorBufferObject);
+            gl2.BufferSubData(ARRAY_BUFFER, (uint)offsetInBytes, new uint[] { color });
+        }
+
+        /// <summary>
+        /// Binds the colors onto the GL render context and assigns one ColorBuffer index to the passed <see cref="IMeshImp" /> instance.
+        /// </summary>
+        /// <param name="mr">The <see cref="IMeshImp" /> instance.</param>
+        /// <param name="idx">The index position</param>
+        /// <param name="color">The color.</param>
+        public void SetColor1(IMeshImp mr, int idx, uint color)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Binds the colors onto the GL render context and assigns one ColorBuffer index to the passed <see cref="IMeshImp" /> instance.
+        /// </summary>
+        /// <param name="mr">The <see cref="IMeshImp" /> instance.</param>
+        /// <param name="idx">The index position</param>
+        /// <param name="color">The color.</param>
+        public void SetColor2(IMeshImp mr, int idx, uint color)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Binds the triangles onto the GL render context and assigns one ElementBuffer index to the passed <see cref="IMeshImp" /> instance.
+        /// </summary>
+        /// <param name="mr">The <see cref="IMeshImp" /> instance.</param>
+        /// <param name="idx">The index position</param>
+        /// <param name="triangleIndex">The triangle index.</param>
+        public void SetTriangle(IMeshImp mr, int idx, ushort triangleIndex)
+        {
+            int offsetInBytes = idx * sizeof(ushort);
+
+            if (((MeshImp)mr).ElementBufferObject == null)
+            {
+                var bufferObj = gl2.CreateBuffer();
+                ((MeshImp)mr).ElementBufferObject = bufferObj;
+            }
+            gl2.BindBuffer(ELEMENT_ARRAY_BUFFER, ((MeshImp)mr).ElementBufferObject);
+            gl2.BufferSubData(ELEMENT_ARRAY_BUFFER, (uint)offsetInBytes, new ushort[] { triangleIndex });
+        }
+
+        /// <summary>
+        /// Binds the bone indices onto the GL render context and assigns one BoneBuffer index to the passed <see cref="IMeshImp" /> instance.
+        /// </summary>
+        /// <param name="mr">The <see cref="IMeshImp" /> instance.</param>
+        /// <param name="idx">The index position</param>
+        /// <param name="boneIndex">The bone index.</param>
+        public void SetBoneIndex(IMeshImp mr, int idx, float4 boneIndex)
+        {
+            int offsetInBytes = idx * sizeof(float) * 4;
+            if (((MeshImp)mr).BoneIndexBufferObject == null)
+            {
+                var bufferObj = gl2.CreateBuffer();
+                ((MeshImp)mr).BoneIndexBufferObject = bufferObj;
+            }
+
+            gl2.BindBuffer(ARRAY_BUFFER, ((MeshImp)mr).BoneIndexBufferObject);
+            gl2.BufferSubData(ARRAY_BUFFER, (uint)offsetInBytes, boneIndex.ToArray());
+        }
+
+        /// <summary>
+        /// Binds the bone weights onto the GL render context and assigns one BoneWeight index to the passed <see cref="IMeshImp" /> instance.
+        /// </summary>
+        /// <param name="mr">The <see cref="IMeshImp" /> instance.</param>
+        /// <param name="idx">The index position</param>
+        /// <param name="boneWeight">The bone weight.</param>
+        public void SetBoneWeight(IMeshImp mr, int idx, float4 boneWeight)
+        {
+            int offsetInBytes = idx * sizeof(float) * 4;
+
+            if (((MeshImp)mr).BoneWeightBufferObject == null)
+            {
+                var bufferObj = gl2.CreateBuffer();
+                ((MeshImp)mr).BoneWeightBufferObject = bufferObj;
+            }
+
+            gl2.BindBuffer(ARRAY_BUFFER, ((MeshImp)mr).BoneWeightBufferObject);
+            gl2.BufferSubData(ARRAY_BUFFER, (uint)offsetInBytes, boneWeight.ToArray());
+        }
+
 
         /// <summary>
         /// Deletes the buffer associated with the mesh implementation.
@@ -2656,12 +2855,12 @@ namespace Fusee.Engine.Imp.Graphics.Blazor
             throw new NotImplementedException();
         }
 
-        public void SetColors1(IMeshImp mr, uint[] colors)
+        public void SetColors1(IMeshImp mr, ReadOnlySpan<uint> colors)
         {
             throw new NotImplementedException();
         }
 
-        public void SetColors2(IMeshImp mr, uint[] colors)
+        public void SetColors2(IMeshImp mr, ReadOnlySpan<uint> colors)
         {
             throw new NotImplementedException();
         }

--- a/src/Engine/Imp/Graphics/Blazor/WebGL.cs
+++ b/src/Engine/Imp/Graphics/Blazor/WebGL.cs
@@ -817,7 +817,7 @@ namespace Fusee.Engine.Imp.Graphics.Blazor
 
         public void BufferSubData(uint target, uint offset, Array data)
         {
-            Invoke("bufferSubData", target, offset, data);
+            ((IJSUnmarshalledRuntime)BlazorExtensions.Runtime).InvokeUnmarshalled<uint, Array, uint, object>("customSubBufferData", target, data, offset);
         }
 
         public uint CheckFramebufferStatus(uint target)
@@ -2048,20 +2048,15 @@ namespace Fusee.Engine.Imp.Graphics.Blazor
             Invoke("bufferData", target, srcData, usage);
         }
 
-        public void BufferSubData(uint target, uint dstByteOffset, Memory<byte> srcData)
-        {
-            Invoke("bufferSubData", target, dstByteOffset, srcData);
-        }
-
         public void BufferData(uint target, Memory<byte> srcData, uint usage, uint srcOffset, uint length)
         {
             Invoke("bufferData", target, srcData, usage, srcOffset, length);
         }
 
-        public void BufferSubData(uint target, uint dstByteOffset, Memory<byte> srcData, uint srcOffset, uint length)
-        {
-            Invoke("bufferSubData", target, dstByteOffset, srcData, srcOffset, length);
-        }
+        //public void BufferSubData(uint target, uint dstByteOffset, Memory<byte> srcData, uint srcOffset, uint length)
+        //{
+        //    Invoke("bufferSubData", target, dstByteOffset, srcData, srcOffset, length);
+        //}
 
         public void CopyBufferSubData(uint readTarget, uint writeTarget, uint readOffset, uint writeOffset, double size)
         {

--- a/src/Engine/Imp/Graphics/Blazor/wwwroot/Fusee.Engine.Imp.Graphics.Blazor.Native.js
+++ b/src/Engine/Imp/Graphics/Blazor/wwwroot/Fusee.Engine.Imp.Graphics.Blazor.Native.js
@@ -238,6 +238,26 @@ function customBufferData(target, data, usage) {
     }
 }
 
+function customSubBufferData(target, data, offset) {
+
+    const gl2 = document.getElementsByTagName("canvas")[0].getContext('webgl2');
+
+    if (target == gl2.ARRAY_BUFFER) {
+        const dataPtr = Blazor.platform.getArrayEntryPtr(data, 0, 8);
+        const length = Blazor.platform.getArrayLength(data);
+        const floats = new Float32Array(Module.HEAPU8.buffer, dataPtr, length);
+        gl2.bufferSubData(target, offset, floats);
+    }
+    else if (target == gl2.ELEMENT_ARRAY_BUFFER) {
+        const dataPtr = Blazor.platform.getArrayEntryPtr(data, 0, 2);
+        const length = Blazor.platform.getArrayLength(data);
+        const ints = new Uint16Array(Module.HEAPU16.buffer, dataPtr, length);
+        gl2.bufferSubData(target, offset, ints);
+    } else {
+        console.error("Error: Buffer type not found:", target);
+    }
+}
+
 function generateCtx(contextAttributes) {
     const canvas = document.getElementsByTagName("canvas")[0];
     const gl = canvas.getContext('webgl2', contextAttributes);

--- a/src/Engine/Imp/Graphics/Desktop/RenderContextImp.cs
+++ b/src/Engine/Imp/Graphics/Desktop/RenderContextImp.cs
@@ -1576,6 +1576,218 @@ namespace Fusee.Engine.Imp.Graphics.Desktop
                 throw new ApplicationException(string.Format("Problem uploading vertex buffer to VBO (offsets). Tried to upload {0} bytes, uploaded {1}.", trisBytes, vboBytes));
         }
 
+
+        /// <summary>
+        /// Binds the vertices onto the GL render context and assigns one vertex to the passed <see cref="IMeshImp" /> instance.
+        /// </summary>
+        /// <param name="mesh">The <see cref="IMeshImp" /> instance.</param>
+        /// <param name="idx">The index position</param>
+        /// <param name="vertex">The vertex.</param>
+        public void SetVertex(IMeshImp mesh, int idx, float3 vertex)
+        {
+            int vertsBytes = 3 * sizeof(float);
+            int offsetInBytes = idx * sizeof(float) * 3;
+            if (((MeshImp)mesh).VertexBufferObject == 0)
+            {
+                GL.GenBuffers(1, out int bufferObj);
+                ((MeshImp)mesh).VertexBufferObject = bufferObj;
+            }
+
+            GL.NamedBufferSubData(((MeshImp)mesh).VertexBufferObject, (IntPtr)offsetInBytes, vertsBytes, ref vertex);
+        }
+
+        /// <summary>
+        /// Binds the tangents onto the GL render context and assigns one tangent index to the passed <see cref="IMeshImp" /> instance.
+        /// </summary>
+        /// <param name="mr">The <see cref="IMeshImp" /> instance.</param>
+        /// <param name="idx">The index position</param>
+        /// <param name="tangents">The tangents.</param>
+        public void SetTangent(IMeshImp mr, int idx, float4 tangents)
+        {
+            int tangentBytes = 4 * sizeof(float);
+            int offsetInBytes = idx * sizeof(float) * 4;
+
+            if (((MeshImp)mr).TangentBufferObject == 0)
+            {
+                GL.GenBuffers(1, out int bufferObj);
+                ((MeshImp)mr).TangentBufferObject = bufferObj;
+            }
+            GL.NamedBufferSubData(((MeshImp)mr).TangentBufferObject, (IntPtr)offsetInBytes, tangentBytes, ref tangents);
+        }
+
+        /// <summary>
+        /// Binds the bitangents onto the GL render context and assigns one BiTangent index to the passed <see cref="IMeshImp" /> instance.
+        /// </summary>
+        /// <param name="mr">The <see cref="IMeshImp" /> instance.</param>
+        /// <param name="idx">The index position</param>
+        /// <param name = "bitangent">The bitangent.</param>
+        public void SetBiTangent(IMeshImp mr, int idx, float3 bitangent)
+        {
+            int bitangentBytes = sizeof(float) * 3;
+            int offsetInBytes = idx * sizeof(float) * 3;
+
+            if (((MeshImp)mr).BitangentBufferObject == 0)
+            {
+                GL.GenBuffers(1, out int bufferObj);
+                ((MeshImp)mr).BitangentBufferObject = bufferObj;
+            }
+            GL.NamedBufferSubData(((MeshImp)mr).BitangentBufferObject, (IntPtr)offsetInBytes, bitangentBytes, ref bitangent);
+        }
+
+        /// <summary>
+        /// Binds the normals onto the GL render context and assigns one NormalBuffer index to the passed <see cref="IMeshImp" /> instance.
+        /// </summary>
+        /// <param name="mr">The <see cref="IMeshImp" /> instance.</param>
+        /// <param name="idx">The index position</param>
+        /// <param name="normal">The normal.</param>
+        public void SetNormal(IMeshImp mr, int idx, float3 normal)
+        {
+            int normalBytes = sizeof(float) * 3;
+            int offsetInBytes = idx * sizeof(float) * 3;
+
+            if (((MeshImp)mr).NormalBufferObject == 0)
+            {
+                GL.GenBuffers(1, out int bufferObj);
+                ((MeshImp)mr).NormalBufferObject = bufferObj;
+            }
+            GL.NamedBufferSubData(((MeshImp)mr).NormalBufferObject, (IntPtr)offsetInBytes, normalBytes, ref normal);
+        }
+
+        /// <summary>
+        /// Binds the UV coordinates onto the GL render context and assigns one UVBuffer index to the passed <see cref="IMeshImp" /> instance.
+        /// </summary>
+        /// <param name="mr">The <see cref="IMeshImp" /> instance.</param>
+        /// <param name="idx">The index position</param>
+        /// <param name="uv">The UV.</param>
+        public void SetUV(IMeshImp mr, int idx, float2 uv)
+        {
+            int uvBytes = sizeof(float) * 2;
+            int offsetInBytes = idx * sizeof(float) * 2;
+
+            if (((MeshImp)mr).UVBufferObject == 0)
+            {
+                GL.GenBuffers(1, out int bufferObj);
+                ((MeshImp)mr).UVBufferObject = bufferObj;
+            }
+            GL.NamedBufferSubData(((MeshImp)mr).UVBufferObject, (IntPtr)offsetInBytes, uvBytes, ref uv);
+        }
+
+        /// <summary>
+        /// Binds the colors onto the GL render context and assigns one ColorBuffer index to the passed <see cref="IMeshImp" /> instance.
+        /// </summary>
+        /// <param name="mr">The <see cref="IMeshImp" /> instance.</param>
+        /// <param name="idx">The index position</param>
+        /// <param name="color">The colors.</param>
+        public void SetColor(IMeshImp mr, int idx, uint color)
+        {
+            int colorBytes = sizeof(uint);
+            int offsetInBytes = idx * sizeof(uint);
+
+            if (((MeshImp)mr).ColorBufferObject == 0)
+            {
+                GL.GenBuffers(1, out int bufferObj);
+                ((MeshImp)mr).ColorBufferObject = bufferObj;
+            }
+            GL.NamedBufferSubData(((MeshImp)mr).ColorBufferObject, (IntPtr)offsetInBytes, colorBytes, ref color);
+        }
+
+        /// <summary>
+        /// Binds the colors onto the GL render context and assigns one ColorBuffer index to the passed <see cref="IMeshImp" /> instance.
+        /// </summary>
+        /// <param name="mr">The <see cref="IMeshImp" /> instance.</param>
+        /// <param name="idx">The index position</param>
+        /// <param name="color">The color.</param>
+        public void SetColor1(IMeshImp mr, int idx, uint color)
+        {
+            int colorBytes = sizeof(uint);
+            int offsetInBytes = idx * sizeof(uint);
+
+            if (((MeshImp)mr).ColorBufferObject1 == 0)
+            {
+                GL.GenBuffers(1, out int bufferObj);
+                ((MeshImp)mr).ColorBufferObject1 = bufferObj;
+            }
+            GL.NamedBufferSubData(((MeshImp)mr).ColorBufferObject1, (IntPtr)offsetInBytes, colorBytes, ref color);
+        }
+
+        /// <summary>
+        /// Binds the colors onto the GL render context and assigns one ColorBuffer index to the passed <see cref="IMeshImp" /> instance.
+        /// </summary>
+        /// <param name="mr">The <see cref="IMeshImp" /> instance.</param>
+        /// <param name="idx">The index position</param>
+        /// <param name="color">The color.</param>
+        public void SetColor2(IMeshImp mr, int idx, uint color)
+        {
+            int colorBytes = sizeof(uint);
+            int offsetInBytes = idx * sizeof(uint);
+
+            if (((MeshImp)mr).ColorBufferObject2 == 0)
+            {
+                GL.GenBuffers(1, out int bufferObj);
+                ((MeshImp)mr).ColorBufferObject2 = bufferObj;
+            }
+            GL.NamedBufferSubData(((MeshImp)mr).ColorBufferObject2, (IntPtr)offsetInBytes, colorBytes, ref color);
+        }
+
+        /// <summary>
+        /// Binds the triangles onto the GL render context and assigns one ElementBuffer index to the passed <see cref="IMeshImp" /> instance.
+        /// </summary>
+        /// <param name="mr">The <see cref="IMeshImp" /> instance.</param>
+        /// <param name="idx">The index position</param>
+        /// <param name="triangleIndex">The triangle index.</param>
+        public void SetTriangle(IMeshImp mr, int idx, ushort triangleIndex)
+        {
+            int triangleBytes = sizeof(ushort);
+            int offsetInBytes = idx * sizeof(ushort);
+
+            if (((MeshImp)mr).ElementBufferObject == 0)
+            {
+                GL.GenBuffers(1, out int bufferObj);
+                ((MeshImp)mr).ElementBufferObject = bufferObj;
+            }
+            GL.NamedBufferSubData(((MeshImp)mr).ElementBufferObject, (IntPtr)offsetInBytes, triangleBytes, ref triangleIndex);
+
+            GL.GetBufferParameter(BufferTarget.ArrayBuffer, BufferParameterName.BufferSize, out int vboBytes);
+        }
+
+        /// <summary>
+        /// Binds the bone indices onto the GL render context and assigns one BoneBuffer index to the passed <see cref="IMeshImp" /> instance.
+        /// </summary>
+        /// <param name="mr">The <see cref="IMeshImp" /> instance.</param>
+        /// <param name="idx">The index position</param>
+        /// <param name="boneIndex">The bone index.</param>
+        public void SetBoneIndex(IMeshImp mr, int idx, float4 boneIndex)
+        {
+            int boneBytes = sizeof(float) * 4;
+            int offsetInBytes = idx * sizeof(float) * 4;
+
+            if (((MeshImp)mr).BoneIndexBufferObject == 0)
+            {
+                GL.GenBuffers(1, out int bufferObj);
+                ((MeshImp)mr).BoneIndexBufferObject = bufferObj;
+            }
+            GL.NamedBufferSubData(((MeshImp)mr).BoneIndexBufferObject, (IntPtr)offsetInBytes, boneBytes, ref boneIndex);
+        }
+
+        /// <summary>
+        /// Binds the bone weights onto the GL render context and assigns one BoneWeight index to the passed <see cref="IMeshImp" /> instance.
+        /// </summary>
+        /// <param name="mr">The <see cref="IMeshImp" /> instance.</param>
+        /// <param name="idx">The index position</param>
+        /// <param name="boneWeight">The bone weight.</param>
+        public void SetBoneWeight(IMeshImp mr, int idx, float4 boneWeight)
+        {
+            int boneWeightBytes = sizeof(float) * 4;
+            int offsetInBytes = idx * sizeof(float) * 4;
+
+            if (((MeshImp)mr).BoneWeightBufferObject == 0)
+            {
+                GL.GenBuffers(1, out int bufferObj);
+                ((MeshImp)mr).BoneWeightBufferObject = bufferObj;
+            }
+            GL.NamedBufferSubData(((MeshImp)mr).BoneWeightBufferObject, (IntPtr)offsetInBytes, boneWeightBytes, ref boneWeight);
+        }
+
         /// <summary>
         /// Deletes the buffer associated with the mesh implementation.
         /// </summary>

--- a/src/Engine/Imp/Graphics/Desktop/RenderContextImp.cs
+++ b/src/Engine/Imp/Graphics/Desktop/RenderContextImp.cs
@@ -5,10 +5,12 @@ using Fusee.Engine.Core;
 using Fusee.Engine.Core.ShaderShards;
 using Fusee.Engine.Imp.Shared;
 using Fusee.Math.Core;
+using Microsoft.Toolkit.Diagnostics;
 using OpenTK.Graphics.OpenGL;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.InteropServices;
 
 namespace Fusee.Engine.Imp.Graphics.Desktop
 {
@@ -1304,12 +1306,9 @@ namespace Fusee.Engine.Imp.Graphics.Desktop
         /// <param name="vertices">The vertices.</param>
         /// <exception cref="ArgumentException">Vertices must not be null or empty</exception>
         /// <exception cref="ApplicationException"></exception>
-        public void SetVertices(IMeshImp mr, float3[] vertices)
+        public void SetVertices(IMeshImp mr, ReadOnlySpan<float3> vertices)
         {
-            if (vertices == null || vertices.Length == 0)
-            {
-                throw new ArgumentException("Vertices must not be null or empty");
-            }
+            Guard.IsGreaterThan(vertices.Length, 0, nameof(vertices));
 
             int vertsBytes = vertices.Length * 3 * sizeof(float);
             if (((MeshImp)mr).VertexBufferObject == 0)
@@ -1319,7 +1318,7 @@ namespace Fusee.Engine.Imp.Graphics.Desktop
             }
 
             GL.BindBuffer(BufferTarget.ArrayBuffer, ((MeshImp)mr).VertexBufferObject);
-            GL.BufferData(BufferTarget.ArrayBuffer, (IntPtr)(vertsBytes), vertices, BufferUsageHint.StaticDraw);
+            GL.BufferData(BufferTarget.ArrayBuffer, vertsBytes, ref MemoryMarshal.GetReference(vertices), BufferUsageHint.StaticDraw);
             GL.GetBufferParameter(BufferTarget.ArrayBuffer, BufferParameterName.BufferSize, out int vboBytes);
             if (vboBytes != vertsBytes)
                 throw new ApplicationException(string.Format("Problem uploading vertex buffer to VBO (vertices). Tried to upload {0} bytes, uploaded {1}.", vertsBytes, vboBytes));
@@ -1332,12 +1331,9 @@ namespace Fusee.Engine.Imp.Graphics.Desktop
         /// <param name="tangents">The tangents.</param>
         /// <exception cref="ArgumentException">Tangents must not be null or empty</exception>
         /// <exception cref="ApplicationException"></exception>
-        public void SetTangents(IMeshImp mr, float4[] tangents)
+        public void SetTangents(IMeshImp mr, ReadOnlySpan<float4> tangents)
         {
-            if (tangents == null || tangents.Length == 0)
-            {
-                throw new ArgumentException("Tangents must not be null or empty");
-            }
+            Guard.IsGreaterThan(tangents.Length, 0, nameof(tangents));
 
             int tangentBytes = tangents.Length * 4 * sizeof(float);
             if (((MeshImp)mr).TangentBufferObject == 0)
@@ -1347,7 +1343,7 @@ namespace Fusee.Engine.Imp.Graphics.Desktop
             }
 
             GL.BindBuffer(BufferTarget.ArrayBuffer, ((MeshImp)mr).TangentBufferObject);
-            GL.BufferData(BufferTarget.ArrayBuffer, (IntPtr)(tangentBytes), tangents, BufferUsageHint.StaticDraw);
+            GL.BufferData(BufferTarget.ArrayBuffer, tangentBytes, ref MemoryMarshal.GetReference(tangents), BufferUsageHint.StaticDraw);
             GL.GetBufferParameter(BufferTarget.ArrayBuffer, BufferParameterName.BufferSize, out int vboBytes);
             if (vboBytes != tangentBytes)
                 throw new ApplicationException(string.Format("Problem uploading vertex buffer to VBO (tangents). Tried to upload {0} bytes, uploaded {1}.", tangentBytes, vboBytes));
@@ -1360,12 +1356,9 @@ namespace Fusee.Engine.Imp.Graphics.Desktop
         /// <param name="bitangents">The BiTangents.</param>
         /// <exception cref="ArgumentException">BiTangents must not be null or empty</exception>
         /// <exception cref="ApplicationException"></exception>
-        public void SetBiTangents(IMeshImp mr, float3[] bitangents)
+        public void SetBiTangents(IMeshImp mr, ReadOnlySpan<float3> bitangents)
         {
-            if (bitangents == null || bitangents.Length == 0)
-            {
-                throw new ArgumentException("BiTangents must not be null or empty");
-            }
+            Guard.IsGreaterThan(bitangents.Length, 0, nameof(bitangents));
 
             int bitangentBytes = bitangents.Length * 3 * sizeof(float);
             if (((MeshImp)mr).BitangentBufferObject == 0)
@@ -1375,7 +1368,7 @@ namespace Fusee.Engine.Imp.Graphics.Desktop
             }
 
             GL.BindBuffer(BufferTarget.ArrayBuffer, ((MeshImp)mr).BitangentBufferObject);
-            GL.BufferData(BufferTarget.ArrayBuffer, (IntPtr)(bitangentBytes), bitangents, BufferUsageHint.StaticDraw);
+            GL.BufferData(BufferTarget.ArrayBuffer, bitangentBytes, ref MemoryMarshal.GetReference(bitangents), BufferUsageHint.StaticDraw);
             GL.GetBufferParameter(BufferTarget.ArrayBuffer, BufferParameterName.BufferSize, out int vboBytes);
             if (vboBytes != bitangentBytes)
                 throw new ApplicationException(string.Format("Problem uploading vertex buffer to VBO (bitangents). Tried to upload {0} bytes, uploaded {1}.", bitangentBytes, vboBytes));
@@ -1388,12 +1381,9 @@ namespace Fusee.Engine.Imp.Graphics.Desktop
         /// <param name="normals">The normals.</param>
         /// <exception cref="ArgumentException">Normals must not be null or empty</exception>
         /// <exception cref="ApplicationException"></exception>
-        public void SetNormals(IMeshImp mr, float3[] normals)
+        public void SetNormals(IMeshImp mr, ReadOnlySpan<float3> normals)
         {
-            if (normals == null || normals.Length == 0)
-            {
-                throw new ArgumentException("Normals must not be null or empty");
-            }
+            Guard.IsGreaterThan(normals.Length, 0, nameof(normals));
 
             int normsBytes = normals.Length * 3 * sizeof(float);
             if (((MeshImp)mr).NormalBufferObject == 0)
@@ -1403,7 +1393,7 @@ namespace Fusee.Engine.Imp.Graphics.Desktop
             }
 
             GL.BindBuffer(BufferTarget.ArrayBuffer, ((MeshImp)mr).NormalBufferObject);
-            GL.BufferData(BufferTarget.ArrayBuffer, (IntPtr)(normsBytes), normals, BufferUsageHint.StaticDraw);
+            GL.BufferData(BufferTarget.ArrayBuffer, normsBytes, ref MemoryMarshal.GetReference(normals), BufferUsageHint.StaticDraw);
             GL.GetBufferParameter(BufferTarget.ArrayBuffer, BufferParameterName.BufferSize, out int vboBytes);
             if (vboBytes != normsBytes)
                 throw new ApplicationException(string.Format("Problem uploading normal buffer to VBO (normals). Tried to upload {0} bytes, uploaded {1}.", normsBytes, vboBytes));
@@ -1416,12 +1406,9 @@ namespace Fusee.Engine.Imp.Graphics.Desktop
         /// <param name="boneIndices">The bone indices.</param>
         /// <exception cref="ArgumentException">BoneIndices must not be null or empty</exception>
         /// <exception cref="ApplicationException"></exception>
-        public void SetBoneIndices(IMeshImp mr, float4[] boneIndices)
+        public void SetBoneIndices(IMeshImp mr, ReadOnlySpan<float4> boneIndices)
         {
-            if (boneIndices == null || boneIndices.Length == 0)
-            {
-                throw new ArgumentException("BoneIndices must not be null or empty");
-            }
+            Guard.IsGreaterThan(boneIndices.Length, 0, nameof(boneIndices));
 
             int indicesBytes = boneIndices.Length * 4 * sizeof(float);
             if (((MeshImp)mr).BoneIndexBufferObject == 0)
@@ -1431,7 +1418,7 @@ namespace Fusee.Engine.Imp.Graphics.Desktop
             }
 
             GL.BindBuffer(BufferTarget.ArrayBuffer, ((MeshImp)mr).BoneIndexBufferObject);
-            GL.BufferData(BufferTarget.ArrayBuffer, (IntPtr)(indicesBytes), boneIndices, BufferUsageHint.StaticDraw);
+            GL.BufferData(BufferTarget.ArrayBuffer, indicesBytes, ref MemoryMarshal.GetReference(boneIndices), BufferUsageHint.StaticDraw);
             GL.GetBufferParameter(BufferTarget.ArrayBuffer, BufferParameterName.BufferSize, out int vboBytes);
             if (vboBytes != indicesBytes)
                 throw new ApplicationException(string.Format("Problem uploading bone indices buffer to VBO (bone indices). Tried to upload {0} bytes, uploaded {1}.", indicesBytes, vboBytes));
@@ -1444,12 +1431,9 @@ namespace Fusee.Engine.Imp.Graphics.Desktop
         /// <param name="boneWeights">The bone weights.</param>
         /// <exception cref="ArgumentException">BoneWeights must not be null or empty</exception>
         /// <exception cref="ApplicationException"></exception>
-        public void SetBoneWeights(IMeshImp mr, float4[] boneWeights)
+        public void SetBoneWeights(IMeshImp mr, ReadOnlySpan<float4> boneWeights)
         {
-            if (boneWeights == null || boneWeights.Length == 0)
-            {
-                throw new ArgumentException("BoneWeights must not be null or empty");
-            }
+            Guard.IsGreaterThan(boneWeights.Length, 0, nameof(boneWeights));
 
             int weightsBytes = boneWeights.Length * 4 * sizeof(float);
             if (((MeshImp)mr).BoneWeightBufferObject == 0)
@@ -1459,7 +1443,7 @@ namespace Fusee.Engine.Imp.Graphics.Desktop
             }
 
             GL.BindBuffer(BufferTarget.ArrayBuffer, ((MeshImp)mr).BoneWeightBufferObject);
-            GL.BufferData(BufferTarget.ArrayBuffer, (IntPtr)(weightsBytes), boneWeights, BufferUsageHint.StaticDraw);
+            GL.BufferData(BufferTarget.ArrayBuffer, weightsBytes, ref MemoryMarshal.GetReference(boneWeights), BufferUsageHint.StaticDraw);
             GL.GetBufferParameter(BufferTarget.ArrayBuffer, BufferParameterName.BufferSize, out int vboBytes);
             if (vboBytes != weightsBytes)
                 throw new ApplicationException(string.Format("Problem uploading bone weights buffer to VBO (bone weights). Tried to upload {0} bytes, uploaded {1}.", weightsBytes, vboBytes));
@@ -1472,12 +1456,9 @@ namespace Fusee.Engine.Imp.Graphics.Desktop
         /// <param name="uvs">The UV's.</param>
         /// <exception cref="ArgumentException">UVs must not be null or empty</exception>
         /// <exception cref="ApplicationException"></exception>
-        public void SetUVs(IMeshImp mr, float2[] uvs)
+        public void SetUVs(IMeshImp mr, ReadOnlySpan<float2> uvs)
         {
-            if (uvs == null || uvs.Length == 0)
-            {
-                throw new ArgumentException("UVs must not be null or empty");
-            }
+            Guard.IsGreaterThan(uvs.Length, 0, nameof(uvs));
 
             int uvsBytes = uvs.Length * 2 * sizeof(float);
             if (((MeshImp)mr).UVBufferObject == 0)
@@ -1487,7 +1468,7 @@ namespace Fusee.Engine.Imp.Graphics.Desktop
             }
 
             GL.BindBuffer(BufferTarget.ArrayBuffer, ((MeshImp)mr).UVBufferObject);
-            GL.BufferData(BufferTarget.ArrayBuffer, (IntPtr)(uvsBytes), uvs, BufferUsageHint.StaticDraw);
+            GL.BufferData(BufferTarget.ArrayBuffer, uvsBytes, ref MemoryMarshal.GetReference(uvs), BufferUsageHint.StaticDraw);
             GL.GetBufferParameter(BufferTarget.ArrayBuffer, BufferParameterName.BufferSize, out int vboBytes);
             if (vboBytes != uvsBytes)
                 throw new ApplicationException(string.Format("Problem uploading uv buffer to VBO (uvs). Tried to upload {0} bytes, uploaded {1}.", uvsBytes, vboBytes));
@@ -1500,12 +1481,9 @@ namespace Fusee.Engine.Imp.Graphics.Desktop
         /// <param name="colors">The colors.</param>
         /// <exception cref="ArgumentException">colors must not be null or empty</exception>
         /// <exception cref="ApplicationException"></exception>
-        public void SetColors(IMeshImp mr, uint[] colors)
+        public void SetColors(IMeshImp mr, ReadOnlySpan<uint> colors)
         {
-            if (colors == null || colors.Length == 0)
-            {
-                throw new ArgumentException("colors must not be null or empty");
-            }
+            Guard.IsGreaterThan(colors.Length, 0, nameof(colors));
 
             int colsBytes = colors.Length * sizeof(uint);
             if (((MeshImp)mr).ColorBufferObject == 0)
@@ -1515,7 +1493,7 @@ namespace Fusee.Engine.Imp.Graphics.Desktop
             }
 
             GL.BindBuffer(BufferTarget.ArrayBuffer, ((MeshImp)mr).ColorBufferObject);
-            GL.BufferData(BufferTarget.ArrayBuffer, (IntPtr)(colsBytes), colors, BufferUsageHint.StaticDraw);
+            GL.BufferData(BufferTarget.ArrayBuffer, colsBytes, ref MemoryMarshal.GetReference(colors), BufferUsageHint.StaticDraw);
             GL.GetBufferParameter(BufferTarget.ArrayBuffer, BufferParameterName.BufferSize, out int vboBytes);
             if (vboBytes != colsBytes)
                 throw new ApplicationException(string.Format("Problem uploading color buffer to VBO (colors). Tried to upload {0} bytes, uploaded {1}.", colsBytes, vboBytes));
@@ -1528,12 +1506,9 @@ namespace Fusee.Engine.Imp.Graphics.Desktop
         /// <param name="colors">The colors.</param>
         /// <exception cref="ArgumentException">colors must not be null or empty</exception>
         /// <exception cref="ApplicationException"></exception>
-        public void SetColors1(IMeshImp mr, uint[] colors)
+        public void SetColors1(IMeshImp mr, ReadOnlySpan<uint> colors)
         {
-            if (colors == null || colors.Length == 0)
-            {
-                throw new ArgumentException("colors must not be null or empty");
-            }
+            Guard.IsGreaterThan(colors.Length, 0, nameof(colors));
 
             int colsBytes = colors.Length * sizeof(uint);
             if (((MeshImp)mr).ColorBufferObject1 == 0)
@@ -1543,7 +1518,7 @@ namespace Fusee.Engine.Imp.Graphics.Desktop
             }
 
             GL.BindBuffer(BufferTarget.ArrayBuffer, ((MeshImp)mr).ColorBufferObject1);
-            GL.BufferData(BufferTarget.ArrayBuffer, (IntPtr)(colsBytes), colors, BufferUsageHint.StaticDraw);
+            GL.BufferData(BufferTarget.ArrayBuffer, colsBytes, ref MemoryMarshal.GetReference(colors), BufferUsageHint.StaticDraw);
             GL.GetBufferParameter(BufferTarget.ArrayBuffer, BufferParameterName.BufferSize, out int vboBytes);
             if (vboBytes != colsBytes)
                 throw new ApplicationException(string.Format("Problem uploading color buffer to VBO (colors). Tried to upload {0} bytes, uploaded {1}.", colsBytes, vboBytes));
@@ -1556,12 +1531,9 @@ namespace Fusee.Engine.Imp.Graphics.Desktop
         /// <param name="colors">The colors.</param>
         /// <exception cref="ArgumentException">colors must not be null or empty</exception>
         /// <exception cref="ApplicationException"></exception>
-        public void SetColors2(IMeshImp mr, uint[] colors)
+        public void SetColors2(IMeshImp mr, ReadOnlySpan<uint> colors)
         {
-            if (colors == null || colors.Length == 0)
-            {
-                throw new ArgumentException("colors must not be null or empty");
-            }
+            Guard.IsGreaterThan(colors.Length, 0, nameof(colors));
 
             int colsBytes = colors.Length * sizeof(uint);
             if (((MeshImp)mr).ColorBufferObject2 == 0)
@@ -1571,7 +1543,7 @@ namespace Fusee.Engine.Imp.Graphics.Desktop
             }
 
             GL.BindBuffer(BufferTarget.ArrayBuffer, ((MeshImp)mr).ColorBufferObject2);
-            GL.BufferData(BufferTarget.ArrayBuffer, (IntPtr)(colsBytes), colors, BufferUsageHint.StaticDraw);
+            GL.BufferData(BufferTarget.ArrayBuffer, colsBytes, ref MemoryMarshal.GetReference(colors), BufferUsageHint.StaticDraw);
             GL.GetBufferParameter(BufferTarget.ArrayBuffer, BufferParameterName.BufferSize, out int vboBytes);
             if (vboBytes != colsBytes)
                 throw new ApplicationException(string.Format("Problem uploading color buffer to VBO (colors). Tried to upload {0} bytes, uploaded {1}.", colsBytes, vboBytes));
@@ -1584,12 +1556,10 @@ namespace Fusee.Engine.Imp.Graphics.Desktop
         /// <param name="triangleIndices">The triangle indices.</param>
         /// <exception cref="ArgumentException">triangleIndices must not be null or empty</exception>
         /// <exception cref="ApplicationException"></exception>
-        public void SetTriangles(IMeshImp mr, ushort[] triangleIndices)
+        public void SetTriangles(IMeshImp mr, ReadOnlySpan<ushort> triangleIndices)
         {
-            if (triangleIndices == null || triangleIndices.Length == 0)
-            {
-                throw new ArgumentException("triangleIndices must not be null or empty");
-            }
+            Guard.IsGreaterThan(triangleIndices.Length, 0, nameof(triangleIndices));
+
             ((MeshImp)mr).NElements = triangleIndices.Length;
             int trisBytes = triangleIndices.Length * sizeof(short);
 
@@ -1600,7 +1570,7 @@ namespace Fusee.Engine.Imp.Graphics.Desktop
             }
             // Upload the index buffer (elements inside the vertex buffer, not color indices as per the IndexPointer function!)
             GL.BindBuffer(BufferTarget.ElementArrayBuffer, ((MeshImp)mr).ElementBufferObject);
-            GL.BufferData(BufferTarget.ElementArrayBuffer, (IntPtr)(trisBytes), triangleIndices, BufferUsageHint.StaticDraw);
+            GL.BufferData(BufferTarget.ElementArrayBuffer, trisBytes, ref MemoryMarshal.GetReference(triangleIndices), BufferUsageHint.StaticDraw);
             GL.GetBufferParameter(BufferTarget.ElementArrayBuffer, BufferParameterName.BufferSize, out int vboBytes);
             if (vboBytes != trisBytes)
                 throw new ApplicationException(string.Format("Problem uploading vertex buffer to VBO (offsets). Tried to upload {0} bytes, uploaded {1}.", trisBytes, vboBytes));

--- a/src/Math/Core/AABBf.cs
+++ b/src/Math/Core/AABBf.cs
@@ -46,6 +46,18 @@ namespace Fusee.Math.Core
         }
 
         /// <summary>
+        /// Create a new axis aligned bounding box.
+        /// </summary>
+        /// <param name="vertices">The list of vertices the bounding box is created for.</param>
+        public AABBf(ReadOnlySpan<float3> vertices)
+        {
+            min = vertices[0];
+            max = vertices[0];
+            foreach (float3 p in vertices)
+                this |= p;
+        }
+
+        /// <summary>
         /// Applies a transformation on the bounding box. After the transformation another
         /// axis aligned bounding box results. This is done by transforming all eight
         /// vertices of the box and re-aligning to the axes afterwards.
@@ -188,7 +200,7 @@ namespace Fusee.Math.Core
         }
 
         /// <summary>
-        /// Checks if a viewing frustum lies within or intersects this AABB.      
+        /// Checks if a viewing frustum lies within or intersects this AABB.
         /// </summary>
         /// <param name="frustum">The frustum to test against.</param>
         /// <returns>false if fully outside, true if inside or intersecting.</returns>
@@ -211,7 +223,7 @@ namespace Fusee.Math.Core
         }
 
         /// <summary>
-        /// Checks if a plane lies within or intersects this AABB.      
+        /// Checks if a plane lies within or intersects this AABB.
         /// </summary>
         /// <param name="plane">The plane to test against.</param>
         /// <returns>false if fully outside, true if inside or intersecting.</returns>
@@ -277,7 +289,7 @@ namespace Fusee.Math.Core
         /// Operator override for equality.
         /// </summary>
         /// <param name="left">The AABBf.</param>
-        /// <param name="right">The scalar value.</param>        
+        /// <param name="right">The scalar value.</param>
         public static bool operator ==(AABBf left, AABBf right)
         {
             return left.Equals(right);

--- a/src/Math/Core/AABBf.cs
+++ b/src/Math/Core/AABBf.cs
@@ -46,18 +46,6 @@ namespace Fusee.Math.Core
         }
 
         /// <summary>
-        /// Create a new axis aligned bounding box.
-        /// </summary>
-        /// <param name="vertices">The list of vertices the bounding box is created for.</param>
-        public AABBf(ReadOnlySpan<float3> vertices)
-        {
-            min = vertices[0];
-            max = vertices[0];
-            foreach (float3 p in vertices)
-                this |= p;
-        }
-
-        /// <summary>
         /// Applies a transformation on the bounding box. After the transformation another
         /// axis aligned bounding box results. This is done by transforming all eight
         /// vertices of the box and re-aligning to the axes afterwards.

--- a/src/Tests/Serialization/V1/SimpleConvertSceneGraph.cs
+++ b/src/Tests/Serialization/V1/SimpleConvertSceneGraph.cs
@@ -131,13 +131,13 @@ namespace Fusee.Tests.Serialization.V1
                 {
                     Assert.Equal(mesh.Name, ((FusMesh)fusFileComp).Name);
                     Assert.Equal(mesh.BoundingBox, ((FusMesh)fusFileComp).BoundingBox);
-                    Assert.Equal(mesh.Colors, ((FusMesh)fusFileComp).Colors);
-                    Assert.Equal(mesh.Vertices, ((FusMesh)fusFileComp).Vertices);
-                    Assert.Equal(mesh.Triangles, ((FusMesh)fusFileComp).Triangles);
-                    Assert.Equal(mesh.UVs, ((FusMesh)fusFileComp).UVs);
+                    Assert.Equal(mesh.Colors.ToArray(), ((FusMesh)fusFileComp).Colors);
+                    Assert.Equal(mesh.Vertices.ToArray(), ((FusMesh)fusFileComp).Vertices);
+                    Assert.Equal(mesh.Triangles.ToArray(), ((FusMesh)fusFileComp).Triangles);
+                    Assert.Equal(mesh.UVs.ToArray(), ((FusMesh)fusFileComp).UVs);
                     Assert.Equal((int)mesh.MeshType, ((FusMesh)fusFileComp).MeshType);
-                    Assert.Equal(mesh.Tangents, ((FusMesh)fusFileComp).Tangents);
-                    Assert.Equal(mesh.BiTangents, ((FusMesh)fusFileComp).BiTangents);
+                    Assert.Equal(mesh.Tangents.ToArray(), ((FusMesh)fusFileComp).Tangents);
+                    Assert.Equal(mesh.BiTangents.ToArray(), ((FusMesh)fusFileComp).BiTangents);
                 }
 
                 if (gtComp is Weight weight)
@@ -216,7 +216,7 @@ namespace Fusee.Tests.Serialization.V1
             //Assert.Equal(t.Name, ((Transform)sceneFileComp).Name);
             //Assert.Equal(t.Rotation, ((Transform)sceneFileComp).Rotation);
             //Assert.Equal(t.Scale, ((Transform)sceneFileComp).Scale);
-            //Assert.Equal(t.Translation, ((Transform)sceneFileComp).Translation);                   
+            //Assert.Equal(t.Translation, ((Transform)sceneFileComp).Translation);
             //}
 
             //if (gtComp is Bone bone)


### PR DESCRIPTION
Closes: #525

This MR addresses some problems with the old `Mesh` and `MeshManager` implementation 

- Properties as arrays (costly defensive copies on every getter call)
- No `ChangedEvent` when changing a single value
- Re-creation of the complete OpenGL buffer when changing only one value

## Fixes:

- Continue using array backing field
- Use `ReadOnlySpan<T>` for user access
- Implemented `SetVertices()`, `SetTriangles()`, ... methods for changing the backing fields (call event for `MeshManager`, re-create whole OpenGL buffer)
- Implemented `SetVertex()`, `SetTriangle()`, ... methods (notice: no plural 😉) for changing a single value (call extra event for `MeshManager`, change element via OpenGL `SubBufferData`, do not re-create whole buffer!)
- Fixes problems with the `AABB` calculation after changing only one vertex (event for `MeshManager` did never occur) (fixes: #456)

## Additional info

- Does work for __Desktop__ and __Blazor__
- Implemented for __Android__, however I haven't been able to test as the implementation is currently broken furthermore, I've switched to Apple recently :P