### PR TITLE
Impl isAppClosing functionality

### DIFF
--- a/src/Engine/Common/IRenderCanvasImp.cs
+++ b/src/Engine/Common/IRenderCanvasImp.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.ComponentModel;
 
 namespace Fusee.Engine.Common
 {
@@ -63,7 +64,7 @@ namespace Fusee.Engine.Common
 
         /// <summary>
         /// Implementation Tasks: Gets and sets a value indicating whether this <see cref="IRenderCanvasImp"/> is in fullscreen mode.
-        /// This option can not be applied to all plattforms. 
+        /// This option can not be applied to all plattforms.
         /// </summary>
         /// <value>
         ///   <c>true</c> if fullscreen; otherwise, <c>false</c>.
@@ -166,5 +167,9 @@ namespace Fusee.Engine.Common
         /// Occurs when [Resize] is called.
         /// </summary>
         event EventHandler<ResizeEventArgs> Resize;
+        /// <summary>
+        /// Occurs when [Close] is called.
+        /// </summary>
+        event EventHandler<CancelEventArgs> Closing;
     }
 }

--- a/src/Engine/Core/RenderCanvas.cs
+++ b/src/Engine/Core/RenderCanvas.cs
@@ -2,6 +2,7 @@ using Fusee.Base.Common;
 using Fusee.Base.Core;
 using Fusee.Engine.Common;
 using System;
+using System.ComponentModel;
 using System.Threading.Tasks;
 
 namespace Fusee.Engine.Core
@@ -72,7 +73,7 @@ namespace Fusee.Engine.Core
         /// <summary>
         /// Used to inject functionality that is meant to be executed when the application is shutting down.
         /// </summary>
-        public event EventHandler? ApplicationIsShuttingDown;
+        public event EventHandler<CancelEventArgs>? ApplicationIsShuttingDown;
 
         /// <summary>
         /// Used to inject functionality that is meant to execute at the end of each frame. E.g. if components of the SceneGraph need to be changed.
@@ -90,8 +91,7 @@ namespace Fusee.Engine.Core
             private set
             {
                 _isShuttingDown = value;
-                if (_isShuttingDown)
-                    ApplicationIsShuttingDown?.Invoke(this, new EventArgs());
+
             }
         }
         private bool _isShuttingDown;
@@ -190,6 +190,12 @@ namespace Fusee.Engine.Core
             RC.GetWindowWidth = () => CanvasImplementor.Width;
 
             VideoManager.Instance.VideoManagerImp = VideoManagerImplementor;
+
+            CanvasImplementor.Closing += (s, e) =>
+            {
+                ApplicationIsShuttingDown?.Invoke(this, e);
+                IsShuttingDown = !e.Cancel; // only set shutdown if not canceled
+            };
 
             CanvasImplementor.Init += async delegate
             {

--- a/src/Engine/Imp/Graphics/Android/RenderCanvasImp.cs
+++ b/src/Engine/Imp/Graphics/Android/RenderCanvasImp.cs
@@ -7,6 +7,7 @@ using OpenTK.Graphics;
 using OpenTK.Graphics.ES30;
 using OpenTK.Platform.Android;
 using System;
+using System.ComponentModel;
 using System.Diagnostics;
 using Uri = Android.Net.Uri;
 
@@ -308,6 +309,11 @@ namespace Fusee.Engine.Imp.Graphics.Android
         /// </summary>
         public event EventHandler<ResizeEventArgs> Resize;
 
+        /// <summary>
+        /// Occurs when [closing] - not wired, dummy impl.
+        /// </summary>
+        public event EventHandler<CancelEventArgs> Closing;
+
         #endregion Events
 
         /// <summary>
@@ -459,7 +465,7 @@ namespace Fusee.Engine.Imp.Graphics.Android
                 _renderCanvasImp.DoRender();
         }
 
-        // This method is called every time the context needs to be recreated. 
+        // This method is called every time the context needs to be recreated.
         //Use it to set any egl-specific settings prior to context creation.
         protected override void CreateFrameBuffer()
         {

--- a/src/Engine/Imp/Graphics/Blazor/RenderCanvasImp.cs
+++ b/src/Engine/Imp/Graphics/Blazor/RenderCanvasImp.cs
@@ -2,7 +2,7 @@ using Fusee.Base.Imp.Blazor;
 using Fusee.Engine.Common;
 using Microsoft.JSInterop;
 using System;
-
+using System.ComponentModel;
 
 namespace Fusee.Engine.Imp.Graphics.Blazor
 {
@@ -104,12 +104,18 @@ namespace Fusee.Engine.Imp.Graphics.Blazor
         public event EventHandler<RenderEventArgs> Update;
 
         /// <summary>
+        /// Occurs when closing the application
+        /// </summary>
+        public event EventHandler<CancelEventArgs> Closing;
+
+        /// <summary>
         /// Closes the game window.
         /// </summary>
         /// <remarks>Not needed in WebGL.</remarks>
         public void CloseGameWindow()
         {
             UnLoad?.Invoke(this, null);
+            Closing.Invoke(this, null);
         }
 
         /// <summary>
@@ -128,7 +134,7 @@ namespace Fusee.Engine.Imp.Graphics.Blazor
         /// </summary>
         public void Present()
         {
-            // Nothing to do in WebGL            
+            // Nothing to do in WebGL
         }
 
         /// <summary>

--- a/src/Engine/Imp/Graphics/Desktop/RenderCanvasGameWindow.cs
+++ b/src/Engine/Imp/Graphics/Desktop/RenderCanvasGameWindow.cs
@@ -2,6 +2,7 @@
 using OpenTK.Windowing.Desktop;
 using OpenTK.Windowing.GraphicsLibraryFramework;
 using System;
+using System.ComponentModel;
 
 namespace Fusee.Engine.Imp.Graphics.Desktop
 {
@@ -95,9 +96,9 @@ namespace Fusee.Engine.Imp.Graphics.Desktop
             int major = version[0];
             // int minor = (int)version[2];
 
-            if (major < 2)
+            if (major < 3)
             {
-                throw new InvalidOperationException("You need at least OpenGL 2.0 to run this example. GLSL not supported.");
+                throw new InvalidOperationException("You need at least OpenGL 3.0 to run this application. GLSL not supported.");
             }
 
             // Use VSync!
@@ -121,6 +122,12 @@ namespace Fusee.Engine.Imp.Graphics.Desktop
                 _renderCanvasImp.Height = e.Height;
                 _renderCanvasImp.DoResize(e.Width, e.Height);
             }
+        }
+
+        protected override void OnClosing(CancelEventArgs e)
+        {
+            _renderCanvasImp.DoClose(e);
+            base.OnClosing(e);
         }
 
         protected override void OnUpdateFrame(OpenTK.Windowing.Common.FrameEventArgs args)

--- a/src/Engine/Imp/Graphics/Desktop/RenderCanvasImp.cs
+++ b/src/Engine/Imp/Graphics/Desktop/RenderCanvasImp.cs
@@ -7,6 +7,7 @@ using OpenTK.Windowing.Desktop;
 using SixLabors.ImageSharp.PixelFormats;
 using SixLabors.ImageSharp.Processing;
 using System;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -313,6 +314,11 @@ namespace Fusee.Engine.Imp.Graphics.Desktop
         /// </summary>
         public event EventHandler<ResizeEventArgs> Resize;
 
+        /// <summary>
+        /// Occurs when [close] is called.
+        /// </summary>
+        public event EventHandler<CancelEventArgs> Closing;
+
         #endregion
 
         #region Members
@@ -349,7 +355,6 @@ namespace Fusee.Engine.Imp.Graphics.Desktop
         {
             UnLoad?.Invoke(this, new InitEventArgs());
         }
-
         /// <summary>
         /// Does the update of this instance.
         /// </summary>
@@ -364,6 +369,14 @@ namespace Fusee.Engine.Imp.Graphics.Desktop
         public virtual void DoRender()
         {
             Render?.Invoke(this, new RenderEventArgs());
+        }
+
+        /// <summary>
+        /// Does close the window
+        /// </summary>
+        public virtual void DoClose(CancelEventArgs e)
+        {
+            Closing?.Invoke(this, e);
         }
 
         /// <summary>


### PR DESCRIPTION
Closes: #810 

Added/modified existing event `public event EventHandler<CancelEventArgs>? ApplicationIsShuttingDown;`

This event is now called when `CloseGameWindow`-methods AND/OR the window close button 'x' is used.
One has now the possibility to cancel the current shutdown by setting the `CancelEventArgs.Cancel` to `true`. This should provide a neat possibility to ask the user if they want to really close the application before shutting down.


