### PR TITLE
Lots of warnings when using picker and GuiText

### DIFF
--- a/src/Engine/Core/ScenePicker.cs
+++ b/src/Engine/Core/ScenePicker.cs
@@ -775,7 +775,7 @@ namespace Fusee.Engine.Core
                 mesh.BoundingBox = new(mesh.Vertices.AsReadOnlySpan);
             }
 
-            if (mesh.GetType() != typeof(Primitives.Plane) && (mesh.BoundingBox.Size.x <= 0f || mesh.BoundingBox.Size.y <= 0f || mesh.BoundingBox.Size.z <= 0f))
+            if (mesh is not Primitives.Plane && (mesh.BoundingBox.Size.x <= 0f || mesh.BoundingBox.Size.y <= 0f || mesh.BoundingBox.Size.z <= 0f))
             {
                 Diagnostics.Warn($"Size of current bounding box is 0 for one or more dimensions. Picking not possible.");
                 return;

--- a/src/Engine/GUI/GuiText.cs
+++ b/src/Engine/GUI/GuiText.cs
@@ -1,5 +1,6 @@
 ﻿using Fusee.Engine.Common;
 using Fusee.Engine.Core;
+using Fusee.Engine.Core.Primitives;
 using Fusee.Engine.Core.Scene;
 using Fusee.Math.Core;
 using System;
@@ -11,7 +12,7 @@ namespace Fusee.Engine.Gui
     /// <summary>
     /// Creates a text mesh for the GUI.
     /// </summary>
-    public class GuiText : Mesh
+    public class GuiText : Plane
     {
         private readonly FontMap _fontMap;
 


### PR DESCRIPTION
 * Changed inherritance of `GuiText` frome `Mesh` to `Primitives.Plane`.
 * Changed `ScenePicker` type checking for `Primitives.Plane` to recognize inherritance.


fixes #836 