### PR TITLE
Feature/555 writable multisample tex without RC

### DIFF
--- a/Examples/Complete/ImGui/Desktop/CoreControl.cs
+++ b/Examples/Complete/ImGui/Desktop/CoreControl.cs
@@ -177,7 +177,6 @@ namespace Fusee.Examples.FuseeImGui.Desktop
             {
                 _camPivotTransform.RotationQuaternion = QuaternionF.FromEuler(_angleVert, _angleHorz, 0);
                 _renderer.Render(_rc);
-                _rc.BlitMultisample2DTextureToTexture(_renderTexture, _renderTexture.InternalResultTexture);
             }
             return _renderTexture?.TextureHandle;
         }

--- a/Examples/Complete/ImGui/Desktop/CoreControl.cs
+++ b/Examples/Complete/ImGui/Desktop/CoreControl.cs
@@ -173,9 +173,12 @@ namespace Fusee.Examples.FuseeImGui.Desktop
 
         protected override ITextureHandle RenderAFrame()
         {
-            _camPivotTransform.RotationQuaternion = QuaternionF.FromEuler(_angleVert, _angleHorz, 0);
-            _renderer.Render(_rc);
-
+            if (_renderTexture != null)
+            {
+                _camPivotTransform.RotationQuaternion = QuaternionF.FromEuler(_angleVert, _angleHorz, 0);
+                _renderer.Render(_rc);
+                _rc.BlitMultisample2DTextureToTexture(_renderTexture, _renderTexture.InternalResultTexture);
+            }
             return _renderTexture?.TextureHandle;
         }
 
@@ -188,7 +191,7 @@ namespace Fusee.Examples.FuseeImGui.Desktop
             Height = height;
 
             _renderTexture?.Dispose();
-            _renderTexture = WritableMultisampleTexture.CreateAlbedoTex(_rc, Width, Height, 8);
+            _renderTexture = WritableMultisampleTexture.CreateAlbedoTex(Width, Height, 8);
             _cam.RenderTexture = _renderTexture;
         }
 

--- a/src/Engine/Common/IRenderContextImp.cs
+++ b/src/Engine/Common/IRenderContextImp.cs
@@ -739,7 +739,7 @@ namespace Fusee.Engine.Common
         /// <param name="output">WritableTexture</param>
         /// <param name="height">Height of texture</param>
         /// <param name="width">Height of texture</param>
-        void BlitMultisample2DTextureToTexture(ITextureHandle input, ITextureHandle output, int width, int height);
+        void BlitMultisample2DTextureToTexture(IWritableTexture input, IWritableTexture output);
 
         /// <summary>
         /// Renders into the given textures of the RenderTarget.

--- a/src/Engine/Core/RenderContext.cs
+++ b/src/Engine/Core/RenderContext.cs
@@ -1844,11 +1844,9 @@ namespace Fusee.Engine.Core
         /// </summary>
         /// <param name="input">WritableMultisampleTexture</param>
         /// <param name="output">WritableTexture</param>
-        /// <param name="width">Texture width</param>
-        /// <param name="height">Texture height</param>
-        public void BlitMultisample2DTextureToTexture(ITextureHandle input, ITextureHandle output, int width, int height)
+        public void BlitMultisample2DTextureToTexture(WritableMultisampleTexture input, WritableTexture output)
         {
-            _rci.BlitMultisample2DTextureToTexture(input, output, width, height);
+            _rci.BlitMultisample2DTextureToTexture(input, output);
         }
 
         /// <summary>

--- a/src/Engine/Core/SceneRendererDeferred.cs
+++ b/src/Engine/Core/SceneRendererDeferred.cs
@@ -498,6 +498,13 @@ namespace Fusee.Engine.Core
             }
 
             RenderAllPasses(viewport, renderTex);
+
+
+            // if we have a multisample texture we need to blt the result of our rendering to the result texture
+            if (cam.Camera.RenderTexture is WritableMultisampleTexture wmt)
+            {
+                _rc.BlitMultisample2DTextureToTexture(wmt, wmt.InternalResultTexture);
+            }
         }
 
         private void RenderAllPasses(float4 lightingPassViewport, IWritableTexture renderTex = null)

--- a/src/Engine/Core/SceneRendererForward.cs
+++ b/src/Engine/Core/SceneRendererForward.cs
@@ -380,6 +380,12 @@ namespace Fusee.Engine.Core
 
             Traverse(_sc.Children);
 
+            // if we have a multisample texture we need to blt the result of our rendering to the result texture
+            if(tex is WritableMultisampleTexture wmt)
+            {
+                _rc.BlitMultisample2DTextureToTexture(wmt, wmt.InternalResultTexture);
+            }
+
         }
 
         /// <summary>

--- a/src/Engine/Core/TextureManager.cs
+++ b/src/Engine/Core/TextureManager.cs
@@ -77,8 +77,10 @@ namespace Fusee.Engine.Core
             // Configure newly created TextureHandle to reflect Texture's properties on GPU (allocate buffers)
             // Generate the multi-sample texture, as well as the result texture where the final image is being blit to
             ITextureHandle textureHandle = _renderContextImp.CreateTexture(texture);
-
             texture.InternalTextureHandle = textureHandle;
+
+            ITextureHandle internalTexHandle = _renderContextImp.CreateTexture(texture.InternalResultTexture);
+            texture.InternalResultTexture.TextureHandle = internalTexHandle;
 
             // Setup handler to observe changes of the texture data and dispose event (deallocation)
             texture.TextureChanged += TextureChanged;

--- a/src/Engine/Core/WritableMultisampleTexture.cs
+++ b/src/Engine/Core/WritableMultisampleTexture.cs
@@ -1,4 +1,4 @@
-﻿using Fusee.Base.Common;
+using Fusee.Base.Common;
 using Fusee.Engine.Common;
 using System;
 
@@ -56,8 +56,10 @@ namespace Fusee.Engine.Core
         /// </summary>
         public Compare CompareFunc { get; private set; }
 
-        private WritableTexture _internalResultTexture;
-        private readonly RenderContext RC;
+        /// <summary>
+        /// Renderable result texture.
+        /// </summary>
+        public WritableTexture InternalResultTexture { get; private set; }
 
         /// <summary>
         /// Opaque handle to texture, this is the internal handle, which can be used. However this is not yet sampled to one result texture
@@ -77,15 +79,7 @@ namespace Fusee.Engine.Core
         {
             get
             {
-                if (_internalResultTexture == null)
-                {
-                    _internalResultTexture = WritableTexture.CreateAlbedoTex(Width, Height, PixelFormat);
-                    // set it once, therefore all framebuffer, etc. are being generated
-                    RC.SetRenderTarget(_internalResultTexture);
-                }
-
-                RC.BlitMultisample2DTextureToTexture(InternalTextureHandle, _internalResultTexture.TextureHandle, Width, Height);
-                return _internalResultTexture.TextureHandle;
+                return InternalResultTexture.TextureHandle;
             }
         }
 
@@ -104,7 +98,6 @@ namespace Fusee.Engine.Core
         /// </summary>
         public TextureFilterMode FilterMode { get; private set; }
 
-
         private bool disposedValue;
 
         /// <summary>
@@ -120,7 +113,7 @@ namespace Fusee.Engine.Core
         /// <param name="wrapMode">Defines the wrapping mode <see cref="TextureWrapMode"/>.</param>
         /// <param name="compareMode">The textures compare mode. If uncertain, leaf on NONE, this is only important for depth (shadow) textures (<see cref="TextureCompareMode"/>).</param>
         /// <param name="compareFunc">The textures compare function. If uncertain, leaf on LEESS, this is only important for depth (shadow) textures and if the CompareMode isn't NONE (<see cref="Compare"/>)</param>
-        public WritableMultisampleTexture(RenderContext rc, RenderTargetTextureTypes texType, ImagePixelFormat colorFormat, int width, int height, int multisampleFactor = 4, TextureFilterMode filterMode = TextureFilterMode.NearestMipmapLinear, TextureWrapMode wrapMode = TextureWrapMode.Repeat, TextureCompareMode compareMode = TextureCompareMode.None, Compare compareFunc = Compare.Less)
+        public WritableMultisampleTexture(RenderTargetTextureTypes texType, ImagePixelFormat colorFormat, int width, int height, int multisampleFactor = 4, TextureFilterMode filterMode = TextureFilterMode.NearestMipmapLinear, TextureWrapMode wrapMode = TextureWrapMode.Repeat, TextureCompareMode compareMode = TextureCompareMode.None, Compare compareFunc = Compare.Less)
         {
             //var maxSamples = rc.GetHardwareCapabilities(HardwareCapability.MaxSamples);
             //if(maxSamples == 0)
@@ -143,7 +136,8 @@ namespace Fusee.Engine.Core
             CompareMode = compareMode;
             CompareFunc = compareFunc;
             MultisampleFactor = multisampleFactor;
-            RC = rc;
+
+            InternalResultTexture = WritableTexture.CreateAlbedoTex(Width, Height, PixelFormat);
         }
 
         /// <summary>
@@ -153,10 +147,14 @@ namespace Fusee.Engine.Core
         /// <param name="width">Width in px.</param>
         /// <param name="height">Height in px.</param>
         /// <param name="multisampleFactor">Define how many samples are being used to sample this texture, default: 4</param>
-        public static WritableMultisampleTexture CreateAlbedoTex(RenderContext rc, int width, int height, int multisampleFactor = 4)
+        public static WritableMultisampleTexture CreateAlbedoTex(int width, int height, int multisampleFactor = 4)
         {
-            return new WritableMultisampleTexture(rc, RenderTargetTextureTypes.Albedo, new ImagePixelFormat(ColorFormat.RGBA),
-                width, height, multisampleFactor);
+            var pxFormat = new ImagePixelFormat(ColorFormat.RGBA);
+            var resTex = new WritableMultisampleTexture(RenderTargetTextureTypes.Albedo, pxFormat, width, height, multisampleFactor);
+
+            resTex.InternalResultTexture = WritableTexture.CreateAlbedoTex(resTex.Width, resTex.Height, pxFormat);
+
+            return resTex;
         }
 
         /// <summary>
@@ -170,6 +168,7 @@ namespace Fusee.Engine.Core
                 if (disposing)
                 {
                     TextureChanged?.Invoke(this, new TextureEventArgs(this, TextureChangedEnum.Disposed));
+                    InternalResultTexture.Dispose();
                 }
 
                 disposedValue = true;

--- a/src/Engine/Imp/Graphics/Android/RenderContextImp.cs
+++ b/src/Engine/Imp/Graphics/Android/RenderContextImp.cs
@@ -2331,7 +2331,7 @@ namespace Fusee.Engine.Imp.Graphics.Android
         /// </summary>
         /// <param name="input">WritableMultisampleTexture</param>
         /// <param name="output">WritableTexture</param>
-        public void BlitMultisample2DTextureToTexture(ITextureHandle input, ITextureHandle output, int width, int height)
+        public void BlitMultisample2DTextureToTexture(IWritableTexture input, IWritableTexture output)
         {
             throw new NotSupportedException("Android has no MultisampleWritableTexture support!");
         }

--- a/src/Engine/Imp/Graphics/Blazor/RenderContextImp.cs
+++ b/src/Engine/Imp/Graphics/Blazor/RenderContextImp.cs
@@ -2419,7 +2419,7 @@ namespace Fusee.Engine.Imp.Graphics.Blazor
         /// </summary>
         /// <param name="input">WritableMultisampleTexture</param>
         /// <param name="output">WritableTexture</param>
-        public void BlitMultisample2DTextureToTexture(ITextureHandle input, ITextureHandle output, int width, int height)
+        public void BlitMultisample2DTextureToTexture(IWritableTexture input, IWritableTexture output)
         {
             throw new NotSupportedException("Blazor has no MultisampleWritableTexture support!");
         }

--- a/src/Engine/Imp/Graphics/Desktop/RenderCanvasImp.cs
+++ b/src/Engine/Imp/Graphics/Desktop/RenderCanvasImp.cs
@@ -8,7 +8,6 @@ using SixLabors.ImageSharp.PixelFormats;
 using SixLabors.ImageSharp.Processing;
 using System;
 using System.Diagnostics;
-using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Image = OpenTK.Windowing.Common.Input.Image;

--- a/src/ImGui/Desktop/Fusee.ImGui.Desktop/ImGuiController.cs
+++ b/src/ImGui/Desktop/Fusee.ImGui.Desktop/ImGuiController.cs
@@ -8,7 +8,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Numerics;
 using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
 
 namespace Fusee.ImGuiImp.Desktop
 {

--- a/src/ImGui/Desktop/Fusee.ImGui.Desktop/Templates/FuseeControlToTexture.cs
+++ b/src/ImGui/Desktop/Fusee.ImGui.Desktop/Templates/FuseeControlToTexture.cs
@@ -109,10 +109,6 @@ namespace Fusee.ImGuiImp.Desktop.Templates
             _rc.SetRenderTarget();
             _rc.Viewport(0, 0, _originalWidth, _originalHeight);
 
-
-            _rc.SetRenderTarget();
-            _rc.Viewport(0, 0, _originalWidth, _originalHeight);
-
             // Warning: wolves ahead
             if (prgmHndl == null)
                 prgmHndl = new ShaderHandle() { Handle = ImGuiController.ShaderProgram };


### PR DESCRIPTION
# Summary

Removes the reference to the `RenderContext` from `WritableMultisampleTexture`