### PR TITLE
Feature/817 prepare filefolder picker for internationalization/localization

### DIFF
--- a/src/ImGui/Desktop/Fusee.ImGui.Desktop/Templates/ImGuiFilePicker.cs
+++ b/src/ImGui/Desktop/Fusee.ImGui.Desktop/Templates/ImGuiFilePicker.cs
@@ -24,7 +24,6 @@ namespace Fusee.ImGuiImp.Desktop.Templates
         /// </summary>
         public bool AllowFilePickerResize { get; set; } = true;
 
-
         /// <summary>
         /// Allow resizing of new folder window
         /// </summary>

--- a/src/ImGui/Desktop/Fusee.ImGui.Desktop/Templates/ImGuiFilePicker.cs
+++ b/src/ImGui/Desktop/Fusee.ImGui.Desktop/Templates/ImGuiFilePicker.cs
@@ -1,7 +1,6 @@
 using ImGuiNET;
 using System;
 using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations;
 using System.IO;
 using System.Numerics;
 
@@ -82,19 +81,8 @@ namespace Fusee.ImGuiImp.Desktop.Templates
         /// <summary>
         /// Show a button which let's the user create a new folder at the current directory
         /// </summary>
-        public bool ShowNewFolderButton
-        {
-            get => _showNewFolderButton;
-            set
-            {
-                if (value)
-                    DriveSelectionWidth = 120;
-                else
-                    DriveSelectionWidth = 100;
+        public bool ShowNewFolderButton { get; set; }
 
-                _showNewFolderButton = value;
-            }
-        }
         public string NewFolderButtonTxt = "\uf65e";
 
         /// <summary>
@@ -112,7 +100,6 @@ namespace Fusee.ImGuiImp.Desktop.Templates
         /// </summary>
         public string CreateNewFolderHintTxt = "Insert folder name";
 
-        private bool _showNewFolderButton;
         private bool _isNewFolderNameWindowOpen;
 
         // as we cannot use the property as ref, we need to check and set all variables every time
@@ -166,15 +153,12 @@ namespace Fusee.ImGuiImp.Desktop.Templates
         protected DirectoryInfo CurrentlySelectedFolder;
         protected readonly DirectoryInfo StartingFolder;
 
-        protected const float FolderTextInputWidth = 350;
-        protected const float FileTextInputWidth = 350;
-        protected static float DriveSelectionWidth = 100;
-        protected const float BrowserHeight = 200;
         protected readonly Vector2 WindowPadding = new(15, 15);
         protected readonly Vector2 BottomButtonSize = new(55, 26);
         protected readonly Vector2 TopButtonSize = new(35, 30);
-        protected Vector2 WinSize;
+
         protected bool DoFocusPicker = true;
+
 
         private static int _filePickerCount = 0;
 
@@ -653,7 +637,14 @@ namespace Fusee.ImGuiImp.Desktop.Templates
                 {
                     try
                     {
-                        Directory.CreateDirectory(Path.Combine(currentFolder.FullName, _newFolderName));
+                        if (Path.IsPathRooted(_newFolderName))
+                        {
+                            Directory.CreateDirectory(_newFolderName);
+                        }
+                        else
+                        {
+                            Directory.CreateDirectory(Path.Combine(currentFolder.FullName, _newFolderName));
+                        }
                     }
                     catch (Exception ex)
                     {

--- a/src/ImGui/Desktop/Fusee.ImGui.Desktop/Templates/ImGuiFilePicker.cs
+++ b/src/ImGui/Desktop/Fusee.ImGui.Desktop/Templates/ImGuiFilePicker.cs
@@ -566,7 +566,8 @@ namespace Fusee.ImGuiImp.Desktop.Templates
                 {
                     ImGui.SameLine();
 
-                    if (ImGui.Button($"{PickedFileTxt}##{_filePickerCount}", pickedFileButtonSize) || ImGui.IsKeyReleased(ImGuiKey.Enter))
+                    if (ImGui.Button($"{PickedFileTxt}##{_filePickerCount}", pickedFileButtonSize) ||
+                        (ImGui.IsKeyReleased(ImGuiKey.Enter) && !IsNewFolderNameWindowOpen))
                     {
                         if (HandlePickedFile(fi))
                         {
@@ -631,7 +632,8 @@ namespace Fusee.ImGuiImp.Desktop.Templates
             });
             ImGui.SameLine();
 
-            if (ImGui.Button($"{CreateFolderTxt}", createFolderButtonSize))
+            if (ImGui.Button($"{CreateFolderTxt}", createFolderButtonSize) ||
+                ImGui.IsKeyReleased(ImGuiKey.Enter))
             {
                 if (!string.IsNullOrEmpty(_newFolderName))
                 {

--- a/src/ImGui/Desktop/Fusee.ImGui.Desktop/Templates/ImGuiFilePicker.cs
+++ b/src/ImGui/Desktop/Fusee.ImGui.Desktop/Templates/ImGuiFilePicker.cs
@@ -635,15 +635,18 @@ namespace Fusee.ImGuiImp.Desktop.Templates
             {
                 if (!string.IsNullOrEmpty(_newFolderName))
                 {
+                    var folderName = string.Empty;
                     try
                     {
                         if (Path.IsPathRooted(_newFolderName))
                         {
+                            folderName = _newFolderName;
                             Directory.CreateDirectory(_newFolderName);
                         }
                         else
                         {
-                            Directory.CreateDirectory(Path.Combine(currentFolder.FullName, _newFolderName));
+                            folderName = Path.Combine(currentFolder.FullName, _newFolderName);
+                            Directory.CreateDirectory(folderName);
                         }
                     }
                     catch (Exception ex)
@@ -652,6 +655,11 @@ namespace Fusee.ImGuiImp.Desktop.Templates
                         return;
 
                     }
+
+                    // open new folder
+                    CurrentlySelectedFolder = new DirectoryInfo(folderName);
+                    LastOpenendFolders.Push(CurrentOpenFolder);
+                    CurrentOpenFolder = new DirectoryInfo(folderName);
                 }
                 IsNewFolderNameWindowOpen = false;
             }

--- a/src/ImGui/Desktop/Fusee.ImGui.Desktop/Templates/ImGuiFilePicker.cs
+++ b/src/ImGui/Desktop/Fusee.ImGui.Desktop/Templates/ImGuiFilePicker.cs
@@ -157,7 +157,7 @@ namespace Fusee.ImGuiImp.Desktop.Templates
         protected readonly DirectoryInfo StartingFolder;
 
         protected const float FolderTextInputWidth = 350;
-        protected const float FileTextInputWidth = 300;
+        protected const float FileTextInputWidth = 350;
         protected static float DriveSelectionWidth = 100;
         protected const float BrowserHeight = 200;
         protected readonly Vector2 WindowPadding = new(15, 15);
@@ -259,6 +259,7 @@ namespace Fusee.ImGuiImp.Desktop.Templates
 
                 AllowedExtensions.AddRange(allowedExtensions.Split(new char[] { '|' }, StringSplitOptions.RemoveEmptyEntries));
             }
+
         }
 
         public virtual unsafe void Draw(ref bool filePickerOpen)
@@ -277,11 +278,16 @@ namespace Fusee.ImGuiImp.Desktop.Templates
                 filePickerOpen = false;
             }
 
+            var openFileTextSize = ImGui.CalcTextSize(PickedFileTxt) + new Vector2(7, 11);
+            var cancelFileTextSize = ImGui.CalcTextSize(CancelFileOpenTxt) + new Vector2(7, 11);
+
             if (DoFocusPicker)
                 ImGui.SetNextWindowFocus();
             var headerHeight = FontSize + WindowPadding.Y * 2;
             var itemSpacing = ImGui.GetStyle().ItemSpacing;
-            WinSize = new Vector2(FolderTextInputWidth + DriveSelectionWidth + (WindowPadding.X * 2) + itemSpacing.X, headerHeight + BrowserHeight + TopButtonSize.Y + BottomButtonSize.Y + 4 * WindowPadding.Y + 3 * itemSpacing.Y + 5);
+            WinSize = new Vector2(
+                FolderTextInputWidth + DriveSelectionWidth + (WindowPadding.X * 2) + itemSpacing.X + openFileTextSize.X + cancelFileTextSize.X,
+                headerHeight + BrowserHeight + TopButtonSize.Y + BottomButtonSize.Y + (openFileTextSize.Y / 2) + 4 * WindowPadding.Y + 3 * itemSpacing.Y + 5);
             ImGui.SetNextWindowSize(WinSize);
             ImGui.Begin(Id, ref filePickerOpen, ImGuiWindowFlags.Modal | ImGuiWindowFlags.NoCollapse | ImGuiWindowFlags.AlwaysAutoResize | ImGuiWindowFlags.NoDocking);
 
@@ -338,7 +344,7 @@ namespace Fusee.ImGuiImp.Desktop.Templates
             // Folder Selection
             var currentFolder = Environment.ExpandEnvironmentVariables(CurrentOpenFolder.FullName);
             ImGui.SameLine(DriveSelectionWidth + WindowPadding.X + ImGui.GetStyle().ItemSpacing.X);
-            ImGui.SetNextItemWidth(FolderTextInputWidth - ImGui.CalcTextSize(FolderLabelTxt).X - ImGui.GetStyle().ItemSpacing.X);
+            ImGui.SetNextItemWidth(FolderTextInputWidth - ImGui.CalcTextSize(FolderLabelTxt).X - ImGui.GetStyle().ItemSpacing.X + openFileTextSize.X + cancelFileTextSize.X);
             ImGui.InputTextWithHint($"{FolderLabelTxt}##{_filePickerCount}", PathToFolderTxt, ref currentFolder, 400, ImGuiInputTextFlags.AutoSelectAll | ImGuiInputTextFlags.CallbackAlways, (x) =>
             {
                 var arr = currentFolder.ToCharArray();
@@ -417,7 +423,7 @@ namespace Fusee.ImGuiImp.Desktop.Templates
             ImGui.EndChild();
             ImGui.SameLine();
 
-            if (ImGui.BeginChild($"#FolderBrowser##{_filePickerCount}", new Vector2(FolderTextInputWidth, BrowserHeight), false, ImGuiWindowFlags.AlwaysUseWindowPadding | ImGuiWindowFlags.AlwaysAutoResize | ImGuiWindowFlags.HorizontalScrollbar))
+            if (ImGui.BeginChild($"#FolderBrowser##{_filePickerCount}", new Vector2(-1, BrowserHeight), false, ImGuiWindowFlags.AlwaysUseWindowPadding | ImGuiWindowFlags.AlwaysAutoResize | ImGuiWindowFlags.HorizontalScrollbar))
             {
                 if (CurrentOpenFolder != null && CurrentOpenFolder.Exists)
                 {
@@ -509,14 +515,14 @@ namespace Fusee.ImGuiImp.Desktop.Templates
             if (_sizeOfInputText == Vector2.Zero)
                 _sizeOfInputText = ImGui.GetItemRectSize();
 
-            var sameLineOffset = WinSize.X - WindowPadding.X - (BottomButtonSize.X * 2 + ImGui.GetStyle().ItemSpacing.X * 4);
+            var sameLineOffset = WinSize.X - WindowPadding.X - (openFileTextSize.X + cancelFileTextSize.X + ImGui.GetStyle().ItemSpacing.X * 4);
             if (SelectedFile != null)
             {
                 var fi = SelectedFile;
                 if (AllowedExtensions != null && AllowedExtensions.Contains(fi.Extension))
                 {
                     ImGui.SameLine(sameLineOffset);
-                    if (ImGui.Button($"{PickedFileTxt}##{_filePickerCount}", BottomButtonSize) || ImGui.IsKeyReleased(ImGuiKey.Enter))
+                    if (ImGui.Button($"{PickedFileTxt}##{_filePickerCount}", openFileTextSize) || ImGui.IsKeyReleased(ImGuiKey.Enter))
                     {
                         if (HandlePickedFile(fi))
                         {
@@ -529,7 +535,7 @@ namespace Fusee.ImGuiImp.Desktop.Templates
                 {
                     ImGui.SameLine(sameLineOffset);
                     ImGui.BeginDisabled();
-                    ImGui.Button(PickedFileTxt, BottomButtonSize);
+                    ImGui.Button(PickedFileTxt, openFileTextSize);
                     ImGui.EndDisabled();
                 }
             }
@@ -537,12 +543,12 @@ namespace Fusee.ImGuiImp.Desktop.Templates
             {
                 ImGui.SameLine(sameLineOffset);
                 ImGui.BeginDisabled();
-                ImGui.Button(PickedFileTxt, BottomButtonSize);
+                ImGui.Button(PickedFileTxt, openFileTextSize);
                 ImGui.EndDisabled();
             }
 
             ImGui.SameLine();
-            if (ImGui.Button($"{CancelFileOpenTxt}##{_filePickerCount}", BottomButtonSize))
+            if (ImGui.Button($"{CancelFileOpenTxt}##{_filePickerCount}", cancelFileTextSize))
             {
                 OnCancel?.Invoke(this, EventArgs.Empty);
                 filePickerOpen = false;

--- a/src/ImGui/Desktop/Fusee.ImGui.Desktop/Templates/ImGuiFolderPicker.cs
+++ b/src/ImGui/Desktop/Fusee.ImGui.Desktop/Templates/ImGuiFolderPicker.cs
@@ -256,11 +256,16 @@ namespace Fusee.ImGuiImp.Desktop.Templates
                 filePickerOpen = false;
             }
 
+            var openFileTextSize = ImGui.CalcTextSize(PickedFileTxt) + new Vector2(7, 11);
+            var cancelFileTextSize = ImGui.CalcTextSize(CancelFileOpenTxt) + new Vector2(7, 11);
+
             if (DoFocusPicker)
                 ImGui.SetNextWindowFocus();
             var headerHeight = FontSize + WindowPadding.Y * 2;
             var itemSpacing = ImGui.GetStyle().ItemSpacing;
-            WinSize = new Vector2(FolderTextInputWidth + DriveSelectionWidth + (WindowPadding.X * 2) + itemSpacing.X, headerHeight + BrowserHeight + TopButtonSize.Y + BottomButtonSize.Y + 4 * WindowPadding.Y + 3 * itemSpacing.Y + 5);
+            WinSize = new Vector2(
+                FolderTextInputWidth + DriveSelectionWidth + (WindowPadding.X * 2) + itemSpacing.X + openFileTextSize.X + cancelFileTextSize.X,
+                headerHeight + BrowserHeight + TopButtonSize.Y + BottomButtonSize.Y + (openFileTextSize.Y / 2) + 4 * WindowPadding.Y + 3 * itemSpacing.Y + 5);
             ImGui.SetNextWindowSize(WinSize);
             ImGui.Begin(Id, ref filePickerOpen, ImGuiWindowFlags.Modal | ImGuiWindowFlags.NoCollapse | ImGuiWindowFlags.AlwaysAutoResize | ImGuiWindowFlags.NoDocking);
 
@@ -314,7 +319,7 @@ namespace Fusee.ImGuiImp.Desktop.Templates
             // Folder Selection
             var currentFolder = Environment.ExpandEnvironmentVariables(CurrentOpenFolder.FullName);
             ImGui.SameLine(DriveSelectionWidth + WindowPadding.X + ImGui.GetStyle().ItemSpacing.X);
-            ImGui.SetNextItemWidth(FolderTextInputWidth - ImGui.CalcTextSize(FolderLabelTxt).X - ImGui.GetStyle().ItemSpacing.X);
+            ImGui.SetNextItemWidth(FolderTextInputWidth - ImGui.CalcTextSize(FolderLabelTxt).X - ImGui.GetStyle().ItemSpacing.X + openFileTextSize.X + cancelFileTextSize.X);
             ImGui.InputTextWithHint($"{FolderLabelTxt}##{_folderPickerCount}", PathToFolderTxt, ref currentFolder, 400, ImGuiInputTextFlags.AutoSelectAll | ImGuiInputTextFlags.CallbackAlways, (x) =>
             {
                 var arr = currentFolder.ToCharArray();
@@ -367,7 +372,7 @@ namespace Fusee.ImGuiImp.Desktop.Templates
             ImGui.EndChild();
             ImGui.SameLine();
 
-            if (ImGui.BeginChild($"#FolderBrowser##{_folderPickerCount}", new Vector2(FolderTextInputWidth, BrowserHeight), false, ImGuiWindowFlags.AlwaysUseWindowPadding | ImGuiWindowFlags.AlwaysAutoResize | ImGuiWindowFlags.HorizontalScrollbar))
+            if (ImGui.BeginChild($"#FolderBrowser##{_folderPickerCount}", new Vector2(-1, BrowserHeight), false, ImGuiWindowFlags.AlwaysUseWindowPadding | ImGuiWindowFlags.AlwaysAutoResize | ImGuiWindowFlags.HorizontalScrollbar))
             {
                 var fileSystemEntries = GetFileSystemEntries(CurrentOpenFolder.FullName);
                 foreach (var fse in fileSystemEntries)
@@ -416,13 +421,13 @@ namespace Fusee.ImGuiImp.Desktop.Templates
             ImGui.SetNextItemWidth(FileTextInputWidth - ImGui.CalcTextSize(FileLabelTxt).X - ImGui.GetStyle().ItemSpacing.X);
             ImGui.Dummy(new Vector2(-1, -1));
 
-            var sameLineOffset = WinSize.X - WindowPadding.X - (BottomButtonSize.X * 2 + ImGui.GetStyle().ItemSpacing.X * 4);
+            var sameLineOffset = WinSize.X - WindowPadding.X - (openFileTextSize.X + cancelFileTextSize.X + ImGui.GetStyle().ItemSpacing.X * 4);
 
             if (CurrentlySelectedFolder != null && CurrentlySelectedFolder.Exists)
             {
                 ImGui.SameLine(sameLineOffset);
 
-                if (ImGui.Button($"{PickedFileTxt}##{_folderPickerCount}", BottomButtonSize) || ImGui.IsKeyReleased(ImGuiKey.Enter))
+                if (ImGui.Button($"{PickedFileTxt}##{_folderPickerCount}", openFileTextSize) || ImGui.IsKeyReleased(ImGuiKey.Enter))
                 {
                     if (CurrentlySelectedFolder != null)
                         OnPicked?.Invoke(this, CurrentlySelectedFolder);
@@ -435,12 +440,12 @@ namespace Fusee.ImGuiImp.Desktop.Templates
             {
                 ImGui.SameLine(sameLineOffset);
                 ImGui.BeginDisabled();
-                ImGui.Button(PickedFileTxt, BottomButtonSize);
+                ImGui.Button(PickedFileTxt, openFileTextSize);
                 ImGui.EndDisabled();
             }
 
             ImGui.SameLine();
-            if (ImGui.Button($"{CancelFileOpenTxt}##{_folderPickerCount}", BottomButtonSize))
+            if (ImGui.Button($"{CancelFileOpenTxt}##{_folderPickerCount}", cancelFileTextSize))
             {
                 OnCancel?.Invoke(this, EventArgs.Empty);
                 filePickerOpen = false;

--- a/src/ImGui/Desktop/Fusee.ImGui.Desktop/Templates/ImGuiFolderPicker.cs
+++ b/src/ImGui/Desktop/Fusee.ImGui.Desktop/Templates/ImGuiFolderPicker.cs
@@ -69,19 +69,8 @@ namespace Fusee.ImGuiImp.Desktop.Templates
         /// <summary>
         /// Show a button which let's the user create a new folder at the current directory
         /// </summary>
-        public bool ShowNewFolderButton
-        {
-            get => _showNewFolderButton;
-            set
-            {
-                if (value)
-                    DriveSelectionWidth = 120;
-                else
-                    DriveSelectionWidth = 100;
+        public bool ShowNewFolderButton { get; set; }
 
-                _showNewFolderButton = value;
-            }
-        }
         public string NewFolderButtonTxt = "\uf65e";
 
         /// <summary>
@@ -99,7 +88,6 @@ namespace Fusee.ImGuiImp.Desktop.Templates
         /// </summary>
         public string CreateNewFolderHintTxt = "Insert folder name";
 
-        private bool _showNewFolderButton;
         private bool _isNewFolderNameWindowOpen;
 
         // as we cannot use the property as ref, we need to check and set all variables every time
@@ -153,14 +141,10 @@ namespace Fusee.ImGuiImp.Desktop.Templates
         protected DirectoryInfo? CurrentlySelectedFolder;
         protected readonly DirectoryInfo StartingFolder;
 
-        protected const float FolderTextInputWidth = 350;
-        protected const float FileTextInputWidth = 300;
-        protected static float DriveSelectionWidth = 100;
-        protected const float BrowserHeight = 200;
         protected readonly Vector2 WindowPadding = new(15, 15);
         protected readonly Vector2 BottomButtonSize = new(55, 26);
         protected readonly Vector2 TopButtonSize = new(35, 30);
-        protected Vector2 WinSize;
+
         protected bool DoFocusPicker = true;
 
         private static int _folderPickerCount = 0;
@@ -550,7 +534,14 @@ namespace Fusee.ImGuiImp.Desktop.Templates
                 {
                     try
                     {
-                        Directory.CreateDirectory(Path.Combine(currentFolder.FullName, _newFolderName));
+                        if (Path.IsPathRooted(_newFolderName))
+                        {
+                            Directory.CreateDirectory(_newFolderName);
+                        }
+                        else
+                        {
+                            Directory.CreateDirectory(Path.Combine(currentFolder.FullName, _newFolderName));
+                        }
                     }
                     catch (Exception ex)
                     {

--- a/src/ImGui/Desktop/Fusee.ImGui.Desktop/Templates/ImGuiFolderPicker.cs
+++ b/src/ImGui/Desktop/Fusee.ImGui.Desktop/Templates/ImGuiFolderPicker.cs
@@ -21,7 +21,7 @@ namespace Fusee.ImGuiImp.Desktop.Templates
         /// <summary>
         /// Allow resizing of file picker window
         /// </summary>
-        public bool AllowFilePickerResize { get; set; } = true;
+        public bool AllowFolderPickerResize { get; set; } = true;
 
         /// <summary>
         /// Allow resizing of new folder window
@@ -253,7 +253,7 @@ namespace Fusee.ImGuiImp.Desktop.Templates
 
             // Begin window
             ImGui.SetNextWindowSizeConstraints(new Vector2(500, 300), ImGui.GetWindowViewport().Size * 0.75f);
-            var allowResizeFlag = AllowFilePickerResize ? ImGuiWindowFlags.None : ImGuiWindowFlags.NoResize;
+            var allowResizeFlag = AllowFolderPickerResize ? ImGuiWindowFlags.None : ImGuiWindowFlags.NoResize;
             ImGui.Begin(Id, ref filePickerOpen, ImGuiWindowFlags.Modal | ImGuiWindowFlags.NoCollapse | allowResizeFlag);
 
             // draw navigation buttons and folder selection on the same line

--- a/src/ImGui/Desktop/Fusee.ImGui.Desktop/Templates/ImGuiFolderPicker.cs
+++ b/src/ImGui/Desktop/Fusee.ImGui.Desktop/Templates/ImGuiFolderPicker.cs
@@ -1,10 +1,8 @@
-using Fusee.Engine.Core;
 using ImGuiNET;
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Numerics;
-using System.Runtime.Intrinsics.X86;
 
 namespace Fusee.ImGuiImp.Desktop.Templates
 {
@@ -267,7 +265,7 @@ namespace Fusee.ImGuiImp.Desktop.Templates
                 FolderTextInputWidth + DriveSelectionWidth + (WindowPadding.X * 2) + itemSpacing.X + openFileTextSize.X + cancelFileTextSize.X,
                 headerHeight + BrowserHeight + TopButtonSize.Y + BottomButtonSize.Y + (openFileTextSize.Y / 2) + 4 * WindowPadding.Y + 3 * itemSpacing.Y + 5);
             ImGui.SetNextWindowSize(WinSize);
-            ImGui.Begin(Id, ref filePickerOpen, ImGuiWindowFlags.Modal | ImGuiWindowFlags.NoCollapse | ImGuiWindowFlags.AlwaysAutoResize | ImGuiWindowFlags.NoDocking);
+            ImGui.Begin(Id, ref filePickerOpen, ImGuiWindowFlags.Modal | ImGuiWindowFlags.NoCollapse | ImGuiWindowFlags.NoResize | ImGuiWindowFlags.NoDocking);
 
             if ((IntPtr)SymbolsFontPtr.NativePtr != IntPtr.Zero)
                 ImGui.PushFont(SymbolsFontPtr);

--- a/src/ImGui/Desktop/Fusee.ImGui.Desktop/Templates/ImGuiFolderPicker.cs
+++ b/src/ImGui/Desktop/Fusee.ImGui.Desktop/Templates/ImGuiFolderPicker.cs
@@ -36,12 +36,12 @@ namespace Fusee.ImGuiImp.Desktop.Templates
         /// <summary>
         /// Caption of the "Open" button.
         /// </summary>
-        public string PickedFileTxt = "Open";
+        public string PickedFolderTxt = "Open";
 
         /// <summary>
         /// Caption of the "Cancel" button.
         /// </summary>
-        public string CancelFileOpenTxt = "Cancel";
+        public string CancelFolderOpenTxt = "Cancel";
 
         /// <summary>
         /// Path to folder text.
@@ -59,9 +59,9 @@ namespace Fusee.ImGuiImp.Desktop.Templates
         public string FolderLabelTxt = "Folder";
 
         /// <summary>
-        /// Caption of file input text
+        /// Caption of folder input text (bottom)
         /// </summary>
-        public string FileLabelTxt = "Folder";
+        public string SelectedFolderLabelTxt = "Folder";
 
         public string ParentFolderTxt = "Parent";
         public string BackTxt = "Back";
@@ -194,7 +194,7 @@ namespace Fusee.ImGuiImp.Desktop.Templates
         /// <summary>
         /// Background of file selection menu
         /// </summary>
-        public Vector4 FileSelectionMenuBackground = new(125, 125, 125, 255);
+        public Vector4 FolderSelectionMenuBackground = new(125, 125, 125, 255);
 
         /// <summary>
         /// Color of <see cref="ImGui.SetTooltip(string)"/> when an error occurs
@@ -232,16 +232,16 @@ namespace Fusee.ImGuiImp.Desktop.Templates
         }
 
 
-        public virtual unsafe void Draw(ref bool filePickerOpen)
+        public virtual unsafe void Draw(ref bool folderPickerOpen)
         {
-            IsOpen = filePickerOpen;
-            if (!filePickerOpen) return;
+            IsOpen = folderPickerOpen;
+            if (!folderPickerOpen) return;
 
             // close on ESC
             if (ImGui.IsKeyReleased(ImGuiKey.Escape))
             {
                 OnCancel?.Invoke(this, EventArgs.Empty);
-                filePickerOpen = false;
+                folderPickerOpen = false;
             }
 
             if (DoFocusPicker)
@@ -254,7 +254,7 @@ namespace Fusee.ImGuiImp.Desktop.Templates
             // Begin window
             ImGui.SetNextWindowSizeConstraints(new Vector2(500, 300), ImGui.GetWindowViewport().Size * 0.75f);
             var allowResizeFlag = AllowFolderPickerResize ? ImGuiWindowFlags.None : ImGuiWindowFlags.NoResize;
-            ImGui.Begin(Id, ref filePickerOpen, ImGuiWindowFlags.Modal | ImGuiWindowFlags.NoCollapse | allowResizeFlag);
+            ImGui.Begin(Id, ref folderPickerOpen, ImGuiWindowFlags.Modal | ImGuiWindowFlags.NoCollapse | allowResizeFlag);
 
             // draw navigation buttons and folder selection on the same line
             DrawNavButtons();
@@ -262,18 +262,18 @@ namespace Fusee.ImGuiImp.Desktop.Templates
 
             // draw drive and file selector window
             ImGui.NewLine();
-            ImGui.PushStyleColor(ImGuiCol.ChildBg, FileSelectionMenuBackground.ToUintColor());
+            ImGui.PushStyleColor(ImGuiCol.ChildBg, FolderSelectionMenuBackground.ToUintColor());
             ImGui.PushStyleVar(ImGuiStyleVar.WindowPadding, new Vector2(10, 10));
 
             DrawDriveSelector();
-            DrawFolderSelector(ref filePickerOpen);
+            DrawFolderSelector(ref folderPickerOpen);
 
             ImGui.PopStyleColor();
             ImGui.PopStyleVar();
 
             // draw okay, cancel button
             ImGui.NewLine();
-            DrawFolderSelectorButtons(ref filePickerOpen);
+            DrawFolderSelectorButtons(ref folderPickerOpen);
 
             ImGui.End();
 
@@ -389,7 +389,7 @@ namespace Fusee.ImGuiImp.Desktop.Templates
         private void DrawDriveSelector()
         {
             // take all space in y, however shrink in y in item height + standard padding + WindowPadding
-            var offsetFromBottom = ImGui.CalcTextSize(PickedFileTxt) + ImGui.GetStyle().FramePadding * 2 + ImGui.GetStyle().WindowPadding * 2;
+            var offsetFromBottom = ImGui.CalcTextSize(PickedFolderTxt) + ImGui.GetStyle().FramePadding * 2 + ImGui.GetStyle().WindowPadding * 2;
             var driveSelectionWidth = ImGui.GetWindowSize().X * 0.25f; // 25% of windowSize.x
 
             ImGui.BeginChild($"DriveSelection##{_folderPickerCount}", new Vector2(driveSelectionWidth, -offsetFromBottom.Y), false, ImGuiWindowFlags.AlwaysUseWindowPadding | ImGuiWindowFlags.AlwaysAutoResize);
@@ -416,7 +416,7 @@ namespace Fusee.ImGuiImp.Desktop.Templates
 
             ImGui.SameLine();
             // take all space in y, however shrink in y in item height + standard padding + WindowPadding
-            var offsetFromBottom = ImGui.CalcTextSize(PickedFileTxt) + ImGui.GetStyle().FramePadding * 2 + ImGui.GetStyle().WindowPadding * 2;
+            var offsetFromBottom = ImGui.CalcTextSize(PickedFolderTxt) + ImGui.GetStyle().FramePadding * 2 + ImGui.GetStyle().WindowPadding * 2;
             if (ImGui.BeginChild($"#FolderBrowser##{_folderPickerCount}", new Vector2(-1, -offsetFromBottom.Y), false, ImGuiWindowFlags.AlwaysUseWindowPadding | ImGuiWindowFlags.AlwaysAutoResize | ImGuiWindowFlags.HorizontalScrollbar))
             {
                 var fileSystemEntries = GetFileSystemEntries(CurrentOpenFolder.FullName);
@@ -458,8 +458,8 @@ namespace Fusee.ImGuiImp.Desktop.Templates
 
         private void DrawFolderSelectorButtons(ref bool filePickerOpen)
         {
-            var pickedFileButtonSize = ImGui.CalcTextSize(PickedFileTxt) + ImGui.GetStyle().FramePadding * 2;
-            var cancelFileButtonSize = ImGui.CalcTextSize(CancelFileOpenTxt) + ImGui.GetStyle().FramePadding * 2;
+            var pickedFileButtonSize = ImGui.CalcTextSize(PickedFolderTxt) + ImGui.GetStyle().FramePadding * 2;
+            var cancelFileButtonSize = ImGui.CalcTextSize(CancelFolderOpenTxt) + ImGui.GetStyle().FramePadding * 2;
 
             ImGui.BeginChild($"FolderSelector##{_folderPickerCount}", new Vector2(-1, -1), false, ImGuiWindowFlags.AlwaysAutoResize);
 
@@ -471,7 +471,7 @@ namespace Fusee.ImGuiImp.Desktop.Templates
             {
                 ImGui.SameLine();
 
-                if (ImGui.Button($"{PickedFileTxt}##{_folderPickerCount}", pickedFileButtonSize) || ImGui.IsKeyReleased(ImGuiKey.Enter))
+                if (ImGui.Button($"{PickedFolderTxt}##{_folderPickerCount}", pickedFileButtonSize) || ImGui.IsKeyReleased(ImGuiKey.Enter))
                 {
                     if (CurrentlySelectedFolder != null)
                         OnPicked?.Invoke(this, CurrentlySelectedFolder);
@@ -484,12 +484,12 @@ namespace Fusee.ImGuiImp.Desktop.Templates
             {
                 ImGui.SameLine();
                 ImGui.BeginDisabled();
-                ImGui.Button(PickedFileTxt, pickedFileButtonSize);
+                ImGui.Button(PickedFolderTxt, pickedFileButtonSize);
                 ImGui.EndDisabled();
             }
 
             ImGui.SameLine();
-            if (ImGui.Button($"{CancelFileOpenTxt}##{_folderPickerCount}", cancelFileButtonSize))
+            if (ImGui.Button($"{CancelFolderOpenTxt}##{_folderPickerCount}", cancelFileButtonSize))
             {
                 OnCancel?.Invoke(this, EventArgs.Empty);
                 filePickerOpen = false;
@@ -532,15 +532,18 @@ namespace Fusee.ImGuiImp.Desktop.Templates
             {
                 if (!string.IsNullOrEmpty(_newFolderName))
                 {
+                    var folderName = string.Empty;
                     try
                     {
                         if (Path.IsPathRooted(_newFolderName))
                         {
+                            folderName = _newFolderName;
                             Directory.CreateDirectory(_newFolderName);
                         }
                         else
                         {
-                            Directory.CreateDirectory(Path.Combine(currentFolder.FullName, _newFolderName));
+                            folderName = Path.Combine(currentFolder.FullName, _newFolderName);
+                            Directory.CreateDirectory(folderName);
                         }
                     }
                     catch (Exception ex)
@@ -549,6 +552,11 @@ namespace Fusee.ImGuiImp.Desktop.Templates
                         return;
 
                     }
+
+                    // open new folder
+                    CurrentlySelectedFolder = new DirectoryInfo(folderName);
+                    LastOpenendFolders.Push(CurrentOpenFolder);
+                    CurrentOpenFolder = new DirectoryInfo(folderName);
                 }
                 IsNewFolderNameWindowOpen = false;
             }

--- a/src/ImGui/Desktop/Fusee.ImGui.Desktop/Templates/ImGuiFolderPicker.cs
+++ b/src/ImGui/Desktop/Fusee.ImGui.Desktop/Templates/ImGuiFolderPicker.cs
@@ -471,7 +471,8 @@ namespace Fusee.ImGuiImp.Desktop.Templates
             {
                 ImGui.SameLine();
 
-                if (ImGui.Button($"{PickedFolderTxt}##{_folderPickerCount}", pickedFileButtonSize) || ImGui.IsKeyReleased(ImGuiKey.Enter))
+                if (ImGui.Button($"{PickedFolderTxt}##{_folderPickerCount}", pickedFileButtonSize) ||
+                    (ImGui.IsKeyReleased(ImGuiKey.Enter) && !IsNewFolderNameWindowOpen))
                 {
                     if (CurrentlySelectedFolder != null)
                         OnPicked?.Invoke(this, CurrentlySelectedFolder);
@@ -528,7 +529,8 @@ namespace Fusee.ImGuiImp.Desktop.Templates
             });
             ImGui.SameLine();
 
-            if (ImGui.Button($"{CreateFolderTxt}", createFolderButtonSize))
+            if (ImGui.Button($"{CreateFolderTxt}", createFolderButtonSize) ||
+                ImGui.IsKeyReleased(ImGuiKey.Enter))
             {
                 if (!string.IsNullOrEmpty(_newFolderName))
                 {


### PR DESCRIPTION
Close: #817

Error strings were already present: see `FolderNotFoundTxt` and `FileNotFoundTxt`.
Button size adapts now to the button text size (no max limit when using sane input text :wink:).