### PR TITLE
ImGui: handle High-DPI, fix lagging mouse

### DIFF
--- a/Examples/Complete/ImGui/Desktop/Core.cs
+++ b/Examples/Complete/ImGui/Desktop/Core.cs
@@ -71,6 +71,9 @@ namespace Fusee.Examples.FuseeImGui.Desktop
 
         public override async void RenderAFrame()
         {
+            // Enable Dockspace
+            ImGui.GetIO().ConfigFlags |= ImGuiConfigFlags.DockingEnable;
+
             // Set Window flags for Dockspace
             var wndDockspaceFlags =
                     ImGuiWindowFlags.NoDocking

--- a/Examples/Complete/ImGui/Desktop/CoreControl.cs
+++ b/Examples/Complete/ImGui/Desktop/CoreControl.cs
@@ -175,7 +175,7 @@ namespace Fusee.Examples.FuseeImGui.Desktop
             _camPivotTransform.RotationQuaternion = QuaternionF.FromEuler(_angleVert, _angleHorz, 0);
             _renderer.Render(_rc);
 
-            return _renderTexture.TextureHandle;
+            return _renderTexture?.TextureHandle;
         }
 
         protected override void Resize(int width, int height)
@@ -197,7 +197,7 @@ namespace Fusee.Examples.FuseeImGui.Desktop
             {
                 if (disposing)
                 {
-                    _renderTexture.Dispose();
+                    _renderTexture?.Dispose();
                 }
 
 

--- a/Examples/Complete/PointCloudPotree2/ImGui/Core.cs
+++ b/Examples/Complete/PointCloudPotree2/ImGui/Core.cs
@@ -68,6 +68,9 @@ namespace Fusee.Examples.PointCloudPotree2.PotreeImGui
 
         public override void RenderAFrame()
         {
+            // Enable Dockspace
+            ImGui.GetIO().ConfigFlags |= ImGuiConfigFlags.DockingEnable;
+
             // Set Window flags for Dockspace
             var wndDockspaceFlags =
                     ImGuiWindowFlags.NoDocking

--- a/Examples/Complete/PointCloudPotree2/ImGui/Core.cs
+++ b/Examples/Complete/PointCloudPotree2/ImGui/Core.cs
@@ -57,12 +57,12 @@ namespace Fusee.Examples.PointCloudPotree2.PotreeImGui
 
         public override void Update()
         {
-            _fuControl.Update(_isMouseInsideFuControl);
+            _fuControl?.Update(_isMouseInsideFuControl);
         }
 
         public override void Resize(ResizeEventArgs e)
         {
-            _fuControl.UpdateOriginalGameWindowDimensions(e.Width, e.Height);
+            _fuControl?.UpdateOriginalGameWindowDimensions(e.Width, e.Height);
 
         }
 

--- a/Examples/Complete/PointCloudPotree2/ImGui/PointCloudControlCore.cs
+++ b/Examples/Complete/PointCloudPotree2/ImGui/PointCloudControlCore.cs
@@ -171,7 +171,7 @@ namespace Fusee.Examples.PointCloudPotree2.PotreeImGui
 
             ReadyToLoadNewFile = true;
 
-            return RenderTexture.TextureHandle;
+            return RenderTexture?.TextureHandle;
         }
 
         public override void Update(bool allowInput)

--- a/src/Engine/Imp/Graphics/Desktop/RenderContextImp.cs
+++ b/src/Engine/Imp/Graphics/Desktop/RenderContextImp.cs
@@ -458,18 +458,8 @@ namespace Fusee.Engine.Imp.Graphics.Desktop
             GL.BindTexture(TextureTarget.Texture2DMultisample, id);
 
             var glMinMagFilter = GetMinMagFilter(tex.FilterMode);
-            var minFilter = glMinMagFilter.Item1;
-            var magFilter = glMinMagFilter.Item2;
-            var glWrapMode = GetWrapMode(tex.WrapMode);
 
             GL.TexImage2DMultisample(TextureTargetMultisample.Texture2DMultisample, tex.MultisampleFactor, PixelInternalFormat.Rgba, tex.Width, tex.Height, true);
-
-            GL.TexParameter(TextureTarget.Texture2DMultisample, TextureParameterName.TextureCompareMode, (int)GetTexComapreMode(tex.CompareMode));
-            GL.TexParameter(TextureTarget.Texture2DMultisample, TextureParameterName.TextureCompareFunc, (int)GetDepthCompareFunc(tex.CompareFunc));
-            GL.TexParameter(TextureTarget.Texture2DMultisample, TextureParameterName.TextureMinFilter, (int)minFilter);
-            GL.TexParameter(TextureTarget.Texture2DMultisample, TextureParameterName.TextureMagFilter, (int)magFilter);
-            GL.TexParameter(TextureTarget.Texture2DMultisample, TextureParameterName.TextureWrapS, (int)glWrapMode);
-            GL.TexParameter(TextureTarget.Texture2DMultisample, TextureParameterName.TextureWrapT, (int)glWrapMode);
 
             ITextureHandle texID = new TextureHandle { TexHandle = id };
 

--- a/src/ImGui/Desktop/Fusee.ImGui.Desktop/ImGuiController.cs
+++ b/src/ImGui/Desktop/Fusee.ImGui.Desktop/ImGuiController.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Numerics;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 
 namespace Fusee.ImGuiDesktop
 {
@@ -49,8 +50,14 @@ namespace Fusee.ImGuiDesktop
 
         internal static int ShaderProgram;
         private static readonly Dictionary<string, UniformFieldInfo> _uniformVarToLocation = new();
+        private readonly RenderCanvasGameWindow _gw;
 
-        public ImGuiController(int width, int height) => WindowResized(width, height);
+        public ImGuiController(RenderCanvasGameWindow gw)
+        {
+            WindowResized(gw.Size.X, gw.Size.Y);
+            _gw = gw;
+
+        }
 
         public void WindowResized(int width, int height)
         {
@@ -82,6 +89,7 @@ namespace Fusee.ImGuiDesktop
             io.ConfigFlags |= ImGuiConfigFlags.DockingEnable;
             io.ConfigFlags |= ImGuiConfigFlags.NavEnableKeyboard;
 
+
             CreateDeviceResources();
             SetPerFrameImGuiData(1f / 60f);
             ImGuiInputImp.InitImGuiInput();
@@ -89,6 +97,8 @@ namespace Fusee.ImGuiDesktop
             // TODO(mr): Let user decide
             if (File.Exists("Assets/ImGuiSettings.ini"))
                 ImGui.LoadIniSettingsFromDisk("Assets/ImGuiSettings.ini");
+
+            io.MouseDrawCursor = true;
         }
 
         private static void CreateDeviceResources()
@@ -209,13 +219,16 @@ namespace Fusee.ImGuiDesktop
             io.Fonts.ClearTexData();
         }
 
+
         private void SetPerFrameImGuiData(float deltaSeconds)
         {
+            _gw.TryGetCurrentMonitorScale(out var hScale, out var vScale);
+            _scaleFactor = new Vector2(hScale, vScale);
+            var displaySizeX = GameWindowWidth / _scaleFactor.X;
+            var displaySizeY = GameWindowHeight / _scaleFactor.Y;
 
             ImGuiIOPtr io = ImGui.GetIO();
-            io.DisplaySize = new System.Numerics.Vector2(
-                GameWindowWidth / _scaleFactor.X,
-                GameWindowHeight / _scaleFactor.Y);
+            io.DisplaySize = new System.Numerics.Vector2(displaySizeX, displaySizeY);
             io.DisplayFramebufferScale = _scaleFactor;
             io.DeltaTime = deltaSeconds; // DeltaTime is in seconds.
         }

--- a/src/ImGui/Desktop/Fusee.ImGui.Desktop/ImGuiController.cs
+++ b/src/ImGui/Desktop/Fusee.ImGui.Desktop/ImGuiController.cs
@@ -89,6 +89,7 @@ namespace Fusee.ImGuiDesktop
             io.ConfigFlags |= ImGuiConfigFlags.DockingEnable;
             io.ConfigFlags |= ImGuiConfigFlags.NavEnableKeyboard;
 
+            io.ConfigInputTrickleEventQueue = false;
 
             CreateDeviceResources();
             SetPerFrameImGuiData(1f / 60f);
@@ -98,7 +99,7 @@ namespace Fusee.ImGuiDesktop
             if (File.Exists("Assets/ImGuiSettings.ini"))
                 ImGui.LoadIniSettingsFromDisk("Assets/ImGuiSettings.ini");
 
-            io.MouseDrawCursor = true;
+            //io.MouseDrawCursor = true;
         }
 
         private static void CreateDeviceResources()
@@ -236,7 +237,7 @@ namespace Fusee.ImGuiDesktop
         public void UpdateImGui(float DeltaTimeUpdate)
         {
             SetPerFrameImGuiData(DeltaTimeUpdate);
-            ImGuiInputImp.UpdateImGuiInput();
+            ImGuiInputImp.UpdateImGuiInput(_scaleFactor);
 
             ImGui.NewFrame();
         }

--- a/src/ImGui/Desktop/Fusee.ImGui.Desktop/ImGuiController.cs
+++ b/src/ImGui/Desktop/Fusee.ImGui.Desktop/ImGuiController.cs
@@ -86,7 +86,6 @@ namespace Fusee.ImGuiDesktop
             }
 
             io.BackendFlags |= ImGuiBackendFlags.RendererHasVtxOffset;
-            io.ConfigFlags |= ImGuiConfigFlags.DockingEnable;
             io.ConfigFlags |= ImGuiConfigFlags.NavEnableKeyboard;
 
             io.ConfigInputTrickleEventQueue = false;

--- a/src/ImGui/Desktop/Fusee.ImGui.Desktop/ImGuiInputImp.cs
+++ b/src/ImGui/Desktop/Fusee.ImGui.Desktop/ImGuiInputImp.cs
@@ -5,6 +5,7 @@ using ImGuiNET;
 using OpenTK.Windowing.Desktop;
 using System;
 using System.Collections.Generic;
+using System.Numerics;
 
 namespace Fusee.ImGuiDesktop
 {
@@ -297,17 +298,18 @@ namespace Fusee.ImGuiDesktop
             };
         }
 
-        public static void UpdateImGuiInput()
+        public static void UpdateImGuiInput(Vector2 scaleFactor)
         {
             var io = ImGui.GetIO();
             io.ClearInputCharacters();
 
-            io.AddMousePosEvent(Input.Mouse.X, Input.Mouse.Y);
+
+            io.AddMousePosEvent(Input.Mouse.X / scaleFactor.X, Input.Mouse.Y / scaleFactor.Y);
             io.AddMouseButtonEvent(0, Input.Mouse.LeftButton);
             io.AddMouseButtonEvent(1, Input.Mouse.MiddleButton);
             io.AddMouseButtonEvent(2, Input.Mouse.RightButton);
 
-            io.AddMouseWheelEvent(0, Input.Mouse.Wheel);
+            io.AddMouseWheelEvent(0, Input.Mouse.WheelVel * 0.01f);
 
 
             io.KeyShift = Input.Keyboard.IsKeyDown(KeyCodes.LShift) || Input.Keyboard.IsKeyDown(KeyCodes.RShift);

--- a/src/ImGui/Desktop/Fusee.ImGui.Desktop/ImGuiRenderCanvasImp.cs
+++ b/src/ImGui/Desktop/Fusee.ImGui.Desktop/ImGuiRenderCanvasImp.cs
@@ -78,10 +78,6 @@ namespace Fusee.ImGuiDesktop
 
             _gameWindow.CenterWindow();
 
-            _gameWindow.CursorState = OpenTK.Windowing.Common.CursorState.Hidden; // let ImGui Render the cursor
-
-
-
             _controller = new ImGuiController(_gameWindow);
         }
 

--- a/src/ImGui/Desktop/Fusee.ImGui.Desktop/ImGuiRenderCanvasImp.cs
+++ b/src/ImGui/Desktop/Fusee.ImGui.Desktop/ImGuiRenderCanvasImp.cs
@@ -58,6 +58,7 @@ namespace Fusee.ImGuiDesktop
 
         public ImGuiRenderCanvasImp(ImageData? icon = null, bool isMultithreaded = false)
         {
+
             int width = 1280;
             int height = 720;
 
@@ -76,28 +77,12 @@ namespace Fusee.ImGuiDesktop
             };
 
             _gameWindow.CenterWindow();
-            if (_gameWindow.IsMultiThreaded)
-                _gameWindow.Context.MakeNoneCurrent();
 
-            // convert icon to OpenTKImage
-            //if (icon != null)
-            //{
-            //    // convert Bgra to Rgba for OpenTK.WindowIcon
-            //    var pxData = SixLabors.ImageSharp.Image.LoadPixelData<Bgra32>(icon.PixelData, icon.Width, icon.Height);
-            //    var bgra = pxData.CloneAs<Rgba32>();
-            //    bgra.Mutate(x => x.AutoOrient());
-            //    bgra.Mutate(x => x.RotateFlip(RotateMode.None, FlipMode.Vertical));
-            //
-            //    if (!bgra.DangerousTryGetSinglePixelMemory(out var res))
-            //    {
-            //        Diagnostics.Warn("Couldn't convert icon image to Rgba32!");
-            //        return;
-            //    }
-            //    var resBytes = MemoryMarshal.AsBytes<Rgba32>(res.ToArray());
-            //    _gameWindow.Icon = new WindowIcon(new Image[] { new Image(icon.Width, icon.Height, resBytes.ToArray()) });
-            //}
+            _gameWindow.CursorState = OpenTK.Windowing.Common.CursorState.Hidden; // let ImGui Render the cursor
 
-            _controller = new ImGuiController(_gameWindow.Size.X, _gameWindow.Size.Y);
+
+
+            _controller = new ImGuiController(_gameWindow);
         }
 
         public void Run()
@@ -106,6 +91,7 @@ namespace Fusee.ImGuiDesktop
             {
                 _gameWindow.UpdateFrequency = 0;
                 _gameWindow.RenderFrequency = 0;
+                _gameWindow.VSync = OpenTK.Windowing.Common.VSyncMode.Adaptive;
 
                 _gameWindow.Run();
             }
@@ -169,7 +155,7 @@ namespace Fusee.ImGuiDesktop
         protected internal void DoResize(int width, int height)
         {
             Resize?.Invoke(this, new ResizeEventArgs(width, height));
-            _controller.WindowResized(width, height);
+            _controller?.WindowResized(width, height);
         }
 
         public void SetCursor(CursorType cursorType)


### PR DESCRIPTION
Closes: https://github.com/FUSEEProjectTeam/Fusee/issues/550

This PR introduces a high dpi scaling and ~~uses `ImGui's` mouse cursor to prevent having a superfast hardware mouse cursor in lagging applications.~~ (this did not work out as expected).
Disabled `io.ConfigInputTrickleEventQueue` which caused the lagging mouse cursor. Should now work as expected.
Therefore, reverted to hardware mouse cursor and fixed the scrolling wheel behavior on the way.
Also removed `GL.TexParameter` for `MultisampleTexture` which isn't allowed by `OpenGL`.
